### PR TITLE
convenience kinetics uses tuples rather than strings for role, state

### DIFF
--- a/vivarium/composites/growth_division.py
+++ b/vivarium/composites/growth_division.py
@@ -18,16 +18,16 @@ def get_transport_config():
     transport_reactions = {
         'GLC_transport': {
             'stoichiometry': {
-                'GLC_external': -1.0,
-                'GLC_internal': 1.0},
+                ('external', 'GLC'): -1.0,
+                ('internal', 'GLC'): 1.0},
             'is reversible': False,
-            'catalyzed by': ['transporter_internal']}}
+            'catalyzed by': [('internal', 'transporter')]}}
 
     # very simplified PTS
     transport_kinetics = {
         'GLC_transport': {
-            'transporter_internal': {
-                'GLC_external': 1.0,  # km for GLC
+            ('internal', 'transporter'): {
+                ('external', 'GLC'): 1.0,  # km for GLC
                 'kcat_f': 1e-9}}}
 
     transport_initial_state = {

--- a/vivarium/composites/kinetic_FBA.py
+++ b/vivarium/composites/kinetic_FBA.py
@@ -109,19 +109,19 @@ def default_transport_config():
     transport_reactions = {
         'EX_glc__D_e': {
             'stoichiometry': {
-                'g6p_c_internal': 1.0,
-                'glc__D_e_external': -1.0,
-                # 'pep_c_internal': -1.0,  # TODO -- PEP needs mechanism for homeostasis to avoid depletion
-                # 'pyr_c_internal': 1.0
+                ('internal', 'g6p_c'): 1.0,
+                ('external', 'glc__D_e'): -1.0,
+                # ('internal', 'pep_c'): -1.0,  # TODO -- PEP needs mechanism for homeostasis to avoid depletion
+                # ('internal', 'pyr_c'): 1.0
             },
             'is reversible': False,
-            'catalyzed by': ['PTSG_internal']}}
+            'catalyzed by': [('internal', 'PTSG')]}}
 
     transport_kinetics = {
         'EX_glc__D_e': {
-            'PTSG_internal': {
-                'glc__D_e_external': 1e-1,
-                'pep_c_internal': None,
+            ('internal', 'PTSG'): {
+                ('external', 'glc__D_e'): 1e-1,
+                ('internal', 'pep_c'): None,
                 'kcat_f': -3e5}}}
 
     transport_initial_state = {

--- a/vivarium/utils/dict_utils.py
+++ b/vivarium/utils/dict_utils.py
@@ -19,3 +19,16 @@ def flatten_role_dicts(dicts):
         for state, value in states_dict.items():
             merge.update({state + '_' + role: value})
     return merge
+
+def tuplify_role_dicts(dicts):
+    '''
+    Input:
+        dicts (dict): embedded state dictionaries with the {'role_id': {'state_id': state_value}}
+    Return:
+        merge (dict): tuplified dictionary with {(role_id','state_id'): value}
+    '''
+    merge = {}
+    for role, states_dict in dicts.items():
+        for state, value in states_dict.items():
+            merge.update({(role, state): value})
+    return merge


### PR DESCRIPTION
The convenience process now uses tuples with ('role', 'state') for kinetic parameters rather than strings with 'state_role'. This avoids string manipulation and I find it more elegant.