### PR TITLE
Expression composite and abstracting polymerization for translation

### DIFF
--- a/vivarium/composites/gene_expression.py
+++ b/vivarium/composites/gene_expression.py
@@ -118,7 +118,7 @@ if __name__ == '__main__':
 
     # run simulation
     settings = {
-        'total_time': 20}
+        'total_time': 40}
     saved_state = simulate_compartment(gene_expression_compartment, settings)
     del saved_state[0]  # remove the first state
     timeseries = convert_to_timeseries(saved_state)

--- a/vivarium/composites/gene_expression.py
+++ b/vivarium/composites/gene_expression.py
@@ -86,8 +86,8 @@ def plot_gene_expression_output(timeseries, out_dir='out'):
     # plot molecules
     for mol_id, series in molecules.items():
         ax1.plot(time, series, label=mol_id)
-    ax1.legend(loc='center left', bbox_to_anchor=(1.0, 0.5))
-    ax1.title.set_text('molecules')
+    # ax1.legend(loc='center left', bbox_to_anchor=(1.0, 0.5))
+    ax1.title.set_text('metabolites')
 
     # plot transcripts
     for transcript_id, series in transcripts.items():
@@ -107,7 +107,7 @@ def plot_gene_expression_output(timeseries, out_dir='out'):
         axis.spines['top'].set_visible(False)
 
     ax1.set_xticklabels([])
-    # ax2.set_xticklabels([])
+    ax2.set_xticklabels([])
     ax3.set_xlabel('time (s)', fontsize=12)
 
     # save figure

--- a/vivarium/composites/gene_expression.py
+++ b/vivarium/composites/gene_expression.py
@@ -8,6 +8,7 @@ from vivarium.actor.process import initialize_state
 
 # processes
 from vivarium.processes.transcription import Transcription
+from vivarium.processes.translation import Translation
 from vivarium.processes.deriver import Deriver
 from vivarium.processes.division import Division, divide_condition, divide_state
 
@@ -17,12 +18,14 @@ def compose_gene_expression(config):
 
     # declare the processes
     transcription = Transcription(config)
+    translation = Translation(config)
     deriver = Deriver(config)
     division = Division(config)
 
     # place processes in layers
     processes = [
-        {'transcription': transcription},
+        {'transcription': transcription,
+         'translation': translation},
         {'deriver': deriver,
          'division': division}]
 
@@ -32,13 +35,17 @@ def compose_gene_expression(config):
             'chromosome': 'chromosome',
             'molecules': 'molecules',
             'transcripts': 'transcripts'},
+        'translation': {
+            'ribosomes': 'ribosomes',
+            'molecules': 'molecules',
+            'transcripts': 'transcripts',
+            'proteins': 'proteins'},
         'deriver': {
             'counts': 'cell_counts',
             'state': 'cell',
             'prior_state': 'prior_state'},
         'division': {
-            'internal': 'cell'},
-        }
+            'internal': 'cell'}}
 
     # initialize the states
     states = initialize_state(processes, topology, config.get('initial_state', {}))
@@ -63,6 +70,7 @@ def plot_gene_expression_output(timeseries, out_dir='out'):
 
     molecules = timeseries['molecules']
     transcripts = timeseries['transcripts']
+    proteins = timeseries['proteins']
     time = timeseries['time']
 
     # make figure and plot
@@ -88,8 +96,10 @@ def plot_gene_expression_output(timeseries, out_dir='out'):
     ax2.title.set_text('transcripts')
 
     # plot proteins
-    # TODO
-
+    for protein_id, series in proteins.items():
+        ax3.plot(time, series, label=protein_id)
+    ax3.legend(loc='center left', bbox_to_anchor=(1.0, 0.5))
+    ax3.title.set_text('proteins')
 
     # adjust axes
     for axis in [ax1, ax2, ax3]:
@@ -98,7 +108,7 @@ def plot_gene_expression_output(timeseries, out_dir='out'):
 
     ax1.set_xticklabels([])
     # ax2.set_xticklabels([])
-    ax2.set_xlabel('time (s)', fontsize=12)
+    ax3.set_xlabel('time (s)', fontsize=12)
 
     # save figure
     fig_path = os.path.join(out_dir, 'gene_expression')

--- a/vivarium/composites/gfp_expression.py
+++ b/vivarium/composites/gfp_expression.py
@@ -1,0 +1,4 @@
+from vivarium.composite.gene_expression import compose_gene_expression
+
+def generate_gfp_compartment(config):
+    pass

--- a/vivarium/data/amino_acids.py
+++ b/vivarium/data/amino_acids.py
@@ -1,0 +1,26 @@
+amino_acid_records = [
+    {'name': 'Alanine', 'abbreviation': 'Ala', 'symbol': 'A'},
+    {'name': 'Arginine', 'abbreviation': 'Arg', 'symbol': 'R'},
+    {'name': 'Asparagine', 'abbreviation': 'Asn', 'symbol': 'N'},
+    {'name': 'Aspartic acid', 'abbreviation': 'Asp', 'symbol': 'D'},
+    {'name': 'Cysteine', 'abbreviation': 'Cys', 'symbol': 'C'},
+    {'name': 'Glutamic acid', 'abbreviation': 'Glu', 'symbol': 'E'},
+    {'name': 'Glutamine', 'abbreviation': 'Gln', 'symbol': 'Q'},
+    {'name': 'Glycine', 'abbreviation': 'Gly', 'symbol': 'G'},
+    {'name': 'Histidine', 'abbreviation': 'His', 'symbol': 'H'},
+    {'name': 'Isoleucine', 'abbreviation': 'Ile', 'symbol': 'I'},
+    {'name': 'Leucine', 'abbreviation': 'Leu', 'symbol': 'L'},
+    {'name': 'Lysine', 'abbreviation': 'Lys', 'symbol': 'K'},
+    {'name': 'Methionine', 'abbreviation': 'Met', 'symbol': 'M'},
+    {'name': 'Phenylalanine', 'abbreviation': 'Phe', 'symbol': 'F'},
+    {'name': 'Proline', 'abbreviation': 'Pro', 'symbol': 'P'},
+    {'name': 'Serine', 'abbreviation': 'Ser', 'symbol': 'S'},
+    {'name': 'Threonine', 'abbreviation': 'Thr', 'symbol': 'T'},
+    {'name': 'Tryptophan', 'abbreviation': 'Trp', 'symbol': 'W'},
+    {'name': 'Tyrosine', 'abbreviation': 'Tyr', 'symbol': 'Y'},
+    {'name': 'Valine', 'abbreviation': 'Val', 'symbol': 'V'}]
+
+amino_acids = {
+    record['symbol']: record
+    for record in amino_acid_records}
+

--- a/vivarium/data/chromosome.py
+++ b/vivarium/data/chromosome.py
@@ -1,29 +1,3 @@
-amino_acid_records = [
-    {'name': 'Alanine', 'abbreviation': 'Ala', 'symbol': 'A'},
-    {'name': 'Arginine', 'abbreviation': 'Arg', 'symbol': 'R'},
-    {'name': 'Asparagine', 'abbreviation': 'Asn', 'symbol': 'N'},
-    {'name': 'Aspartic acid', 'abbreviation': 'Asp', 'symbol': 'D'},
-    {'name': 'Cysteine', 'abbreviation': 'Cys', 'symbol': 'C'},
-    {'name': 'Glutamic acid', 'abbreviation': 'Glu', 'symbol': 'E'},
-    {'name': 'Glutamine', 'abbreviation': 'Gln', 'symbol': 'Q'},
-    {'name': 'Glycine', 'abbreviation': 'Gly', 'symbol': 'G'},
-    {'name': 'Histidine', 'abbreviation': 'His', 'symbol': 'H'},
-    {'name': 'Isoleucine', 'abbreviation': 'Ile', 'symbol': 'I'},
-    {'name': 'Leucine', 'abbreviation': 'Leu', 'symbol': 'L'},
-    {'name': 'Lysine', 'abbreviation': 'Lys', 'symbol': 'K'},
-    {'name': 'Methionine', 'abbreviation': 'Met', 'symbol': 'M'},
-    {'name': 'Phenylalanine', 'abbreviation': 'Phe', 'symbol': 'F'},
-    {'name': 'Proline', 'abbreviation': 'Pro', 'symbol': 'P'},
-    {'name': 'Serine', 'abbreviation': 'Ser', 'symbol': 'S'},
-    {'name': 'Threonine', 'abbreviation': 'Thr', 'symbol': 'T'},
-    {'name': 'Tryptophan', 'abbreviation': 'Trp', 'symbol': 'W'},
-    {'name': 'Tyrosine', 'abbreviation': 'Tyr', 'symbol': 'Y'},
-    {'name': 'Valine', 'abbreviation': 'Val', 'symbol': 'V'}]
-
-amino_acids = {
-    record['symbol']: record
-    for record in amino_acid_records}
-
 test_chromosome_config = {
     'sequence': 'ATACGGCACGTGACCGTCAACTTA',
     'genes': {

--- a/vivarium/data/chromosome.py
+++ b/vivarium/data/chromosome.py
@@ -18,11 +18,11 @@ test_chromosome_config = {
                 {
                     'position': 6,
                     'strength': 0.5,
-                    'product': 'oA'},
+                    'product': ['oA']},
                 {
                     'position': 11,
                     'strength': 1.0,
-                    'product': 'oAZ'}]},
+                    'product': ['oAZ']}]},
         'pB': {
             'id': 'pB',
             'position': -3,
@@ -36,11 +36,11 @@ test_chromosome_config = {
                 {
                     'position': -8,
                     'strength': 0.5,
-                    'product': 'oB'},
+                    'product': ['oB']},
                 {
                     'position': -11,
                     'strength': 1.0,
-                    'product': 'oBY'}]}},
+                    'product': ['oBY']}]}},
     'domains': {
         0: {
             'id': 0,
@@ -79,7 +79,7 @@ gfp_plasmid_config = {
                 {
                     'position': 736,
                     'strength': 1.0,
-                    'product': 'GFP'}]},
+                    'product': ['GFP']}]},
         },
     'domains': {
         0: {

--- a/vivarium/data/chromosome.py
+++ b/vivarium/data/chromosome.py
@@ -1,3 +1,28 @@
+amino_acid_records = [
+    {'name': 'Alanine', 'abbreviation': 'Ala', 'symbol': 'A'},
+    {'name': 'Arginine', 'abbreviation': 'Arg', 'symbol': 'R'},
+    {'name': 'Asparagine', 'abbreviation': 'Asn', 'symbol': 'N'},
+    {'name': 'Aspartic acid', 'abbreviation': 'Asp', 'symbol': 'D'},
+    {'name': 'Cysteine', 'abbreviation': 'Cys', 'symbol': 'C'},
+    {'name': 'Glutamic acid', 'abbreviation': 'Glu', 'symbol': 'E'},
+    {'name': 'Glutamine', 'abbreviation': 'Gln', 'symbol': 'Q'},
+    {'name': 'Glycine', 'abbreviation': 'Gly', 'symbol': 'G'},
+    {'name': 'Histidine', 'abbreviation': 'His', 'symbol': 'H'},
+    {'name': 'Isoleucine', 'abbreviation': 'Ile', 'symbol': 'I'},
+    {'name': 'Leucine', 'abbreviation': 'Leu', 'symbol': 'L'},
+    {'name': 'Lysine', 'abbreviation': 'Lys', 'symbol': 'K'},
+    {'name': 'Methionine', 'abbreviation': 'Met', 'symbol': 'M'},
+    {'name': 'Phenylalanine', 'abbreviation': 'Phe', 'symbol': 'F'},
+    {'name': 'Proline', 'abbreviation': 'Pro', 'symbol': 'P'},
+    {'name': 'Serine', 'abbreviation': 'Ser', 'symbol': 'S'},
+    {'name': 'Threonine', 'abbreviation': 'Thr', 'symbol': 'T'},
+    {'name': 'Tryptophan', 'abbreviation': 'Trp', 'symbol': 'W'},
+    {'name': 'Tyrosine', 'abbreviation': 'Tyr', 'symbol': 'Y'},
+    {'name': 'Valine', 'abbreviation': 'Val', 'symbol': 'V'}]
+
+amino_acids = {
+    record['symbol']: record
+    for record in amino_acid_records}
 
 test_chromosome_config = {
     'sequence': 'ATACGGCACGTGACCGTCAACTTA',

--- a/vivarium/data/chromosome.py
+++ b/vivarium/data/chromosome.py
@@ -44,11 +44,11 @@ test_chromosome_config = {
                 {
                     'position': 6,
                     'strength': 0.5,
-                    'operon': 'oA'},
+                    'product': 'oA'},
                 {
                     'position': 11,
                     'strength': 1.0,
-                    'operon': 'oAZ'}]},
+                    'product': 'oAZ'}]},
         'pB': {
             'id': 'pB',
             'position': -3,
@@ -62,11 +62,11 @@ test_chromosome_config = {
                 {
                     'position': -8,
                     'strength': 0.5,
-                    'operon': 'oB'},
+                    'product': 'oB'},
                 {
                     'position': -11,
                     'strength': 1.0,
-                    'operon': 'oBY'}]}},
+                    'product': 'oBY'}]}},
     'domains': {
         0: {
             'id': 0,
@@ -75,17 +75,17 @@ test_chromosome_config = {
             'children': []}},
     'rnaps': [
         {
-            'promoter': 'pA',
+            'template': 'pA',
             'domain': 0,
             'state': 'transcribing',
             'position': 3},
         {
-            'promoter': 'pA',
+            'template': 'pA',
             'domain': 0,
             'state': 'transcribing',
             'position': 6},
         {
-            'promoter': 'pA',
+            'template': 'pA',
             'domain': 0,
             'state': 'transcribing',
             'position': 0}]}
@@ -105,7 +105,7 @@ gfp_plasmid_config = {
                 {
                     'position': 736,
                     'strength': 1.0,
-                    'operon': 'GFP'}]},
+                    'product': 'GFP'}]},
         },
     'domains': {
         0: {

--- a/vivarium/processes/transcription.py
+++ b/vivarium/processes/transcription.py
@@ -180,8 +180,8 @@ class Transcription(Process):
         elongation = Elongation(
             chromosome.sequence,
             chromosome.promoters,
-            self.elongation,
-            monomer_limits)
+            monomer_limits,
+            self.elongation)
 
         while time < timestep:
             print('time: {} --------------------------------------------------------'.format(time))

--- a/vivarium/processes/transcription.py
+++ b/vivarium/processes/transcription.py
@@ -237,6 +237,7 @@ class Transcription(Process):
             interval = distance / self.elongation_rate
 
             print('interval: {}'.format(interval))
+            print('substrates: {}'.format(substrate))
 
             # run simulation for interval of time to next terminator
             result = self.initiation.evolve(interval, substrate)
@@ -297,7 +298,7 @@ class Transcription(Process):
             # until the end of this interval.
             terminations, monomer_limits = elongation.elongate(
                 chromosome,
-                time + now,
+                time + interval,
                 self.elongation_rate,
                 monomer_limits)
             unbound_rnaps += terminations

--- a/vivarium/processes/transcription.py
+++ b/vivarium/processes/transcription.py
@@ -151,7 +151,7 @@ class Transcription(Process):
         time = 0
         now = 0
         elongation = Elongation(
-            chromosome.sequence,
+            chromosome.sequences(),
             chromosome.promoters,
             monomer_limits,
             self.elongation)

--- a/vivarium/processes/transcription.py
+++ b/vivarium/processes/transcription.py
@@ -4,7 +4,8 @@ import numpy as np
 from arrow import StochasticSystem
 
 from vivarium.actor.process import Process
-from vivarium.states.chromosome import Chromosome, Rnap, frequencies, test_chromosome_config
+from vivarium.states.chromosome import Chromosome, Rnap, frequencies, add_merge, test_chromosome_config
+from vivarium.utils.polymerize import Elongation
 
 def build_stoichiometry(promoter_count):
     '''
@@ -37,45 +38,6 @@ def choose_element(elements):
         choice = np.random.choice(len(elements), 1)
         return list(elements)[int(choice)]
 
-class Elongation(object):
-    def __init__(self, elongation=0, limits={}):
-        self.time = 0
-        self.monomers = ''
-        self.complete_transcripts = []
-        self.previous_elongations = int(elongation)
-        self.elongation = elongation
-        self.limits = limits
-
-    def elongate(self, chromosome, now, rate, limits):
-        '''
-        Track increments of time and accumulate partial elongations, emitting the full elongation
-        once a unit is attained.
-
-        Returns number of RNAP that terminated transcription this step.
-        '''
-
-        progress = rate * (now - self.time)
-        self.elongation += progress
-        elongations = int(self.elongation) - self.previous_elongations
-        self.time = now
-        terminated = 0
-
-        if elongations:
-            iterations, monomers, complete, limits = chromosome.next_polymerize(
-                elongations, limits)
-            self.monomers += monomers
-            self.complete_transcripts.extend(complete)
-            self.previous_elongations = int(self.elongation)
-            terminated += len(complete)
-
-            print('iterations: {}, monomers: {}, complete: {}'.format(
-                iterations, monomers, complete))
-            print('terminated: {}'.format(terminated))
-
-        return terminated, limits
-
-    def complete(self):
-        return len(self.complete_transcripts)
 
 class Transcription(Process):
     def __init__(self, initial_parameters={}):
@@ -215,7 +177,11 @@ class Transcription(Process):
 
         time = 0
         now = 0
-        elongation = Elongation(self.elongation, monomer_limits)
+        elongation = Elongation(
+            chromosome.sequence,
+            chromosome.promoters,
+            self.elongation,
+            monomer_limits)
 
         while time < timestep:
             print('time: {} --------------------------------------------------------'.format(time))
@@ -250,11 +216,11 @@ class Transcription(Process):
                 print('event {}: {}'.format(now, event))
 
                 # perform the elongation until the next event
-                terminations, monomer_limits = elongation.elongate(
-                    chromosome,
+                terminations, monomer_limits, chromosome.rnaps = elongation.elongate(
                     time + now,
                     self.elongation_rate,
-                    monomer_limits)
+                    monomer_limits,
+                    chromosome.rnaps)
                 unbound_rnaps += terminations
 
                 # RNAP has bound the promoter
@@ -297,15 +263,15 @@ class Transcription(Process):
 
             # now that all events have been accounted for, elongate
             # until the end of this interval.
-            terminations, monomer_limits = elongation.elongate(
-                chromosome,
+            terminations, monomer_limits, chromosome.rnaps = elongation.elongate(
                 time + interval,
                 self.elongation_rate,
-                monomer_limits)
+                monomer_limits,
+                chromosome.rnaps)
             unbound_rnaps += terminations
 
             print('bound rnaps: {}'.format(chromosome.rnaps))
-            print('complete_transcripts: {}'.format(elongation.complete_transcripts))
+            print('complete transcripts: {}'.format(elongation.complete_polymers))
             print('monomer limits: {}'.format(monomer_limits))
 
             time += interval
@@ -318,14 +284,12 @@ class Transcription(Process):
 
         molecules.update({
             key: count * -1
-            for key, count in frequencies(elongation.monomers).items()})
-
-        transcripts = frequencies(elongation.complete_transcripts)
+            for key, count in elongation.monomers.items()})
 
         update = {
             'chromosome': chromosome.to_dict(),
             'molecules': molecules,
-            'transcripts': transcripts}
+            'transcripts': elongation.complete_polymers}
 
         print('molecules update: {}'.format(molecules))
 

--- a/vivarium/processes/transcription.py
+++ b/vivarium/processes/transcription.py
@@ -165,6 +165,8 @@ class Transcription(Process):
                 'promoters': 'set',
                 'domains': 'set',
                 'root_domain': 'set',
+                'promoter_order': 'set',
+                'rnap_id': 'set',
                 'rnaps': 'set'},
             'molecules': {},
             'transcripts': {}}

--- a/vivarium/processes/transcription.py
+++ b/vivarium/processes/transcription.py
@@ -112,9 +112,6 @@ class Transcription(Process):
         self.promoter_affinities = parameters['promoter_affinities']
         self.promoter_order = parameters['promoter_order']
         self.promoter_count = len(self.promoter_order)
-        self.affinity_vector = np.array([
-            self.promoter_affinities[promoter_key]
-            for promoter_key in self.promoter_order], dtype=np.float64)
 
         self.molecule_ids = parameters['molecule_ids']
         self.monomer_ids = parameters['monomer_ids']
@@ -122,6 +119,10 @@ class Transcription(Process):
         self.elongation = 0
         self.elongation_rate = parameters['elongation_rate']
         self.advancement_rate = parameters['advancement_rate']
+
+        self.affinity_vector = np.array([
+            self.promoter_affinities[promoter_key]
+            for promoter_key in self.promoter_order], dtype=np.float64)
 
         self.stoichiometry = build_stoichiometry(self.promoter_count)
         self.rates = build_rates(

--- a/vivarium/processes/transcription.py
+++ b/vivarium/processes/transcription.py
@@ -5,39 +5,12 @@ from arrow import StochasticSystem
 
 from vivarium.actor.process import Process
 from vivarium.states.chromosome import Chromosome, Rnap, frequencies, add_merge, test_chromosome_config
-from vivarium.utils.polymerize import Elongation
-
-def build_stoichiometry(promoter_count):
-    '''
-    Builds a stoichiometry for the given promoters. There are two states per promoter,
-    open and bound, and two reactions per promoter, binding and unbinding. In addition
-    there is a single substrate for available RNAP in the final index.
-
-    Here we are assuming
-    '''
-    stoichiometry = np.zeros((promoter_count * 2, promoter_count * 2 + 1), dtype=np.int64)
-    for index in range(promoter_count):
-        # forward reaction
-        stoichiometry[index][index] = -1
-        stoichiometry[index][index + promoter_count] = 1
-        stoichiometry[index][-1] = -1 # forward reaction consumes RNAP also
-
-        # reverse reaction
-        stoichiometry[index + promoter_count][index] = 1
-        stoichiometry[index + promoter_count][index + promoter_count] = -1
-
-    return stoichiometry
-
-def build_rates(affinities, advancement):
-    return np.concatenate([
-        affinities,
-        np.repeat(advancement, len(affinities))])
+from vivarium.utils.polymerize import Elongation, build_stoichiometry, build_rates
 
 def choose_element(elements):
     if elements:
         choice = np.random.choice(len(elements), 1)
         return list(elements)[int(choice)]
-
 
 class Transcription(Process):
     def __init__(self, initial_parameters={}):

--- a/vivarium/processes/translation.py
+++ b/vivarium/processes/translation.py
@@ -1,11 +1,19 @@
 import copy
 
 from vivarium.actor.process import Process
-from vivarium.data.chromosome import amino_acid_records
+from vivarium.data.amino_acids import amino_acid_records
+from vivarium.utils.datum import Datum
+from vivarium.utils.polymerize import Polymerase, Template
+
+class Ribosome(Polymerase):
+    pass
+
+class Transcript(Template):
+    pass
 
 class Translation(Process):
     def __init__(self, initial_parameters={}):
-        monomer_ids = [record.symbol for record in amino_acid_records]
+        self.monomer_ids = [record['symbol'] for record in amino_acid_records]
         self.default_parameters = {
             'transcript_affinities': {
                 'oA': 1.0,
@@ -14,7 +22,7 @@ class Translation(Process):
                 'oBY': 1.0},
             'elongation_rate': 1.0,
             'advancement_rate': 1.0,
-            'monomer_ids': monomer_ids}
+            'monomer_ids': self.monomer_ids}
         self.default_parameters['transcript_order'] = list(
             self.default_parameters['transcript_affinities'].keys())
 
@@ -25,9 +33,255 @@ class Translation(Process):
         self.transcript_order = parameters['transcript_order']
         self.transcript_count = len(self.transcript_order)
 
+        self.unbound_ribosomes_key = 'unbound_ribosomes'
         self.molecule_ids = parameters['molecule_ids']
         self.monomer_ids = parameters['monomer_ids']
         self.transcript_ids = parameters['transcript_ids']
         self.elongation = 0
         self.elongation_rate = parameters['elongation_rate']
         self.advancement_rate = parameters['advancement_rate']
+
+        self.affinity_vector = np.array([
+            self.promoter_affinities[promoter_key]
+            for promoter_key in self.promoter_order], dtype=np.float64)
+
+        self.stoichiometry = build_stoichiometry(self.transcript_count)
+        self.rates = build_rates(
+            self.affinity_vector,
+            self.advancement_rate)
+
+        print('stoichiometry: {}'.format(self.stoichiometry))
+        print('rates: {}'.format(self.rates))
+        self.initiation = StochasticSystem(self.stoichiometry, self.rates)
+
+        self.ribosome_id = 0
+
+        self.roles = {
+            'ribosomes': ['ribosomes'],
+            'molecules': self.molecule_ids,
+            'transcripts': self.transcript_ids}
+
+        super(Transcription, self).__init__(self.roles, parameters)
+
+    def default_settings(self):
+        default_state = {
+            'ribosomes': {
+                'ribosomes': []},
+            'molecules': dict({
+                self.unbound_ribosomes_key: 10}),
+            'transcripts': {
+                'oA': 10,
+                'oAZ': 15,
+                'oB': 25,
+                'oBY': 40}}
+
+        default_state['molecules'].update({
+            monomer_id: 100
+            for monomer_id in self.monomer_ids})
+        chromosome = Chromosome(default_state['chromosome'])
+        operons = [operon.id for operon in chromosome.operons()]
+
+        default_emitter_keys = {
+            'ribosomes': ['ribosomes'],
+            'molecules': self.monomer_ids + [self.unbound_ribosomes_key],
+            'transcripts': operons}
+
+        default_updaters = {
+            'ribosomes': {},
+            'molecules': {},
+            'transcripts': {}}
+
+        return {
+            'state': default_state,
+            'emitter_keys': default_emitter_keys,
+            'updaters': default_updaters,
+            'parameters': self.default_parameters}
+
+    def next_update(self, timestep, states):
+        ribosomes = states['ribosomes']
+        molecules = states['molecules']
+        transcripts = states['transcripts']
+        transcript_counts = np.array([
+            transcripts.get(transcript_key, 0)
+            for transcript_key in self.transcript_order])
+
+        # Find out how many transcripts are currently blocked by a
+        # newly initiated ribosome
+        bound_transcripts = np.zeros(len(transcript_order))
+        ribosomes_by_transcript = {}
+        for ribosome in ribosomes:
+            if not ribosome.template in ribosomes_by_transcript:
+                ribosomes_by_transcript[ribosome.template] = []
+            ribosomes_by_transcript[ribosome.template].append(ribosome)
+        for index, transcript in enumerate(self.transcript_order):
+            if transcript in ribosomes_by_transcript:
+                bound_transcripts[index] = len(ribosomes_by_transcript[transcript])
+
+        # for promoter_key in chromosome.promoter_order:
+        #     bound_domains[promoter_key] = set([
+        #         rnap.domain
+        #         for rnap in promoter_rnaps.get(promoter_key, {}).values()
+        #         if rnap.is_bound()])
+        #     bound_rnap.append(len(bound_domains[promoter_key]))
+        #     open_domains[promoter_key] = promoter_domains[promoter_key] - bound_domains[promoter_key]
+
+        # bound_rnap = np.array(bound_rnap)
+
+        # Make the state for a gillespie simulation out of total number of each
+        # promoter by copy number not blocked by initiated rnap,
+        # concatenated with the number of each promoter that is bound by rnap.
+        # These are the two states for each promoter the simulation
+        # will operate on, essentially going back and forth between
+        # bound and unbound states.
+
+        original_unbound_ribosomes = states['molecules']['unbound_ribosomes']
+        monomer_limits = {
+            monomer: states['molecules'][monomer]
+            for monomer in self.monomer_ids}
+        unbound_ribosomes = original_unbound_ribosomes
+
+        time = 0
+        now = 0
+        elongation = Elongation(
+            sequences,
+            templates,
+            monomer_limits,
+            self.elongation)
+
+        while time < timestep:
+            print('time: {} -----------======--------------------------'.format(time))
+
+            # build the state vector for the gillespie simulation
+            substrate = np.concatenate([
+                transcript_counts - bound_transcripts,
+                bound_transcripts,
+                [unbound_ribosomes]])
+
+            print('state: {}'.format(substrate))
+            print('unbound rnaps: {}'.format(unbound_rnaps))
+
+            # find number of monomers until next terminator
+            # distance = chromosome.terminator_distance()
+            distance = 1
+
+            print('distance: {}'.format(distance))
+
+            # find interval of time that elongates to the point of the next terminator
+            interval = distance / self.elongation_rate
+
+            print('interval: {}'.format(interval))
+            print('substrates: {}'.format(substrate))
+
+            # run simulation for interval of time to next terminator
+            result = self.initiation.evolve(interval, substrate)
+
+            # go through each event in the simulation and update the state
+            ribosome_bindings = 0
+            for now, event in zip(result['time'], result['events']):
+
+                print('event {}: {}'.format(now, event))
+
+                # perform the elongation until the next event
+                terminations, monomer_limits, ribosomes = elongation.elongate(
+                    time + now,
+                    self.elongation_rate,
+                    monomer_limits,
+                    ribosomes)
+                unbound_ribosomes += terminations
+
+                # RNAP has bound the promoter
+                if event < self.transcript_count:
+                    transcript_key = self.transcript_order[event]
+                    transcript = self.templates[transcript_key]
+                    bound_ribosomes[event] += 1
+
+                    self.ribosome_id += 1
+                    new_ribosome = Ribosome({
+                        'id': self.ribosome_id,
+                        'template': promoter_key,
+                        'position': 0})
+                    new_ribosome.bind()
+                    ribosomes_by_transcript[transcript_key] = new_ribosome
+
+                    print('{}: ribosome binding {}'.format(time, new_ribosome))
+
+                    ribosome_bindings += 1
+                    unbound_ribosomes -= 1
+                # RNAP has begun polymerizing its transcript
+                else:
+                    transcript_index = event - self.transcript_count
+                    transcript_key = self.transcript_order[transcript_index]
+
+                    bound_ribosomes[transcript_index] -= 1
+
+                    # # find rnap on this domain
+                    ribosome = ribosomes_by_transcript[transcript_key].pop()
+                    ribosome.start_transcribing()
+
+                    print('{}: ribosome commencing {}'.format(time, ribosome))
+
+            # now that all events have been accounted for, elongate
+            # until the end of this interval.
+            terminations, monomer_limits, ribosomes = elongation.elongate(
+                time + interval,
+                self.elongation_rate,
+                monomer_limits,
+                ribosomes)
+            unbound_ribosomes += terminations
+
+            print('bound ribosomes: {}'.format(ribosomes))
+            print('complete transcripts: {}'.format(elongation.complete_polymers))
+            print('monomer limits: {}'.format(monomer_limits))
+
+            time += interval
+
+        # track how far elongation proceeded to start from next iteration
+        self.elongation = elongation.elongation - int(elongation.elongation)
+
+        molecules = {
+            'unbound_ribosomes': unbound_ribosomes - original_unbound_ribosomes}
+
+        molecules.update({
+            key: count * -1
+            for key, count in elongation.monomers.items()})
+
+        update = {
+            'ribosomes': {
+                'ribosomes': [ribosome.to_dict() for ribosome in ribosomes]},
+            'molecules': molecules,
+            'transcripts': elongation.complete_polymers}
+
+        print('molecules update: {}'.format(molecules))
+
+        return update
+
+
+def test_translation():
+    parameters = {
+        'transcript_affinities': {
+                'oA': 1.0,
+                'oAZ': 1.0,
+                'oB': 1.0,
+                'oBY': 1.0},
+        'elongation_rate': 10.0,
+        'advancement_rate': 10.0}
+
+    translation = Translation(parameters)
+
+    states = {
+        'ribosomes': [],
+        'molecules': {translation.unbound_ribosomes_key: 10}}
+    states['molecules'].update({
+        molecule_id: 100
+        for molecule_id in translation.molecule_ids})
+
+    update = transcription.next_update(1.0, states)
+    
+    print(update)
+    print('complete!')
+
+
+
+if __name__ == '__main__':
+    test_translation()
+        

--- a/vivarium/processes/translation.py
+++ b/vivarium/processes/translation.py
@@ -1,0 +1,15 @@
+from vivarium.actor.process import Process
+from vivarium.data.chromosome import amino_acids
+
+class Translation(Process):
+    def __init__(self, initial_parameters={}):
+        monomer_ids = list(amino_acids.keys())
+        self.default_parameters = {
+            'transcript_affinities': {
+                'oA': 1.0,
+                'oAZ': 1.0,
+                'oB': 1.0,
+                'oBY': 1.0},
+            'elongation_rate': 1.0,
+            'advancement_rate': 1.0,
+            'monomer_ids': monomer_ids}

--- a/vivarium/processes/translation.py
+++ b/vivarium/processes/translation.py
@@ -1,9 +1,11 @@
+import copy
+
 from vivarium.actor.process import Process
-from vivarium.data.chromosome import amino_acids
+from vivarium.data.chromosome import amino_acid_records
 
 class Translation(Process):
     def __init__(self, initial_parameters={}):
-        monomer_ids = list(amino_acids.keys())
+        monomer_ids = [record.symbol for record in amino_acid_records]
         self.default_parameters = {
             'transcript_affinities': {
                 'oA': 1.0,
@@ -13,3 +15,19 @@ class Translation(Process):
             'elongation_rate': 1.0,
             'advancement_rate': 1.0,
             'monomer_ids': monomer_ids}
+        self.default_parameters['transcript_order'] = list(
+            self.default_parameters['transcript_affinities'].keys())
+
+        parameters = copy.deepcopy(self.default_parameters)
+        parameters.update(initial_parameters)
+
+        self.transcript_affinities = parameters['transcript_affinities']
+        self.transcript_order = parameters['transcript_order']
+        self.transcript_count = len(self.transcript_order)
+
+        self.molecule_ids = parameters['molecule_ids']
+        self.monomer_ids = parameters['monomer_ids']
+        self.transcript_ids = parameters['transcript_ids']
+        self.elongation = 0
+        self.elongation_rate = parameters['elongation_rate']
+        self.advancement_rate = parameters['advancement_rate']

--- a/vivarium/states/chromosome.py
+++ b/vivarium/states/chromosome.py
@@ -115,7 +115,7 @@ class Promoter(Template):
 class Rnap(Polymerase):
     defaults = {
         'id': 0,
-        'template': '',
+        'template': None,
         'terminator': 0,
         'domain': 0,
         'state': None, # other states: ['bound', 'transcribing', 'complete']
@@ -222,12 +222,19 @@ class Chromosome(Datum):
         else:
             return self.sequence[end:begin]
 
+    def sequences(self):
+        return {
+            self.promoters[promoter].id: self.sequence
+            for promoter in self.promoters.keys()}
+
     def next_polymerize(self, elongation_limit=INFINITY, monomer_limits={}):
         distance = self.terminator_distance()
         elongate_to = min(elongation_limit, distance)
 
+        sequences = self.sequences()
+
         monomers, monomer_limits, complete_transcripts, self.rnaps = polymerize_to(
-            self.sequence,
+            sequences,
             self.rnaps,
             self.promoters,
             elongate_to,

--- a/vivarium/states/chromosome.py
+++ b/vivarium/states/chromosome.py
@@ -296,8 +296,10 @@ class Chromosome(Datum):
         'sequence': '',
         'genes': {},
         'promoters': {},
+        'promoter_order': [],
         'domains': {},
         'root_domain': 0,
+        'rnap_id': 0,
         'rnaps': []}
 
     def operons(self):

--- a/vivarium/states/chromosome.py
+++ b/vivarium/states/chromosome.py
@@ -504,8 +504,8 @@ class Chromosome(Datum):
 
     def __init__(self, config):
         super(Chromosome, self).__init__(config, self.defaults)
-        self.promoter_order = list(self.promoters.keys())
-        self.rnap_id = 0
+        if not self.promoter_order:
+            self.promoter_order = list(self.promoters.keys())
 
 
 

--- a/vivarium/states/chromosome.py
+++ b/vivarium/states/chromosome.py
@@ -3,16 +3,9 @@ import copy
 import numpy as np
 
 from vivarium.data.chromosome import test_chromosome_config
+from vivarium.utils.datum import Datum
 
 INFINITY = float('inf')
-
-def first(l):
-    if l:
-        return l[0]
-
-def first_value(d):
-    if d:
-        return d[list(d.keys())[0]]
 
 def flatten(l):
     '''
@@ -52,56 +45,6 @@ def traverse(tree, key, f, combine):
     else:
         return f(node)
 
-
-class Datum(object):
-    '''
-    The Datum class enables functions to be defined on dicts of a certain schema. 
-    It provides two class level variables:
-      * `defaults`: a dictionary of keys to default values this Datum will have if 
-           none is provided to __init__
-      * `schema`: a dictionary of keys to constructors which invoke subdata. 
-
-    Once these are defined, a Datum subclass can be constructed with a dict that provides any
-    values beyond the defaults, and then all of the defined methods for that Datum subclass
-    are available to operate on its values. Once the modifications are complete, it can be
-    rendered back into a dict using the `to_dict()` method.
-    '''
-
-    schema = {}
-    defaults = {}
-
-    def __init__(self, config, default):
-        self.keys = list(set(list(config.keys()) + list(default.keys()))) # a dance
-        for key in self.keys:
-            value = config.get(key, default[key])
-            if value and key in self.schema:
-                realize = self.schema[key]
-                if isinstance(value, list):
-                    value = [realize(item) for item in value]
-                elif isinstance(value, dict):
-                    value = {inner: realize(item) for inner, item in value.items()}
-                else:
-                    value = realize(item)
-            setattr(self, key, value)
-
-    def fields(self):
-        return list(self.defaults.keys())
-
-    def to_dict(self):
-        to = {}
-        for key in self.keys:
-            value = getattr(self, key)
-            if isinstance(value, Datum):
-                value = value.to_dict()
-            elif value and isinstance(value, list) and isinstance(first(value), Datum):
-                value = [datum.to_dict() for datum in value]
-            elif value and isinstance(value, dict) and isinstance(first_value(value), Datum):
-                value = {inner: datum.to_dict() for inner, datum in value.items()}
-            to[key] = value
-        return to
-
-    def __repr__(self):
-        return str(self.to_dict())
 
 class Operon(Datum):
     defaults = {

--- a/vivarium/states/chromosome.py
+++ b/vivarium/states/chromosome.py
@@ -8,17 +8,6 @@ from vivarium.utils.polymerize import Polymerase, BindingSite, Terminator, Templ
 
 INFINITY = float('inf')
 
-def flatten(l):
-    '''
-    Flatten a list by one level:
-        [[1, 2, 3], [[4, 5], 6], [7]] --> [1, 2, 3, [4, 5], 6, 7]
-    '''
-
-    return [
-        item
-        for sublist in l
-        for item in sublist]
-
 def frequencies(l):
     '''
     Return number of times each item appears in the list.
@@ -89,11 +78,11 @@ class Domain(Datum):
 class RnapTerminator(Terminator):
     def operon_from(self, genes, promoter):
         return Operon({
-            'id': self.product,
+            'id': self.product[0], # assume there is only one operon product
             'position': promoter.position,
             'direction': promoter.direction,
             'length': (self.position - promoter.position) * promoter.direction,
-            'genes': genes.get(self.product, [])})
+            'genes': genes.get(self.product[0], [])})
 
 class Promoter(Template):
     '''

--- a/vivarium/utils/datum.py
+++ b/vivarium/utils/datum.py
@@ -1,0 +1,58 @@
+def first(l):
+    if l:
+        return l[0]
+
+def first_value(d):
+    if d:
+        return d[list(d.keys())[0]]
+
+class Datum(object):
+    '''
+    The Datum class enables functions to be defined on dicts of a certain schema. 
+    It provides two class level variables:
+      * `defaults`: a dictionary of keys to default values this Datum will have if 
+           none is provided to __init__
+      * `schema`: a dictionary of keys to constructors which invoke subdata. 
+
+    Once these are defined, a Datum subclass can be constructed with a dict that provides any
+    values beyond the defaults, and then all of the defined methods for that Datum subclass
+    are available to operate on its values. Once the modifications are complete, it can be
+    rendered back into a dict using the `to_dict()` method.
+    '''
+
+    schema = {}
+    defaults = {}
+
+    def __init__(self, config, default):
+        self.keys = list(set(list(config.keys()) + list(default.keys()))) # a dance
+        for key in self.keys:
+            value = config.get(key, default[key])
+            if value and key in self.schema:
+                realize = self.schema[key]
+                if isinstance(value, list):
+                    value = [realize(item) for item in value]
+                elif isinstance(value, dict):
+                    value = {inner: realize(item) for inner, item in value.items()}
+                else:
+                    value = realize(item)
+            setattr(self, key, value)
+
+    def fields(self):
+        return list(self.defaults.keys())
+
+    def to_dict(self):
+        to = {}
+        for key in self.keys:
+            value = getattr(self, key)
+            if isinstance(value, Datum):
+                value = value.to_dict()
+            elif value and isinstance(value, list) and isinstance(first(value), Datum):
+                value = [datum.to_dict() for datum in value]
+            elif value and isinstance(value, dict) and isinstance(first_value(value), Datum):
+                value = {inner: datum.to_dict() for inner, datum in value.items()}
+            to[key] = value
+        return to
+
+    def __repr__(self):
+        return str(self.to_dict())
+

--- a/vivarium/utils/polymerize.py
+++ b/vivarium/utils/polymerize.py
@@ -22,7 +22,7 @@ class Polymerase(Datum):
         'id': 0,
         'state': None, # other states: ['bound', 'transcribing', 'complete']
         'position': 0,
-        'template': '',
+        'template': None,
         'terminator': 0}
 
     def __init__(self, config, defaults=defaults):
@@ -86,7 +86,7 @@ class Template(Datum):
         'terminators': Terminator}
 
     defaults = {
-        'id': 0,
+        'id': None,
         'position': 0,
         'direction': 1,
         'sites': [],
@@ -148,7 +148,7 @@ class Template(Datum):
 
 
 def polymerize_to(
-        sequence,
+        sequences,
         polymerases,
         templates,
         additions,
@@ -166,7 +166,7 @@ def polymerize_to(
                 extent = template.direction
                 projection = polymerase.position + extent
 
-                monomer = sequence[projection]
+                monomer = sequences[template.id][projection]
                 if monomer_limits[monomer] > 0:
                     monomer_limits[monomer] -= 1
                     monomers[monomer] += 1
@@ -190,7 +190,7 @@ def polymerize_to(
 
 
 class Elongation(object):
-    def __init__(self, sequence, templates, elongation=0, limits={}):
+    def __init__(self, sequence, templates, limits, elongation=0):
         self.sequence = sequence
         self.templates = templates
         self.time = 0

--- a/vivarium/utils/polymerize.py
+++ b/vivarium/utils/polymerize.py
@@ -1,5 +1,7 @@
 import random
 
+import numpy as np
+
 from vivarium.utils.datum import Datum
 
 INFINITY = float('inf')
@@ -232,4 +234,31 @@ class Elongation(object):
 
     def complete(self):
         return len(self.complete_polymers)
+
+
+def build_stoichiometry(promoter_count):
+    '''
+    Builds a stoichiometry for the given promoters. There are two states per promoter,
+    open and bound, and two reactions per promoter, binding and unbinding. In addition
+    there is a single substrate for available RNAP in the final index.
+
+    Here we are assuming
+    '''
+    stoichiometry = np.zeros((promoter_count * 2, promoter_count * 2 + 1), dtype=np.int64)
+    for index in range(promoter_count):
+        # forward reaction
+        stoichiometry[index][index] = -1
+        stoichiometry[index][index + promoter_count] = 1
+        stoichiometry[index][-1] = -1 # forward reaction consumes RNAP also
+
+        # reverse reaction
+        stoichiometry[index + promoter_count][index] = 1
+        stoichiometry[index + promoter_count][index + promoter_count] = -1
+
+    return stoichiometry
+
+def build_rates(affinities, advancement):
+    return np.concatenate([
+        affinities,
+        np.repeat(advancement, len(affinities))])
 

--- a/vivarium/utils/polymerize.py
+++ b/vivarium/utils/polymerize.py
@@ -1,0 +1,73 @@
+from vivarium.utils.datum import Datum
+
+class Polymerize(object):
+    def __init__(self, elongation=0, limits={}):
+        self.time = 0
+        self.monomers = ''
+        self.complete_polymers = []
+        self.previous_elongations = int(elongation)
+        self.elongation = elongation
+        self.limits = limits
+
+    def elongate(self, now, rate, limits):
+        '''
+        Track increments of time and accumulate partial elongations, emitting the full elongation
+        once a unit is attained.
+
+        Returns number of polymerases that terminated this step.
+        '''
+
+        progress = rate * (now - self.time)
+        self.elongation += progress
+        elongations = int(self.elongation) - self.previous_elongations
+        self.time = now
+        terminated = 0
+
+        if elongations:
+            iterations, monomers, complete, limits = self.next_polymerize(
+                elongations, limits)
+            self.monomers += monomers
+            self.complete_polymers.extend(complete)
+            self.previous_elongations = int(self.elongation)
+            terminated += len(complete)
+
+            print('iterations: {}, monomers: {}, complete: {}'.format(
+                iterations, monomers, complete))
+            print('terminated: {}'.format(terminated))
+
+        return terminated, limits
+
+    def next_polymerize(self, polymerases, elongation_limit=INFINITY, monomer_limits={}):
+        elongate_to = min(elongation_limit, distance)
+        complete_polymers = []
+        monomers = ''
+
+        for step in range(elongate_to):
+            for polymerase in polymerases:
+                if polymerase.is_transcribing():
+                    promoter = self.promoters[polymerase.promoter]
+                    extent = promoter.direction
+                    projection = polymerase.position + extent
+
+                    monomer = self.sequence[projection]
+                    if monomer_limits[monomer] > 0:
+                        monomer_limits[monomer] -= 1
+                        monomers += monomer
+                        polymerase.position = projection
+
+                        terminator = promoter.terminators[polymerase.terminator]
+                        if terminator.position == polymerase.position:
+                            if promoter.terminates_at(polymerase.terminator):
+                                polymerase.complete()
+                                complete_transcripts.append(terminator.operon)
+
+        polymerases = [
+            polymerase
+            for polymerase in self.polymerases
+            if not polymerase.is_complete()]
+
+        return elongate_to, monomers, complete_transcripts, monomer_limits, polymerases
+
+    def complete(self):
+        return len(self.complete_polymers)
+

--- a/vivarium/utils/polymerize.py
+++ b/vivarium/utils/polymerize.py
@@ -1,20 +1,212 @@
+import random
+
 from vivarium.utils.datum import Datum
 
-class Polymerize(object):
-    def __init__(self, elongation=0, limits={}):
+INFINITY = float('inf')
+
+def add_merge(ds):
+    '''
+    Given a list of dicts, sum the values of each key.
+    '''
+
+    result = {}
+    for d in ds:
+        for key, value in d.items():
+            if not key in result:
+                result[key] = 0
+            result[key] += value
+    return result
+
+class Polymerase(Datum):
+    defaults = {
+        'id': 0,
+        'state': None, # other states: ['bound', 'transcribing', 'complete']
+        'position': 0,
+        'template': '',
+        'terminator': 0}
+
+    def __init__(self, config, defaults=defaults):
+        super(Polymerase, self).__init__(config, self.defaults)
+
+    def bind(self):
+        self.state = 'bound'
+
+    def start_transcribing(self):
+        self.state = 'transcribing'
+
+    def complete(self):
+        self.state = 'complete'
+        print('completing polymerization: {}'.format(self.to_dict()))
+
+    def is_bound(self):
+        return self.state == 'bound'
+
+    def is_transcribing(self):
+        return self.state == 'transcribing'
+
+    def is_complete(self):
+        return self.state == 'complete'
+
+class BindingSite(Datum):
+    defaults = {
+        'position': 0,
+        'length': 0,
+        'thresholds': []} # list of pairs, (factor, threshold)
+
+    def __init__(self, config):
+        super(BindingSite, self).__init__(config, self.defaults)
+
+    def state_when(self, levels):
+        '''
+        Provide the binding state for the given levels of factors. 
+        '''
+
+        state = None
+        for factor, threshold in thresholds:
+            if levels[factor] >= threshold:
+                state = factor
+                break
+        return state
+
+class Terminator(Datum):
+    defaults = {
+        'position': 0,
+        'strength': 0,
+        'product': ''}
+
+    def __init__(self, config, defaults=defaults):
+        super(Terminator, self).__init__(config, self.defaults)
+
+    def between(self, before, after):
+        return before < self.position < after or after < self.position < before
+
+class Template(Datum):
+    schema = {
+        'sites': BindingSite,
+        'terminators': Terminator}
+
+    defaults = {
+        'id': 0,
+        'position': 0,
+        'direction': 1,
+        'sites': [],
+        'terminators': []}
+
+    def __init__(self, config, defaults=defaults):
+        super(Template, self).__init__(config, self.defaults)
+
+        self.terminator_strength = 0
+        for terminator in self.terminators:
+            self.terminator_strength += terminator.strength
+
+    def binding_state(self, levels):
+        state = [
+            site.state_when(levels)
+            for site in self.sites]
+
+        return tuple([self.id] + state)
+
+    def strength_from(self, terminator_index):
+        total = 0
+        for index in range(terminator_index, len(self.terminators)):
+            total += self.terminators[index].strength
+        return total
+
+    def next_terminator(self, position):
+        for index, terminator in enumerate(self.terminators):
+            if terminator.position * self.direction > position * self.direction:
+                break
+        return index
+
+    def terminates_at(self, index=0):
+        if len(self.terminators[index:]) > 1:
+            choice = random.random() * self.strength_from(index)
+            return choice <= self.terminators[index].strength
+        else:
+            return True
+
+    def choose_terminator(self, index=0):
+        if len(self.terminators[index:]) > 1:
+            choice = random.random() * self.strength_from(index)
+            for terminator in self.terminators[index:]:
+                if choice <= terminator.strength:
+                    break
+                else:
+                    choice -= terminator.strength
+            return terminator
+        else:
+            return self.terminators[index]
+
+    def choose_product(self):
+        terminator = self.choose_terminator()
+        return terminator.product
+
+    def products(self):
+        return [
+            terminator.product
+            for terminator in self.terminators]
+
+
+def polymerize_to(
+        sequence,
+        polymerases,
+        templates,
+        additions,
+        monomer_limits={}):
+
+    complete_polymers = {}
+    monomers = {
+        monomer: 0
+        for monomer in monomer_limits.keys()}
+
+    for step in range(additions):
+        for polymerase in polymerases:
+            if polymerase.is_transcribing():
+                template = templates[polymerase.template]
+                extent = template.direction
+                projection = polymerase.position + extent
+
+                monomer = sequence[projection]
+                if monomer_limits[monomer] > 0:
+                    monomer_limits[monomer] -= 1
+                    monomers[monomer] += 1
+                    polymerase.position = projection
+
+                    terminator = template.terminators[polymerase.terminator]
+                    if terminator.position == polymerase.position:
+                        if template.terminates_at(polymerase.terminator):
+                            polymerase.complete()
+
+                            if not terminator.product in complete_polymers:
+                                complete_polymers[terminator.product] = 0
+                            complete_polymers[terminator.product] += 1
+
+    polymerases = [
+        polymerase
+        for polymerase in polymerases
+        if not polymerase.is_complete()]
+
+    return monomers, monomer_limits, complete_polymers, polymerases
+
+
+class Elongation(object):
+    def __init__(self, sequence, templates, elongation=0, limits={}):
+        self.sequence = sequence
+        self.templates = templates
         self.time = 0
-        self.monomers = ''
-        self.complete_polymers = []
+        self.monomers = {}
+        self.complete_polymers = {}
         self.previous_elongations = int(elongation)
         self.elongation = elongation
         self.limits = limits
 
-    def elongate(self, now, rate, limits):
+    def elongate(self, now, rate, limits, polymerases):
         '''
-        Track increments of time and accumulate partial elongations, emitting the full elongation
-        once a unit is attained.
+        Track increments of time and accumulate partial elongations, emitting the full
+        elongation once a unit is attained.
 
-        Returns number of polymerases that terminated this step.
+        Returns number of polymerases that terminated this step, and the updated 
+        monomer limits after all elongations.
         '''
 
         progress = rate * (now - self.time)
@@ -24,49 +216,19 @@ class Polymerize(object):
         terminated = 0
 
         if elongations:
-            iterations, monomers, complete, limits = self.next_polymerize(
-                elongations, limits)
-            self.monomers += monomers
-            self.complete_polymers.extend(complete)
+            monomers, limits, complete, polymerases = polymerize_to(
+                self.sequence,
+                polymerases,
+                self.templates,
+                elongations,
+                limits)
+            self.monomers = add_merge([self.monomers, monomers])
+            self.complete_polymers = add_merge([
+                self.complete_polymers, complete])
             self.previous_elongations = int(self.elongation)
             terminated += len(complete)
 
-            print('iterations: {}, monomers: {}, complete: {}'.format(
-                iterations, monomers, complete))
-            print('terminated: {}'.format(terminated))
-
-        return terminated, limits
-
-    def next_polymerize(self, polymerases, elongation_limit=INFINITY, monomer_limits={}):
-        elongate_to = min(elongation_limit, distance)
-        complete_polymers = []
-        monomers = ''
-
-        for step in range(elongate_to):
-            for polymerase in polymerases:
-                if polymerase.is_transcribing():
-                    promoter = self.promoters[polymerase.promoter]
-                    extent = promoter.direction
-                    projection = polymerase.position + extent
-
-                    monomer = self.sequence[projection]
-                    if monomer_limits[monomer] > 0:
-                        monomer_limits[monomer] -= 1
-                        monomers += monomer
-                        polymerase.position = projection
-
-                        terminator = promoter.terminators[polymerase.terminator]
-                        if terminator.position == polymerase.position:
-                            if promoter.terminates_at(polymerase.terminator):
-                                polymerase.complete()
-                                complete_transcripts.append(terminator.operon)
-
-        polymerases = [
-            polymerase
-            for polymerase in self.polymerases
-            if not polymerase.is_complete()]
-
-        return elongate_to, monomers, complete_transcripts, monomer_limits, polymerases
+        return terminated, limits, polymerases
 
     def complete(self):
         return len(self.complete_polymers)

--- a/vivarium/utils/polymerize.py
+++ b/vivarium/utils/polymerize.py
@@ -164,7 +164,6 @@ def all_products(templates):
         product
         for template in templates.values()
         for product in template.products()])))
-    
 
 def polymerize_to(
         sequences,
@@ -179,6 +178,7 @@ def polymerize_to(
     monomers = {
         monomer: 0
         for monomer in monomer_limits.keys()}
+    terminated = 0
 
     for step in range(additions):
         for polymerase in polymerases:
@@ -198,6 +198,7 @@ def polymerize_to(
                     if terminator.position == polymerase.position:
                         if template.terminates_at(polymerase.terminator):
                             polymerase.complete()
+                            terminated += 1
 
                             products = terminator.product
                             if not isinstance(products, list):
@@ -211,7 +212,7 @@ def polymerize_to(
         for polymerase in polymerases
         if not polymerase.is_complete()]
 
-    return monomers, monomer_limits, complete_polymers, polymerases
+    return monomers, monomer_limits, terminated, complete_polymers, polymerases
 
 
 class Elongation(object):
@@ -241,7 +242,7 @@ class Elongation(object):
         terminated = 0
 
         if elongations:
-            monomers, limits, complete, polymerases = polymerize_to(
+            monomers, limits, terminated, complete, polymerases = polymerize_to(
                 self.sequence,
                 polymerases,
                 self.templates,
@@ -251,7 +252,6 @@ class Elongation(object):
             self.complete_polymers = add_merge([
                 self.complete_polymers, complete])
             self.previous_elongations = int(self.elongation)
-            terminated += len(complete)
 
         return terminated, limits, polymerases
 


### PR DESCRIPTION
This PR introduces a new composite for gene expression, composed of transcription and a new translation process. These processes are linked through a "transcripts" state, which is supplied by the transcription process and subsequently sampled by the translation process. Both processes are essentially the same, being stochastic simulations for binding of polymerases between elongation events. For this reason I abstracted out much of the polymerization code from transcription and the chromosome into the new `polymerize.py`. 

The expression composite behaves in a reasonable way, generating transcripts until nucleotides run out, while also generating proteins from those transcripts until amino acids run out. To run you can type: 

    > python vivarium/composites/gene_expression.py

A demonstration is below (the legend is a little out of control, forgive me):

![gene_expression](https://user-images.githubusercontent.com/9079/73434131-023d0780-42fb-11ea-839a-3f16326cf99a.png)