### PR TITLE
MOMA for cobra_fba

### DIFF
--- a/vivarium/actor/process.py
+++ b/vivarium/actor/process.py
@@ -632,17 +632,20 @@ def set_axes(ax, show_xaxis=False):
 
 def plot_simulation_output(timeseries, settings={}, out_dir='out'):
     '''
-    plot simulation output
-        args:
+    plot simulation output, with rows organized into separate columns.
+
+    Requires:
         - timeseries (dict). This can be obtained from simulation output with convert_to_timeseries()
         - settings (dict) with:
             {
             'max_rows': (int) roles with more states than this number of states get wrapped into a new column
-            'remove_zeros': (bool) if True, timeseries with all 0's get removed
+            'remove_zeros': (bool) if True, timeseries with all zeros get removed
             'remove_flat': (bool) if True, timeseries with all the same value get removed
-            'skip_roles': (list) roles that won't be plotted
+            'skip_roles': (list) entire roles that won't be plotted
             'overlay': (dict) with
                 {'bottom_role': 'top_role'}  roles plotted together by matching state_ids, with 'top_role' in red
+            'show_state': (list) with [('role_id', 'state_id')]
+                for all states that will be highlighted, even if they are otherwise to be removed
             }
     TODO -- some molecules have 'inf' concentrations for practical reasons. How should these be plotted?
     '''
@@ -651,10 +654,10 @@ def plot_simulation_output(timeseries, settings={}, out_dir='out'):
 
     # get settings
     max_rows = settings.get('max_rows', 25)
-    overlay = settings.get('overlay', {})
-    skip_roles = settings.get('skip_roles', [])
-    remove_flat = settings.get('remove_flat', False)
     remove_zeros = settings.get('remove_zeros', False)
+    remove_flat = settings.get('remove_flat', False)
+    skip_roles = settings.get('skip_roles', [])
+    overlay = settings.get('overlay', {})
     show_state = settings.get('show_state', [])
     top_roles = list(overlay.values())
     bottom_roles = list(overlay.keys())

--- a/vivarium/composites/kinetic_FBA.py
+++ b/vivarium/composites/kinetic_FBA.py
@@ -77,19 +77,22 @@ def get_regulation():
 def compose_kinetic_FBA(config):
     """
     A composite with kinetic transport, metabolism, and regulation
+    TODO (eran) -- fit glc/lct uptake rates to growth rates
 
-    TODO -- fit glc/lct uptake rates to growth rates
     """
 
-    ## Declare the processes
+    ## Declare the processes.
+    ## The order allows earlier declared processes to inform later processes
 
-    ## Transport
+    # Transport
+    # load the kinetic parameters
     transport_config = copy.deepcopy(config)
     transport_config.update(get_transport_config())
     transport = ConvenienceKinetics(transport_config)
 
-    ## Metabolism
-    # get target fluxes from transport, load in regulation function
+    # Metabolism
+    # get target fluxes from transport
+    # load regulation function
     metabolism_config = copy.deepcopy(config)
     target_fluxes = transport.kinetic_rate_laws.reaction_ids
     regulation_logic = get_regulation()
@@ -103,7 +106,7 @@ def compose_kinetic_FBA(config):
         'regulation_logic': regulation_logic})
     metabolism = BiGGMetabolism(metabolism_config)
 
-    ## Division
+    # Division
     # get initial volume from metabolism
     division_config = copy.deepcopy(config)
     division_config.update({'initial_state': metabolism.initial_state})
@@ -120,7 +123,7 @@ def compose_kinetic_FBA(config):
         'division': division}
     ]
 
-    ## Make the topology
+    # Make the topology
     # for each process, map process roles to compartment roles
     topology = {
         'transport': {
@@ -140,7 +143,7 @@ def compose_kinetic_FBA(config):
             'internal': 'cell'},
         }
 
-    ## Initialize the states
+    # Initialize the states
     states = initialize_state(processes, topology, config.get('initial_state', {}))
 
     options = {
@@ -204,6 +207,6 @@ if __name__ == '__main__':
 
     # saved_state = simulate_compartment(compartment, settings)
     saved_data = simulate_with_environment(compartment, settings)
-    del saved_data[0]  # remove first state
+    del saved_data[0]  # remove the first state
     timeseries = convert_to_timeseries(saved_data)
     plot_simulation_output(timeseries, plot_settings, out_dir)

--- a/vivarium/composites/kinetic_FBA.py
+++ b/vivarium/composites/kinetic_FBA.py
@@ -95,6 +95,7 @@ def compose_kinetic_FBA(config):
     regulation_logic = get_regulation()
 
     metabolism_config.update({
+        'moma': False,
         'tolerance': {
             'EX_glc__D_e': [1.05, 1.0]},
         'model_path': METABOLISM_FILE,

--- a/vivarium/processes/BiGG_metabolism.py
+++ b/vivarium/processes/BiGG_metabolism.py
@@ -9,7 +9,6 @@ from vivarium.utils.units import units
 
 
 DATA_FILE = os.path.join('models', 'e_coli_core.json')
-# DATA_FILE = os.path.join('models', 'iAF1260b.json')
 
 def BiGGMetabolism(parameters):
     initial_state = get_initial_state()
@@ -30,7 +29,7 @@ def get_initial_state():
             'volume': volume.to('fL').magnitude}
 
     # external state
-    # TODO -- initial state is currently configured to e_coli_core, needs to be generalized
+    # TODO -- initial state is set to e_coli_core, needs to be generalized to whatever BiGG model is loaded
     make_media = Media()
     external = make_media.get_saved_media('ecoli_core_GLC')
 
@@ -79,74 +78,23 @@ if __name__ == '__main__':
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    # toy functions
-    def toy_transport():
-        transport_kinetics = {
-            # 'GLCptspp': kinetic_rate('glc__D_e', 1.5e0, 5),  # for model iAF1260b
-            # 'EX_lac__D_e': kinetic_rate('lac__D_e', -5e-1, 8),
-            # 'LACZpp': kinetic_rate('lac__D_e', 1.5e0, 5),
-            # 'GLCpts': kinetic_rate('glc__D_e', 1.5e0, 5),  # for model e_coli_core
-            # 'LACZ': kinetic_rate('lac__D_e', 1.5e0, 5),
-        }
-        return transport_kinetics
-
-    def toy_regulation():
-        regulation = {
-            # 'EX_lac__D_e': rl.build_rule('IF not (glc__D_e_external)'),
-            # 'EX_glc__D_e': rl.build_rule('IF (glc__D_e_external)'),
-            # 'LACZpp': rl.build_rule('IF not (glc__D_e_external)'),
-            # 'LACZ': rl.build_rule('IF not (glc__D_e_external)'),
-        }
-        return regulation
-
     # define process config
     config = {'model_path': DATA_FILE}
 
-    # additional process-like transport and regulation functions
-    transport = toy_transport()
-    regulation = toy_regulation()
-    metabolism_config = {
-        'moma': False,
-        'constrained_reaction_ids': transport.keys(),
-        'regulation': regulation}
-    metabolism_config.update(config)
-
     # load metabolism model
-    metabolism = BiGGMetabolism(metabolism_config)
+    metabolism = BiGGMetabolism(config)
 
     # simulate model
-    timeline = [
-        # (0, {'external': {
-        #     'glc__D_e': 12.0,
-        #     'lac__D_e': 12.0}
-        # }),
-        # (100, {'external': {
-        #     'glc__D_e': 0.0}
-        # }),
-        (2500, {})]
+    timeline = [(2500, {})]
 
     simulation_config = {
         'process': metabolism,
         'timeline': timeline,
-        'transport_kinetics': toy_transport(),
         'environment_volume': 1e-11}
 
     plot_settings = {
         'max_rows': 30,
         'remove_flat': True,
-        'show_state': [
-            ('external', 'glc__D_e'),
-            ('internal', 'lcts_p'),
-            ('external', 'lac__D_e'),
-            ('flux_bounds', 'LACZ'),
-            ('reactions', 'LACZ'),
-            ('flux_bounds', 'LACZpp'),
-            ('reactions', 'LACZpp'),
-            ('flux_bounds', 'EX_lac__D_e'),
-            ('reactions', 'EX_lac__D_e'),
-            ('flux_bounds', 'EX_glc__D_e'),
-            ('reactions', 'EX_glc__D_e'),
-        ],
         'skip_roles': ['exchange'],
         'overlay': {'reactions': 'flux_bounds'}}
 
@@ -159,6 +107,5 @@ if __name__ == '__main__':
     network_config = {
         'process': metabolism,
         'total_time': 10,
-        'transport_kinetics': toy_transport(),
         'environment_volume': 1e-11}
     save_network(network_config, out_dir)

--- a/vivarium/processes/BiGG_metabolism.py
+++ b/vivarium/processes/BiGG_metabolism.py
@@ -105,11 +105,14 @@ if __name__ == '__main__':
     # additional process-like transport and regulation functions
     transport = toy_transport()
     regulation = toy_regulation()
-    config['constrained_reaction_ids'] = transport.keys()
-    config['regulation'] = regulation
+    metabolism_config = {
+        'moma': False,
+        'constrained_reaction_ids': transport.keys(),
+        'regulation': regulation}
+    metabolism_config.update(config)
 
     # load metabolism model
-    metabolism = BiGGMetabolism(config)
+    metabolism = BiGGMetabolism(metabolism_config)
 
     # simulate model
     timeline = [

--- a/vivarium/processes/metabolism.py
+++ b/vivarium/processes/metabolism.py
@@ -126,7 +126,7 @@ class Metabolism(Process):
         exchange_constraints = {mol_id: 0.0
             for mol_id, conc in external_state.items() if conc <= REGULATION_THRESHOLD}
 
-        # availibility is boolean state of all molecules present
+        # availability is boolean state of all molecules present
         # regulation_state determines state of regulated reactions (True/False)
         availability = flatten_role_dicts({role: states[role]
             for role in ('internal', 'external')})
@@ -408,17 +408,15 @@ if __name__ == '__main__':
 
     # toy functions
     def toy_transport():
-        # process-like function for transport kinetics
+        # process-like function for transport kinetics, used by simulate_metabolism
         transport_kinetics = {
             "EX_A": kinetic_rate("A", -1e-1, 5),  # A import
-            # "R1": kinetic_rate("A", 2.5e-2, 5),  # A import
-            # "EX_E": random_rate(1e-2, 1e-3)  # (0, 1e-1),   #  E exchange, requires 'EX_' prefix
         }
         return transport_kinetics
 
     def toy_regulation():
         regulation = {
-            'R4': rl.build_rule('IF (O2_external) and not (F_external)'),
+            'R4': 'IF (O2_external) and not (F_external)',
         }
         return regulation
 

--- a/vivarium/utils/cobra_fba.py
+++ b/vivarium/utils/cobra_fba.py
@@ -136,7 +136,7 @@ def extract_model(model):
         'molecular_weights': molecular_weights,
         'flux_scaling': flux_scaling}
 
-DEFAULT_UPPER_BOUND = 1000
+DEFAULT_UPPER_BOUND = 100
 
 
 

--- a/vivarium/utils/cobra_fba.py
+++ b/vivarium/utils/cobra_fba.py
@@ -7,7 +7,9 @@ from cobra.medium import minimal_medium
 from cobra import Model, Reaction, Metabolite, Configuration
 
 
+
 EXTERNAL_PREFIX = 'EX_'
+DEFAULT_UPPER_BOUND = 100.0
 
 def build_model(stoichiometry, reversible, objective, external_molecules, default_upper_bound=1000):
     model = Model('fba')
@@ -135,8 +137,6 @@ def extract_model(model):
         'exchange_bounds': exchange_bounds,
         'molecular_weights': molecular_weights,
         'flux_scaling': flux_scaling}
-
-DEFAULT_UPPER_BOUND = 100
 
 
 
@@ -270,7 +270,11 @@ class CobraFBA(object):
                     reaction.lower_bound = 0.0
 
     def objective_value(self):
-        return self.solution.objective_value if self.solution else float('nan')
+        if self.solution:
+            objective_value = self.solution.objective_value * self.flux_scaling
+            return objective_value
+        else:
+            return float('nan')
 
     def optimize(self):
 

--- a/vivarium/utils/cobra_fba.py
+++ b/vivarium/utils/cobra_fba.py
@@ -141,6 +141,14 @@ def extract_model(model):
 
 
 class CobraFBA(object):
+    """
+    This class provides an interface to cobra FBA.
+    It can load in BiGG models (http://bigg.ucsd.edu/models) if provided a model_path to a saved JSON BiGG model,
+    or load in a novel model specified by stoichiometry, reversibility, and objective.
+
+    TODO (Eran) -- MOMA option is provided, but has not yet been tested.
+    """
+
     cobra_configuration = Configuration()
 
     def __init__(self, config={}):
@@ -154,6 +162,7 @@ class CobraFBA(object):
         self.moma = config.get('moma', False)
 
         if model_path:
+            # load a BiGG model
             self.model = cobra.io.load_json_model(model_path)
             extract = extract_model(self.model)
 
@@ -168,6 +177,7 @@ class CobraFBA(object):
             self.default_upper_bound = DEFAULT_UPPER_BOUND  # TODO -- can this be extracted from model?
 
         else:
+            # create an FBA model from config
             self.stoichiometry = config['stoichiometry']
             self.reversible = config.get('reversible', [])
             self.external_molecules = config['external_molecules']

--- a/vivarium/utils/cobra_fba.py
+++ b/vivarium/utils/cobra_fba.py
@@ -196,7 +196,7 @@ class CobraFBA(object):
             for ex, value in max_exchange.items()}
 
         # initialize solution
-        self.solution = None
+        self.solution = self.model.optimize()
 
     def set_exchange_bounds(self, new_bounds={}):
         '''
@@ -224,7 +224,6 @@ class CobraFBA(object):
 
             # scaled_level = [b / self.flux_scaling for b in level]
             scaled_level = level / self.flux_scaling
-            import ipdb; ipdb.set_trace()
 
             if reaction_id in self.tolerance:
                 lower_tolerance, upper_tolerance = self.tolerance[reaction_id]


### PR DESCRIPTION
This extends ```cobra_fba``` to utilize the cobra library's MOMA (minimization of metabolic adjustment) option. To turn it on, include ```{'moma': True}``` in ```cobra_fba's``` config -- by default it is kept off.  I have not extensively tested it, but it should help keep flux solutions from jumping around wildly between time steps. This could be useful with dynamical adjusted flux constraints from transport.