### PR TITLE
Reconfiguring configuration

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [aleph "0.4.6"]
                  [clj-http "3.7.0"]
                  [polaris "0.0.19"]
-                 [com.novemberain/monger "3.1.0"]
+                 [ophion "0.1.0"]
                  [spootnik/kinsky "0.1.22"]]
   :main shepherd.core
   :java-source-paths ["java/src"])

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [aleph "0.4.6"]
                  [clj-http "3.7.0"]
                  [polaris "0.0.19"]
-                 [ophion "0.1.0"]
+                 [ophion "0.1.1"]
                  [spootnik/kinsky "0.1.22"]]
   :main shepherd.core
   :java-source-paths ["java/src"])

--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
                  [aleph "0.4.6"]
                  [clj-http "3.7.0"]
                  [polaris "0.0.19"]
+                 [com.novemberain/monger "3.1.0"]
                  [spootnik/kinsky "0.1.22"]]
   :main shepherd.core
   :java-source-paths ["java/src"])

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,12 @@ with open("requirements.txt", 'r') as requirements:
 
 setup(
     name='wholecell-vivarium',
-    version='0.0.34',
+    version='0.0.39',
     packages=[
         'vivarium',
         'vivarium.actor',
         'vivarium.analysis',
+        'vivarium.composites',
         'vivarium.environment',
         'vivarium.processes',
         'vivarium.data',

--- a/vivarium/actor/actor.py
+++ b/vivarium/actor/actor.py
@@ -75,7 +75,7 @@ class Actor(object):
                 might need. Subclasses use this extensively, but the only key that needs to be
                 present for the base agent class is:
 
-		        * boot (dict): options to pass into the simulation on initialization.
+                * boot (dict): options to pass into the simulation on initialization.
                 * kafka_config (dict): A dictionary containing all of the kafka configuration
                     information, including:
 

--- a/vivarium/actor/emitter.py
+++ b/vivarium/actor/emitter.py
@@ -114,6 +114,11 @@ class KafkaEmitter(Emitter):
 class DatabaseEmitter(Emitter):
     '''
     Emit data to a mongoDB database
+
+	example:
+	config = {
+        'host': 'localhost:27017',
+        'database': 'DB_NAME'}
     '''
     client = None
 
@@ -124,7 +129,7 @@ class DatabaseEmitter(Emitter):
 
         # create singleton instance of mongo client
         if DatabaseEmitter.client is None:
-            DatabaseEmitter.client = MongoClient(config['url'])
+            DatabaseEmitter.client = MongoClient(config['host'])
 
         self.db = getattr(self.client, config.get('database', 'simulations'))
         self.history = getattr(self.db, 'history')

--- a/vivarium/data/knowledge_base.py
+++ b/vivarium/data/knowledge_base.py
@@ -29,15 +29,16 @@ class KnowledgeBase(object):
         # Load raw data from TSV files
 
         for filename in LIST_OF_FLAT_FILENAMES:
-            self._load_tsv(FLAT_DIR, os.path.join(FLAT_DIR, filename))
+            self._load_tsv(FLAT_DIR, filename)
 
     def _load_tsv(self, dir_name, file_name):
         path = self
-        for subPath in file_name[len(dir_name) + 1 : ].split(os.path.sep)[:-1]:
+        steps = file_name.split(os.path.sep)
+        for subPath in steps[:-1]:
             if not hasattr(path, subPath):
                 setattr(path, subPath, DataStore())
             path = getattr(path, subPath)
-        attrName = file_name.split(os.path.sep)[-1].split(".")[0]
+        attrName = steps[-1].split(".")[0]
         setattr(path, attrName, [])
 
         file_path = os.path.join(dir_name, file_name)

--- a/vivarium/environment/boot.py
+++ b/vivarium/environment/boot.py
@@ -69,16 +69,6 @@ def wrap_boot(initialize, initial_state):
 
 def wrap_init_basic(make_process):
     def initialize(boot_config):
-        if not 'emitter' in boot_config:
-            boot_config['emitter'] = DEFAULT_EMITTER_CONFIG
-
-        # boot_config.update({
-        #     'emitter': {
-        #         'type': 'database',
-        #         'url': 'localhost:27017',
-        #         'database': 'simulations',
-        #         },
-        #     })
         process = make_process(boot_config)  # 'boot_config', set in environment.control is the process' initial_parameters
         return generate_lattice_compartment(process, boot_config)
 
@@ -86,17 +76,6 @@ def wrap_init_basic(make_process):
 
 def wrap_init_composite(make_composite):
     def initialize(boot_config):
-        # configure the emitter
-        if not 'emitter' in boot_config:
-            boot_config['emitter'] = DEFAULT_EMITTER_CONFIG
-
-        # boot_config.update({
-        #     'emitter': {
-        #         'type': 'database',
-        #         'url': 'localhost:27017',
-        #         'database': 'simulations'},
-        #     })
-
         # set up the the composite
         composite_config = make_composite(boot_config)
         processes = composite_config['processes']
@@ -126,13 +105,6 @@ def wrap_boot_environment(intialize):
 
         emitter_config = boot_config.get('emitter', DEFAULT_EMITTER_CONFIG)
         emitter_config['experiment_id'] = agent_id
-
-        # # emitter
-        # emitter_config = {
-        #     'type': 'database',
-        #     'url': 'localhost:27017',
-        #     'database': 'simulations',
-        #     'experiment_id': agent_id}
 
         emitter = get_emitter(emitter_config)
         boot_config.update({

--- a/vivarium/environment/boot.py
+++ b/vivarium/environment/boot.py
@@ -25,6 +25,7 @@ import shutil
 from vivarium.actor.inner import Inner
 from vivarium.actor.outer import Outer
 from vivarium.actor.boot import BootAgent
+from vivarium.actor.control import DEFAULT_EMITTER_CONFIG
 from vivarium.actor.emitter import get_emitter, configure_emitter
 
 # environment
@@ -68,13 +69,16 @@ def wrap_boot(initialize, initial_state):
 
 def wrap_init_basic(make_process):
     def initialize(boot_config):
-        boot_config.update({
-            'emitter': {
-                'type': 'database',
-                'url': 'localhost:27017',
-                'database': 'simulations',
-                },
-            })
+        if not 'emitter' in boot_config:
+            boot_config['emitter'] = DEFAULT_EMITTER_CONFIG
+
+        # boot_config.update({
+        #     'emitter': {
+        #         'type': 'database',
+        #         'url': 'localhost:27017',
+        #         'database': 'simulations',
+        #         },
+        #     })
         process = make_process(boot_config)  # 'boot_config', set in environment.control is the process' initial_parameters
         return generate_lattice_compartment(process, boot_config)
 
@@ -83,12 +87,15 @@ def wrap_init_basic(make_process):
 def wrap_init_composite(make_composite):
     def initialize(boot_config):
         # configure the emitter
-        boot_config.update({
-            'emitter': {
-                'type': 'database',
-                'url': 'localhost:27017',
-                'database': 'simulations'},
-            })
+        if not 'emitter' in boot_config:
+            boot_config['emitter'] = DEFAULT_EMITTER_CONFIG
+
+        # boot_config.update({
+        #     'emitter': {
+        #         'type': 'database',
+        #         'url': 'localhost:27017',
+        #         'database': 'simulations'},
+        #     })
 
         # set up the the composite
         composite_config = make_composite(boot_config)
@@ -117,12 +124,16 @@ def wrap_boot_environment(intialize):
         if os.path.isdir(output_dir):
             shutil.rmtree(output_dir)
 
-        # emitter
-        emitter_config = {
-            'type': 'database',
-            'url': 'localhost:27017',
-            'database': 'simulations',
-            'experiment_id': agent_id}
+        emitter_config = boot_config.get('emitter', DEFAULT_EMITTER_CONFIG)
+        emitter_config['experiment_id'] = agent_id
+
+        # # emitter
+        # emitter_config = {
+        #     'type': 'database',
+        #     'url': 'localhost:27017',
+        #     'database': 'simulations',
+        #     'experiment_id': agent_id}
+
         emitter = get_emitter(emitter_config)
         boot_config.update({
             'emitter': emitter,

--- a/vivarium/environment/control.py
+++ b/vivarium/environment/control.py
@@ -21,7 +21,7 @@ class ShepherdControl(ActorControl):
             agent_type,
             agent_config)
 
-    def lattice_experiment(self, args):
+    def lattice_experiment(self, args, agent_config):
         experiment_id = args['experiment_id']
         if not experiment_id:
             experiment_id = self.get_experiment_id()
@@ -38,7 +38,7 @@ class ShepherdControl(ActorControl):
 
         emit_field = args.get('emit_field', ['GLC'])
 
-        lattice_config = {
+        lattice_config = dict(agent_config, **{
             'timeline_str': timeline_str,
             'media_id': media_id,
             'emit_fields': emit_field,
@@ -47,21 +47,23 @@ class ShepherdControl(ActorControl):
             'edge_length_x': 20.0,
             'patches_per_edge_x': 10,
             'translation_jitter': 0.1,
-            'rotation_jitter': 0.01}
+            'rotation_jitter': 0.01})
 
         self.add_agent(experiment_id, 'lattice', lattice_config)
 
         time.sleep(10)  # TODO(jerry): Wait for the Lattice to boot
 
-        for index in range(num_cells):
-            self.add_cell(args['type'] or 'lookup', {
-                'boot': args.get('agent_boot', 'vivarium.environment.boot'),
-                'boot_config': {},
-                'outer_id': experiment_id,
-                'working_dir': args['working_dir'],
-                'seed': index})
+        cell_config = dict(agent_config, **{
+            'boot': args.get('agent_boot', 'vivarium.environment.boot'),
+            'outer_id': experiment_id,
+            'working_dir': args['working_dir']})
 
-    def long_lattice_experiment(self, args):
+        for index in range(num_cells):
+            self.add_cell(
+                args['type'] or 'lookup',
+                dict(cell_config, seed=index))
+
+    def long_lattice_experiment(self, args, agent_config):
         experiment_id = args['experiment_id']
         if not experiment_id:
             experiment_id = self.get_experiment_id()
@@ -77,7 +79,7 @@ class ShepherdControl(ActorControl):
 
         emit_field = ['GLC']
 
-        lattice_config = {
+        lattice_config = dict(agent_config, **{
             'timeline_str': timeline_str,
             'media_id': media_id,
             'emit_fields': emit_field,
@@ -87,21 +89,21 @@ class ShepherdControl(ActorControl):
             'edge_length_y': 20.0,
             'patches_per_edge_x': 8,
             'translation_jitter': 0.1,
-            'rotation_jitter': 0.01}
+            'rotation_jitter': 0.01})
 
         self.add_agent(experiment_id, 'lattice', lattice_config)
 
         time.sleep(10)  # TODO(jerry): Wait for the Lattice to boot
 
         for index in range(num_cells):
-            self.add_cell(args['type'] or 'lookup', {
+            self.add_cell(args['type'] or 'lookup', dict(agent_config, **{
                 'boot': args.get('agent_boot', 'vivarium.environment.boot'),
                 'boot_config': {},
                 'outer_id': experiment_id,
                 'working_dir': args['working_dir'],
-                'seed': index})
+                'seed': index}))
 
-    def large_lattice_experiment(self, args):
+    def large_lattice_experiment(self, args, agent_config):
         experiment_id = args['experiment_id']
         if not experiment_id:
             experiment_id = self.get_experiment_id('large_lattice')
@@ -116,7 +118,7 @@ class ShepherdControl(ActorControl):
 
         emit_field = ['GLC']
 
-        lattice_config = {
+        lattice_config = dict(agent_config, {
             'timeline_str': timeline_str,
             'media_id': media_id,
             'emit_fields': emit_field,
@@ -130,20 +132,20 @@ class ShepherdControl(ActorControl):
                         'center': [0.0, 0.0],
                         'slope': -1.0 / 250.0},
                 }},
-        }
+        })
 
         self.add_agent(experiment_id, 'lattice', lattice_config)
 
         time.sleep(10)  # TODO(jerry): Wait for the Lattice to boot
 
         for index in range(num_cells):
-            self.add_cell(args['type'] or 'ecoli', {
+            self.add_cell(args['type'] or 'ecoli', dict(agent_config, {
                 'boot': 'vivarium.environment.boot',
                 'outer_id': experiment_id,
                 'working_dir': args['working_dir'],
-                'seed': index})
+                'seed': index}))
 
-    def small_lattice_experiment(self, args):
+    def small_lattice_experiment(self, args, agent_config):
         experiment_id = args['experiment_id']
         if not experiment_id:
             experiment_id = self.get_experiment_id('small_lattice')
@@ -158,26 +160,25 @@ class ShepherdControl(ActorControl):
 
         emit_field = ['GLC']
 
-        experiment_config = {
+        experiment_config = dict(agent_config, {
             'timeline_str': timeline_str,
             'run_for': 2.0,
             'emit_fields': emit_field,
             'edge_length_x': 10.0,
-            'patches_per_edge_x': 10,
-        }
+            'patches_per_edge_x': 10})
 
         self.add_agent(experiment_id, 'lattice', experiment_config)
 
         time.sleep(10)  # TODO(jerry): Wait for the Lattice to boot
 
         for index in range(num_cells):
-            self.add_cell(args['type'] or 'metabolism', {
+            self.add_cell(args['type'] or 'metabolism', dict(agent_config, {
                 'boot': 'vivarium.environment.boot',
                 'outer_id': experiment_id,
                 'working_dir': args['working_dir'],
-                'seed': index})
+                'seed': index}))
 
-    def glc_g6p_experiment(self, args):
+    def glc_g6p_experiment(self, args, agent_config):
         experiment_id = args['experiment_id']
         if not experiment_id:
             experiment_id = self.get_experiment_id('glc-g6p')
@@ -192,23 +193,23 @@ class ShepherdControl(ActorControl):
 
         emit_field = ['GLC', 'G6P']
 
-        experiment_config = {
+        experiment_config = dict(agent_config, {
             'timeline_str': timeline_str,
             'run_for': 2.0,
-            'emit_fields': emit_field}
+            'emit_fields': emit_field})
 
         self.add_agent(experiment_id, 'lattice', experiment_config)
 
         time.sleep(10)  # TODO(jerry): Wait for the Lattice to boot
 
         for index in range(num_cells):
-            self.add_cell(args['type'] or 'metabolism', {
+            self.add_cell(args['type'] or 'metabolism', dict(agent_config, {
                 'boot': 'vivarium.environment.boot',
                 'outer_id': experiment_id,
                 'working_dir': args['working_dir'],
-                'seed': index})
+                'seed': index}))
 
-    def chemotaxis_experiment(self, args):
+    def chemotaxis_experiment(self, args, agent_config):
         experiment_id = args['experiment_id']
         if not experiment_id:
             experiment_id = self.get_experiment_id('chemotaxis')
@@ -223,7 +224,7 @@ class ShepherdControl(ActorControl):
         # timeline_str = '0 {}, 14400 end'.format(media_id)
         timeline_str = '0 {}, 1800 end'.format(media_id)
 
-        chemotaxis_config = {
+        chemotaxis_config = dict(agent_config, {
             'timeline_str': timeline_str,
             'new_media': new_media,
             'run_for' : 0.05,
@@ -244,20 +245,20 @@ class ShepherdControl(ActorControl):
             # 'rotation_jitter': 0.05,
             'edge_length_x': 500.0,
             'edge_length_y': 100.0,
-            'patches_per_edge_x': 100}
+            'patches_per_edge_x': 100})
         self.add_agent(experiment_id, 'lattice', chemotaxis_config)
 
         # give lattice time before adding the cells
         time.sleep(15)
 
         for index in range(num_cells):
-            self.add_cell(args['type'] or 'chemotaxis', {
+            self.add_cell(args['type'] or 'chemotaxis', dict(agent_config, {
                 'boot': 'vivarium.environment.boot',
                 'outer_id': experiment_id,
-                'seed': index})
+                'seed': index}))
 
 
-    def swarm_experiment(self, args):
+    def swarm_experiment(self, args, agent_config):
         experiment_id = args['experiment_id']
         if not experiment_id:
             experiment_id = self.get_experiment_id('chemotaxis')
@@ -286,7 +287,7 @@ class ShepherdControl(ActorControl):
         new_media = {media_id: media}
         timeline_str = '0 {}, 3600 end'.format(media_id)
 
-        swarm_config = {
+        swarm_config = dict(agent_config, {
             'cell_placement': [0.5, 0.5], # place cells at center of lattice
             'timeline_str': timeline_str,
             'new_media': new_media,
@@ -296,17 +297,17 @@ class ShepherdControl(ActorControl):
             'diffusion': 0.001,
             'edge_length_x': 100.0,
             'edge_length_y': 100.0,
-            'patches_per_edge_x': 50}
+            'patches_per_edge_x': 50})
         self.add_agent(experiment_id, 'lattice', swarm_config)
 
         # give lattice time before adding the cells
         time.sleep(15)
 
         for index in range(num_cells):
-            self.add_cell(args['type'] or 'chemotaxis', {
+            self.add_cell(args['type'] or 'chemotaxis', dict(agent_config, {
                 'boot': 'vivarium.environment.boot',
                 'outer_id': experiment_id,
-                'seed': index})
+                'seed': index}))
 
 class EnvironmentCommand(AgentCommand):
     """
@@ -344,49 +345,50 @@ class EnvironmentCommand(AgentCommand):
             'glc-g6p-experiment'] + choices
 
         super(EnvironmentCommand, self).__init__(
-			full_choices,
-			full_description)
+            full_choices,
+            {}, # no additional args
+            full_description)
 
     def experiment(self, args):
         self.require(args, 'number', 'working_dir')
         control = ShepherdControl({'kafka_config': self.kafka_config()})
-        control.lattice_experiment(args)
+        control.lattice_experiment(args, self.agent_config)
         control.shutdown()
 
     def long_experiment(self, args):
         self.require(args, 'number', 'working_dir')
         control = ShepherdControl({'kafka_config': self.kafka_config()})
-        control.long_lattice_experiment(args)
+        control.long_lattice_experiment(args, self.agent_config)
         control.shutdown()
 
     def large_experiment(self, args):
         self.require(args, 'number', 'working_dir')
         control = ShepherdControl({'kafka_config': self.kafka_config()})
-        control.large_lattice_experiment(args)
+        control.large_lattice_experiment(args, self.agent_config)
         control.shutdown()
 
     def small_experiment(self, args):
         self.require(args, 'number', 'working_dir')
         control = ShepherdControl({'kafka_config': self.kafka_config()})
-        control.small_lattice_experiment(args)
+        control.small_lattice_experiment(args, self.agent_config)
         control.shutdown()
 
     def glc_g6p_experiment(self, args):
         self.require(args, 'number')
         control = ShepherdControl({'kafka_config': self.kafka_config()})
-        control.glc_g6p_experiment(args)
+        control.glc_g6p_experiment(args, self.agent_config)
         control.shutdown()
 
     def chemotaxis_experiment(self, args):
         self.require(args, 'number')
         control = ShepherdControl({'kafka_config': self.kafka_config()})
-        control.chemotaxis_experiment(args)
+        control.chemotaxis_experiment(args, self.agent_config)
         control.shutdown()
 
     def swarm_experiment(self, args):
         self.require(args, 'number')
         control = ShepherdControl({'kafka_config': self.kafka_config()})
-        control.swarm_experiment(args)
+        control.swarm_experiment(args, self.agent_config)
         control.shutdown()
 
     def add_arguments(self, parser):

--- a/vivarium/environment/control.py
+++ b/vivarium/environment/control.py
@@ -349,43 +349,43 @@ class EnvironmentCommand(AgentCommand):
 
     def experiment(self, args):
         self.require(args, 'number', 'working_dir')
-        control = ShepherdControl({'kafka_config': self.kafka_config})
+        control = ShepherdControl({'kafka_config': self.kafka_config()})
         control.lattice_experiment(args)
         control.shutdown()
 
     def long_experiment(self, args):
         self.require(args, 'number', 'working_dir')
-        control = ShepherdControl({'kafka_config': self.kafka_config})
+        control = ShepherdControl({'kafka_config': self.kafka_config()})
         control.long_lattice_experiment(args)
         control.shutdown()
 
     def large_experiment(self, args):
         self.require(args, 'number', 'working_dir')
-        control = ShepherdControl({'kafka_config': self.kafka_config})
+        control = ShepherdControl({'kafka_config': self.kafka_config()})
         control.large_lattice_experiment(args)
         control.shutdown()
 
     def small_experiment(self, args):
         self.require(args, 'number', 'working_dir')
-        control = ShepherdControl({'kafka_config': self.kafka_config})
+        control = ShepherdControl({'kafka_config': self.kafka_config()})
         control.small_lattice_experiment(args)
         control.shutdown()
 
     def glc_g6p_experiment(self, args):
         self.require(args, 'number')
-        control = ShepherdControl({'kafka_config': self.kafka_config})
+        control = ShepherdControl({'kafka_config': self.kafka_config()})
         control.glc_g6p_experiment(args)
         control.shutdown()
 
     def chemotaxis_experiment(self, args):
         self.require(args, 'number')
-        control = ShepherdControl({'kafka_config': self.kafka_config})
+        control = ShepherdControl({'kafka_config': self.kafka_config()})
         control.chemotaxis_experiment(args)
         control.shutdown()
 
     def swarm_experiment(self, args):
         self.require(args, 'number')
-        control = ShepherdControl({'kafka_config': self.kafka_config})
+        control = ShepherdControl({'kafka_config': self.kafka_config()})
         control.swarm_experiment(args)
         control.shutdown()
 

--- a/vivarium/environment/control.py
+++ b/vivarium/environment/control.py
@@ -44,8 +44,9 @@ class ShepherdControl(ActorControl):
             'emit_fields': emit_field,
             'boot': 'vivarium.environment.boot',
             'run_for': 4.0,
-            'edge_length_x': 20.0,
-            'patches_per_edge_x': 10,
+            'diffusion': args.get('diffusion', 1000),
+            'edge_length_x': args.get('edge_length_x'),
+            'patches_per_edge_x': args.get('patches_per_edge_x', 10),
             'translation_jitter': 0.1,
             'rotation_jitter': 0.01})
 

--- a/vivarium/environment/look_up.py
+++ b/vivarium/environment/look_up.py
@@ -49,9 +49,6 @@ def load_lookup(filename):
         avg = row.get('average')
         dist = row.get('distribution')
 
-        # # convert to list of floats
-        # dist = dist.replace('[', '').replace(']', '').split(', ')
-
         # check if empty distribution
         if dist:
             dist = [float(value) for value in dist]

--- a/vivarium/environment/look_up.py
+++ b/vivarium/environment/look_up.py
@@ -49,11 +49,11 @@ def load_lookup(filename):
         avg = row.get('average')
         dist = row.get('distribution')
 
-        # convert to list of floats
-        dist = dist.replace('[', '').replace(']', '').split(', ')
+        # # convert to list of floats
+        # dist = dist.replace('[', '').replace(']', '').split(', ')
 
         # check if empty distribution
-        if dist[0]:
+        if dist:
             dist = [float(value) for value in dist]
         else:
             dist=[0]

--- a/vivarium/environment/make_media.py
+++ b/vivarium/environment/make_media.py
@@ -87,6 +87,7 @@ class Media(object):
     def _get_stock_media(self, raw_data):
         '''load all stock media'''
         self.stock_media = {}
+
         for label in vars(raw_data.media):
             self.stock_media[label] = {}
 


### PR DESCRIPTION
While trying to innocuously add an option to specify the mongo host for cloud deployment of the cell shepherd I discovered that providing additional options was not facilitating revision, and in general configuration was over-complicated and with too many ways to specify defaults etc, so I tore it all out and made a general way for configuration to be specified from Control and Command classes. 

There is now a concept of "destinations" where command line arguments are mapped to paths into the configuration dict, so that we can declare where values belong without having to get them all there manually in each control method. Also, all configuration flows from the command line outwards instead of values appearing along the journey as it goes. 

This should allow us to provide the mongo host for cloud deployment from the command line. 