### PR TITLE
Fix experiments and environment boots for new configuration paradigm

### DIFF
--- a/vivarium/composites/growth_division.py
+++ b/vivarium/composites/growth_division.py
@@ -27,15 +27,15 @@ def get_transport_config():
     transport_kinetics = {
         'GLC_transport': {
             'transporter_internal': {
-                'GLC_external': 6.0,  # km for GLC
-                'kcat_f': 1e-2}}}
+                'GLC_external': 1.0,  # km for GLC
+                'kcat_f': 1e-9}}}
 
     transport_initial_state = {
         'internal': {
             'GLC': 1.0,
             'transporter': 1.0},
         'external': {
-            'GLC': 12.0},
+            'GLC': 20.0},
         'fluxes': {
             'GLC': 1.0}}
 

--- a/vivarium/environment/boot.py
+++ b/vivarium/environment/boot.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import shutil
+import copy
 
 from vivarium.actor.inner import Inner
 from vivarium.actor.outer import Outer
@@ -95,7 +96,8 @@ def wrap_init_composite(make_composite):
 def wrap_boot_environment(intialize):
     def boot(agent_id, agent_type, agent_config):
         # get boot_config from initialize
-        boot_config = intialize(agent_config)
+        agent_config = intialize(agent_config)
+        boot_config = copy.deepcopy(agent_config['boot_config'])
 
         # paths
         working_dir = agent_config.get('working_dir', os.getcwd())
@@ -162,9 +164,9 @@ def initialize_lattice(agent_config):
         boot_config = {'concentrations': media}
     else:
         boot_config = {'media_id': media_id}
-    boot_config.update(agent_config)
 
-    return boot_config
+    agent_config['boot_config'].update(boot_config)
+    return agent_config
 
 def initialize_glc_g6p_small(agent_config):
     # set up media

--- a/vivarium/environment/boot.py
+++ b/vivarium/environment/boot.py
@@ -157,15 +157,17 @@ class EnvironmentAgent(Outer):
 
 # Define environment initialization functions
 def initialize_lattice(agent_config):
-    # set up media
-    media_id = agent_config.get('media_id', 'minimal')
-    media = agent_config.get('media', {})
-    if media:
-        boot_config = {'concentrations': media}
-    else:
-        boot_config = {'media_id': media_id}
+    boot_config = agent_config['boot_config']
 
-    agent_config['boot_config'].update(boot_config)
+    # set up media
+    media_id = boot_config.get('media_id', 'minimal')
+    media = boot_config.get('media', {})
+    if media:
+        lattice_config = {'concentrations': media}
+    else:
+        lattice_config = {'media_id': media_id}
+
+    agent_config['boot_config'].update(lattice_config)
     return agent_config
 
 def initialize_glc_g6p_small(agent_config):

--- a/vivarium/environment/boot.py
+++ b/vivarium/environment/boot.py
@@ -95,9 +95,10 @@ def wrap_init_composite(make_composite):
 
 def wrap_boot_environment(intialize):
     def boot(agent_id, agent_type, agent_config):
-        # get boot_config from initialize
-        agent_config = intialize(agent_config)
         boot_config = copy.deepcopy(agent_config['boot_config'])
+
+        # get boot_config from initialize
+        boot_config = intialize(boot_config)
 
         # paths
         working_dir = agent_config.get('working_dir', os.getcwd())
@@ -156,9 +157,7 @@ class EnvironmentAgent(Outer):
             print_send=False)
 
 # Define environment initialization functions
-def initialize_lattice(agent_config):
-    boot_config = agent_config['boot_config']
-
+def initialize_lattice(boot_config):
     # set up media
     media_id = boot_config.get('media_id', 'minimal')
     media = boot_config.get('media', {})
@@ -167,25 +166,25 @@ def initialize_lattice(agent_config):
     else:
         lattice_config = {'media_id': media_id}
 
-    agent_config['boot_config'].update(lattice_config)
-    return agent_config
+    boot_config.update(lattice_config)
+    return boot_config
 
-def initialize_glc_g6p_small(agent_config):
+def initialize_glc_g6p_small(boot_config):
     # set up media
     media_id = 'GLC_G6P'
     timeline_str = '0 {}, 1800 end'.format(media_id)  # (2hr*60*60 = 7200 s), (7hr*60*60 = 25200 s)
-    boot_config = {
+    lattice_config = {
         'timeline_str': timeline_str,
         'run_for': 2.0,
         'depth': 1e-01, # 3000 um is default
         'edge_length_x': 1.0,
         'patches_per_edge_x': 1,
     }
-    boot_config.update(agent_config)
 
+    boot_config.update(lattice_config)
     return boot_config
 
-def initialize_custom_small(agent_config):
+def initialize_custom_small(boot_config):
     # set up media
     media_id = 'custom'
     custom_media = {
@@ -207,7 +206,7 @@ def initialize_custom_small(agent_config):
     new_media = {media_id: custom_media}
     timeline_str = '0 {}, 1200 end'.format(media_id)
 
-    boot_config = {
+    lattice_config = {
         'timeline_str': timeline_str,
         'new_media': new_media,
         'run_for': 2.0,
@@ -215,42 +214,45 @@ def initialize_custom_small(agent_config):
         'edge_length_x': 1.0,
         'patches_per_edge_x': 1,
     }
-    boot_config.update(agent_config)
 
+    boot_config.update(lattice_config)
     return boot_config
 
-def initialize_glc_g6p(agent_config):
+def initialize_glc_g6p(boot_config):
     timeline_str = '0 GLC_G6P, 3600 end'
-    boot_config = {
+    lattice_config = {
         'timeline_str': timeline_str,
         'emit_fields': ['GLC', 'G6P']
     }
-    boot_config.update(agent_config)
+
+    boot_config.update(lattice_config)
     return boot_config
 
-def initialize_glc_lct(agent_config):
+def initialize_glc_lct(boot_config):
     timeline_str = '0 GLC_LCT, 3600 end'
-    boot_config = {
+    lattice_config = {
         'timeline_str': timeline_str,
         'emit_fields': ['GLC', 'LCTS']
     }
-    boot_config.update(agent_config)
+
+    boot_config.update(lattice_config)
     return boot_config
 
-def initialize_glc_lct_shift(agent_config):
+def initialize_glc_lct_shift(boot_config):
     timeline_str = '0 GLC_G6P, 1800 GLC_LCT, 3600 end'
-    boot_config = {'timeline_str': timeline_str}
-    boot_config.update(agent_config)
+    lattice_config = {'timeline_str': timeline_str}
+
+    boot_config.update(lattice_config)
     return boot_config
 
-def initialize_ecoli_core_glc(agent_config):
+def initialize_ecoli_core_glc(boot_config):
     # timeline_str = '0 ecoli_core_GLC 1.0 L + lac__D_e 1.0 mmol 0.1 L, ' \
     #                '1800 ecoli_core_GLC 1.0 L + lac__D_e 1.0 mmol 0.1 L - glc__D_e Infinity, ' \
     #                '3600 end'
 
     timeline_str = '0 ecoli_core_GLC 1.0 L + lac__D_e 1.0 mmol 0.1 L, 21600 end'
 
-    boot_config = {
+    lattice_config = {
         'diffusion': 1e-4,
         'depth': 1e-4,
         'timeline_str': timeline_str,
@@ -258,16 +260,17 @@ def initialize_ecoli_core_glc(agent_config):
             'glc__D_e',
             'lac__D_e']
     }
-    boot_config.update(agent_config)
+
+    boot_config.update(lattice_config)
     return boot_config
 
-def initialize_measp(agent_config):
+def initialize_measp(boot_config):
     media_id = 'MeAsp_media'
     media = {'GLC': 20.0,  # assumes mmol/L
              'MeAsp': 1.0}
     new_media = {media_id: media}
     timeline_str = '0 {}, 3600 end'.format(media_id)  # (2hr*60*60 = 7200 s), (7hr*60*60 = 25200 s)
-    boot_config = {
+    lattice_config = {
         'new_media': new_media,
         'timeline_str': timeline_str,
         'emit_fields': ['MeAsp'],
@@ -287,17 +290,17 @@ def initialize_measp(agent_config):
         'rotation_jitter': 0.005,
         'edge_length_x': 50.0,
         'patches_per_edge_x': 40}
-    boot_config.update(agent_config)
 
+    boot_config.update(lattice_config)
     return boot_config
 
-def initialize_measp_long(agent_config):
+def initialize_measp_long(boot_config):
     media_id = 'MeAsp_media'
     media = {'GLC': 20.0,  # assumes mmol/L
              'MeAsp': 1.0}
     new_media = {media_id: media}
     timeline_str = '0 {}, 3600 end'.format(media_id)  # (2hr*60*60 = 7200 s), (7hr*60*60 = 25200 s)
-    boot_config = {
+    lattice_config = {
         'new_media': new_media,
         'timeline_str': timeline_str,
         'emit_fields': ['GLC','MeAsp'],
@@ -318,12 +321,12 @@ def initialize_measp_long(agent_config):
         'edge_length_x': 200.0,
         'edge_length_y': 50.0,
         'patches_per_edge_x': 40}
-    boot_config.update(agent_config)
 
+    boot_config.update(lattice_config)
     return boot_config
 
 
-def initialize_measp_large(agent_config):
+def initialize_measp_large(boot_config):
 
     ## Make media: GLC_G6P with MeAsp
     # get GLC_G6P media
@@ -347,7 +350,7 @@ def initialize_measp_large(agent_config):
 
     emit_field = ['GLC', 'MeAsp']
 
-    boot_config = {
+    lattice_config = {
         'timeline_str': timeline_str,
         'new_media': new_media,
         'run_for': 1.0,
@@ -368,11 +371,11 @@ def initialize_measp_large(agent_config):
         'rotation_jitter': 0.005,
         'edge_length_x': 200.0,
         'patches_per_edge_x': 50}
-    boot_config.update(agent_config)
 
+    boot_config.update(lattice_config)
     return boot_config
 
-def initialize_measp_timeline(agent_config):
+def initialize_measp_timeline(boot_config):
     # Endres and Wingreen (2006) use + 100 uM = 0.1 mmol for attractant. 0.2 b/c of dilution.
     timeline_str = '0 GLC 20.0 mmol 1 L + MeAsp 0.0 mmol 1 L, ' \
                    '200 GLC 20.0 mmol 1 L + MeAsp 0.2 mmol 1 L, ' \
@@ -381,7 +384,7 @@ def initialize_measp_timeline(agent_config):
                    '1400 GLC 20.0 mmol 1 L + MeAsp 0.0 mmol 1 L, ' \
                    '1600 end'
 
-    boot_config = {
+    lattice_config = {
         'timeline_str': timeline_str,
         'run_for': 1.0,
         'static_concentrations': True,
@@ -390,8 +393,8 @@ def initialize_measp_timeline(agent_config):
         'edge_length_x': 100.0,
         'patches_per_edge_x': 50,
     }
-    boot_config.update(agent_config)
 
+    boot_config.update(lattice_config)
     return boot_config
 
 

--- a/vivarium/environment/control.py
+++ b/vivarium/environment/control.py
@@ -119,7 +119,7 @@ class ShepherdControl(ActorControl):
 
         emit_fields = ['GLC']
 
-        lattice_config = dict(agent_config, {
+        lattice_config = dict(agent_config, **{
             'timeline_str': timeline_str,
             'media_id': media_id,
             'emit_fields': emit_fields,
@@ -140,7 +140,7 @@ class ShepherdControl(ActorControl):
         time.sleep(10)  # TODO(jerry): Wait for the Lattice to boot
 
         for index in range(num_cells):
-            self.add_cell(args['type'] or 'ecoli', dict(agent_config, {
+            self.add_cell(args['type'] or 'ecoli', dict(agent_config, **{
                 'boot': 'vivarium.environment.boot',
                 'outer_id': experiment_id,
                 'working_dir': args['working_dir'],
@@ -161,7 +161,7 @@ class ShepherdControl(ActorControl):
 
         emit_fields = ['GLC']
 
-        experiment_config = dict(agent_config, {
+        experiment_config = dict(agent_config, **{
             'timeline_str': timeline_str,
             'run_for': 2.0,
             'emit_fields': emit_fields,
@@ -173,7 +173,7 @@ class ShepherdControl(ActorControl):
         time.sleep(10)  # TODO(jerry): Wait for the Lattice to boot
 
         for index in range(num_cells):
-            self.add_cell(args['type'] or 'metabolism', dict(agent_config, {
+            self.add_cell(args['type'] or 'metabolism', dict(agent_config, **{
                 'boot': 'vivarium.environment.boot',
                 'outer_id': experiment_id,
                 'working_dir': args['working_dir'],
@@ -194,17 +194,17 @@ class ShepherdControl(ActorControl):
 
         emit_fields = ['GLC', 'G6P']
 
-        experiment_config = dict(agent_config, {
+        experiment_config = dict(agent_config, **{
             'timeline_str': timeline_str,
             'run_for': 2.0,
-            'emit_fields': emit_field})
+            'emit_fields': emit_fields})
 
         self.add_agent(experiment_id, 'lattice', experiment_config)
 
         time.sleep(10)  # TODO(jerry): Wait for the Lattice to boot
 
         for index in range(num_cells):
-            self.add_cell(args['type'] or 'metabolism', dict(agent_config, {
+            self.add_cell(args['type'] or 'metabolism', dict(agent_config, **{
                 'boot': 'vivarium.environment.boot',
                 'outer_id': experiment_id,
                 'working_dir': args['working_dir'],
@@ -222,7 +222,7 @@ class ShepherdControl(ActorControl):
         if not timeline_str:
             timeline_str = '0 ecoli_core_GLC 1.0 L + lac__D_e 2.0 mmol 0.1 L, 21600 end'
 
-        experiment_config = dict(agent_config, {
+        experiment_config = dict(agent_config, **{
             'timeline_str': timeline_str,
             'edge_length_x': 15.0,
             'patches_per_edge_x': 15,
@@ -239,7 +239,7 @@ class ShepherdControl(ActorControl):
         time.sleep(10)
 
         for index in range(num_cells):
-            self.add_cell(args['type'] or 'kinetic_FBA', dict(agent_config, {
+            self.add_cell(args['type'] or 'kinetic_FBA', dict(agent_config, **{
                 'boot': 'vivarium.environment.boot',
                 'outer_id': experiment_id,
                 'working_dir': args['working_dir'],
@@ -260,7 +260,7 @@ class ShepherdControl(ActorControl):
         # timeline_str = '0 {}, 14400 end'.format(media_id)
         timeline_str = '0 {}, 1800 end'.format(media_id)
 
-        chemotaxis_config = dict(agent_config, {
+        chemotaxis_config = dict(agent_config, **{
             'timeline_str': timeline_str,
             'new_media': new_media,
             'run_for' : 0.05,
@@ -269,7 +269,7 @@ class ShepherdControl(ActorControl):
             'gradient': {
                 'type': 'linear',
                 'molecules': {
-                    'GLC':{
+                    'GLC': {
                         'center': [0.0, 0.0],
                         'slope': -1.0/150.0},
                     'MeAsp': {
@@ -282,13 +282,14 @@ class ShepherdControl(ActorControl):
             'edge_length_x': 500.0,
             'edge_length_y': 100.0,
             'patches_per_edge_x': 100})
+
         self.add_agent(experiment_id, 'lattice', chemotaxis_config)
 
         # give lattice time before adding the cells
         time.sleep(15)
 
         for index in range(num_cells):
-            self.add_cell(args['type'] or 'chemotaxis', dict(agent_config, {
+            self.add_cell(args['type'] or 'chemotaxis', dict(agent_config, **{
                 'boot': 'vivarium.environment.boot',
                 'outer_id': experiment_id,
                 'seed': index}))
@@ -323,7 +324,7 @@ class ShepherdControl(ActorControl):
         new_media = {media_id: media}
         timeline_str = '0 {}, 3600 end'.format(media_id)
 
-        swarm_config = dict(agent_config, {
+        swarm_config = dict(agent_config, **{
             'cell_placement': [0.5, 0.5], # place cells at center of lattice
             'timeline_str': timeline_str,
             'new_media': new_media,
@@ -340,7 +341,7 @@ class ShepherdControl(ActorControl):
         time.sleep(15)
 
         for index in range(num_cells):
-            self.add_cell(args['type'] or 'chemotaxis', dict(agent_config, {
+            self.add_cell(args['type'] or 'chemotaxis', dict(agent_config, **{
                 'boot': 'vivarium.environment.boot',
                 'outer_id': experiment_id,
                 'seed': index}))

--- a/vivarium/environment/control.py
+++ b/vivarium/environment/control.py
@@ -38,19 +38,21 @@ class ShepherdControl(ActorControl):
 
         emit_fields = ['GLC']
 
-        lattice_config = dict(agent_config, **{
+        lattice_config = {
             'timeline_str': timeline_str,
             'media_id': media_id,
             'emit_fields': emit_fields,
             'boot': 'vivarium.environment.boot',
             'run_for': 4.0,
             'diffusion': args.get('diffusion', 1000),
-            'edge_length_x': args.get('edge_length_x'),
+            'edge_length_x': args.get('edge_length_x', 20),
             'patches_per_edge_x': args.get('patches_per_edge_x', 10),
             'translation_jitter': 0.1,
-            'rotation_jitter': 0.01})
+            'rotation_jitter': 0.01}
 
-        self.add_agent(experiment_id, 'lattice', lattice_config)
+        agent_config['boot_config'].update(lattice_config)
+        self.add_agent(experiment_id, 'lattice', agent_config)
+
 
         time.sleep(10)  # TODO(jerry): Wait for the Lattice to boot
 

--- a/vivarium/environment/control.py
+++ b/vivarium/environment/control.py
@@ -34,25 +34,21 @@ class ShepherdControl(ActorControl):
         timeline_str = args.get('timeline')
         if not timeline_str:
             timeline_str = '0 {}, 7200 end'.format(media_id)
-            # timeline_str = '0 {}, 14400 end'.format(media_id)
-
-        emit_fields = ['GLC']
 
         lattice_config = {
             'timeline_str': timeline_str,
             'media_id': media_id,
-            'emit_fields': emit_fields,
+            'emit_fields': ['GLC'],
             'boot': 'vivarium.environment.boot',
             'run_for': 4.0,
-            'diffusion': args.get('diffusion', 1000),
-            'edge_length_x': args.get('edge_length_x', 20),
-            'patches_per_edge_x': args.get('patches_per_edge_x', 10),
+            'diffusion': 1000,
+            'edge_length_x': 20,
+            'patches_per_edge_x': 10,
             'translation_jitter': 0.1,
             'rotation_jitter': 0.01}
 
         agent_config['boot_config'].update(lattice_config)
         self.add_agent(experiment_id, 'lattice', agent_config)
-
 
         time.sleep(10)  # TODO(jerry): Wait for the Lattice to boot
 
@@ -82,7 +78,7 @@ class ShepherdControl(ActorControl):
 
         emit_fields = ['GLC']
 
-        lattice_config = dict(agent_config, **{
+        lattice_config = {
             'timeline_str': timeline_str,
             'media_id': media_id,
             'emit_fields': emit_fields,
@@ -92,9 +88,10 @@ class ShepherdControl(ActorControl):
             'edge_length_y': 20.0,
             'patches_per_edge_x': 8,
             'translation_jitter': 0.1,
-            'rotation_jitter': 0.01})
+            'rotation_jitter': 0.01}
 
-        self.add_agent(experiment_id, 'lattice', lattice_config)
+        agent_config['boot_config'].update(lattice_config)
+        self.add_agent(experiment_id, 'lattice', agent_config)
 
         time.sleep(10)  # TODO(jerry): Wait for the Lattice to boot
 
@@ -121,7 +118,7 @@ class ShepherdControl(ActorControl):
 
         emit_fields = ['GLC']
 
-        lattice_config = dict(agent_config, **{
+        lattice_config = {
             'timeline_str': timeline_str,
             'media_id': media_id,
             'emit_fields': emit_fields,
@@ -135,9 +132,10 @@ class ShepherdControl(ActorControl):
                         'center': [0.0, 0.0],
                         'slope': -1.0 / 250.0},
                 }},
-        })
+        }
 
-        self.add_agent(experiment_id, 'lattice', lattice_config)
+        agent_config['boot_config'].update(lattice_config)
+        self.add_agent(experiment_id, 'lattice', agent_config)
 
         time.sleep(10)  # TODO(jerry): Wait for the Lattice to boot
 
@@ -163,14 +161,15 @@ class ShepherdControl(ActorControl):
 
         emit_fields = ['GLC']
 
-        experiment_config = dict(agent_config, **{
+        lattice_config = {
             'timeline_str': timeline_str,
             'run_for': 2.0,
             'emit_fields': emit_fields,
             'edge_length_x': 10.0,
-            'patches_per_edge_x': 10})
+            'patches_per_edge_x': 10}
 
-        self.add_agent(experiment_id, 'lattice', experiment_config)
+        agent_config['boot_config'].update(lattice_config)
+        self.add_agent(experiment_id, 'lattice', agent_config)
 
         time.sleep(10)  # TODO(jerry): Wait for the Lattice to boot
 
@@ -196,12 +195,13 @@ class ShepherdControl(ActorControl):
 
         emit_fields = ['GLC', 'G6P']
 
-        experiment_config = dict(agent_config, **{
+        lattice_config = {
             'timeline_str': timeline_str,
             'run_for': 2.0,
-            'emit_fields': emit_fields})
+            'emit_fields': emit_fields}
 
-        self.add_agent(experiment_id, 'lattice', experiment_config)
+        agent_config['boot_config'].update(lattice_config)
+        self.add_agent(experiment_id, 'lattice', agent_config)
 
         time.sleep(10)  # TODO(jerry): Wait for the Lattice to boot
 
@@ -224,7 +224,7 @@ class ShepherdControl(ActorControl):
         if not timeline_str:
             timeline_str = '0 ecoli_core_GLC 1.0 L + lac__D_e 2.0 mmol 0.1 L, 21600 end'
 
-        experiment_config = dict(agent_config, **{
+        lattice_config = {
             'timeline_str': timeline_str,
             'edge_length_x': 15.0,
             'patches_per_edge_x': 15,
@@ -234,9 +234,10 @@ class ShepherdControl(ActorControl):
             'translation_jitter': 1.0,
             'emit_fields': [
                 'glc__D_e',
-                'lac__D_e']})
+                'lac__D_e']}
 
-        self.add_agent(experiment_id, 'lattice', experiment_config)
+        agent_config['boot_config'].update(lattice_config)
+        self.add_agent(experiment_id, 'lattice', agent_config)
 
         time.sleep(10)
 
@@ -262,7 +263,7 @@ class ShepherdControl(ActorControl):
         # timeline_str = '0 {}, 14400 end'.format(media_id)
         timeline_str = '0 {}, 1800 end'.format(media_id)
 
-        chemotaxis_config = dict(agent_config, **{
+        lattice_config = {
             'timeline_str': timeline_str,
             'new_media': new_media,
             'run_for' : 0.05,
@@ -283,9 +284,10 @@ class ShepherdControl(ActorControl):
             # 'rotation_jitter': 0.05,
             'edge_length_x': 500.0,
             'edge_length_y': 100.0,
-            'patches_per_edge_x': 100})
+            'patches_per_edge_x': 100}
 
-        self.add_agent(experiment_id, 'lattice', chemotaxis_config)
+        agent_config['boot_config'].update(lattice_config)
+        self.add_agent(experiment_id, 'lattice', agent_config)
 
         # give lattice time before adding the cells
         time.sleep(15)
@@ -326,7 +328,7 @@ class ShepherdControl(ActorControl):
         new_media = {media_id: media}
         timeline_str = '0 {}, 3600 end'.format(media_id)
 
-        swarm_config = dict(agent_config, **{
+        lattice_config = {
             'cell_placement': [0.5, 0.5], # place cells at center of lattice
             'timeline_str': timeline_str,
             'new_media': new_media,
@@ -336,8 +338,10 @@ class ShepherdControl(ActorControl):
             'diffusion': 0.001,
             'edge_length_x': 100.0,
             'edge_length_y': 100.0,
-            'patches_per_edge_x': 50})
-        self.add_agent(experiment_id, 'lattice', swarm_config)
+            'patches_per_edge_x': 50}
+
+        agent_config['boot_config'].update(lattice_config)
+        self.add_agent(experiment_id, 'lattice', agent_config)
 
         # give lattice time before adding the cells
         time.sleep(15)

--- a/vivarium/environment/lattice.py
+++ b/vivarium/environment/lattice.py
@@ -746,8 +746,6 @@ def test_lattice(total_time=10):
 
 
 def plot_motility(data, out_dir='out'):
-    import matplotlib
-    matplotlib.use('TkAgg')
     import matplotlib.pyplot as plt
 
     expected_speed = 14.2  # um/s (Berg)
@@ -826,8 +824,6 @@ def plot_motility(data, out_dir='out'):
 
 
 def plot_trajectory(data, out_dir='out'):
-    import matplotlib
-    matplotlib.use('TkAgg')
     import matplotlib.pyplot as plt
     from matplotlib.collections import LineCollection
 
@@ -874,8 +870,6 @@ def plot_trajectory(data, out_dir='out'):
 
 
 def plot_field(data, out_dir='out'):
-    import matplotlib
-    matplotlib.use('TkAgg')
     import matplotlib.pyplot as plt
 
     x_length = data['x_length']
@@ -925,9 +919,9 @@ if __name__ == '__main__':
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    output1 = test_lattice(50)
+    output1 = test_lattice(20)
     plot_motility(output1, out_dir)
     plot_trajectory(output1, out_dir)
 
-    # output2 = test_diffusion(2)
-    # plot_field(output2, out_dir)
+    output2 = test_diffusion(2)
+    plot_field(output2, out_dir)


### PR DESCRIPTION
This fixes some errors arising from the recent configuration revamp in #99.  We really need tests for experiments -- I'll go through and manually test all the experiments tomorrow before merging. ```lattice_experiment``` appeared to working fine with the ```growth_division``` composite, and with the analyses.

@prismofeverything -- I changed ```environment.boot.py``` a bit from what we had discussed today.  Rather than ```initialize_lattice``` and all other initializations receiving and updating ```agent_config```, they receive and update ```boot_config```. This seems cleaner since they don't require ```agent_config```.

The ```growth_division``` composite was eating way too much glucose, so I changed its kinetics. Not sure what happened there, I'll keep an eye out on it.

Some additional things I found while digging through this: ```EnvironmentAgent``` should be renamed ```EnvironmentActor``` since it is an ```outer```. Also, most if not all ```agent_config``` should be renamed ```actor_config``` since it is used entirely by actor for managing the different threads.  I also saw that ```color``` is still going through the CELL_EXCHANGE message -- a leftover from early days in which wcEcoli controlled color in the Lens viewer.