### PR TITLE
get_kafka_config()

### DIFF
--- a/vivarium/actor/control.py
+++ b/vivarium/actor/control.py
@@ -270,22 +270,22 @@ class AgentCommand(object):
             if args.get(name) is None:
                 raise ValueError('--{} needed'.format(name))
 
-    def kafka_config(self):
+    def get_kafka_config(self):
         return self.actor_config['kafka_config']
 
     def run(self, args):
-        control = ActorControl('control', {'kafka_config': self.kafka_config()})
+        control = ActorControl('control', {'kafka_config': self.get_kafka_config()})
         control.trigger_execution(args['id'])
         control.shutdown()
 
     def pause(self, args):
-        control = ActorControl('control', {'kafka_config': self.kafka_config()})
+        control = ActorControl('control', {'kafka_config': self.get_kafka_config()})
         control.pause_execution(args['id'])
         control.shutdown()
 
     def add(self, args):
         self.require(args, 'id', 'type')
-        control = ActorControl('control', {'kafka_config': self.kafka_config()})
+        control = ActorControl('control', {'kafka_config': self.get_kafka_config()})
         config = self.actor_config
         control.add_agent(
             str(uuid.uuid1()),
@@ -294,7 +294,7 @@ class AgentCommand(object):
         control.shutdown()
 
     def remove(self, args):
-        control = ActorControl('control', {'kafka_config': self.kafka_config()})
+        control = ActorControl('control', {'kafka_config': self.get_kafka_config()})
         if args['id']:
             control.remove_agent({'agent_id': args['id']})
         elif args['prefix']:
@@ -305,18 +305,18 @@ class AgentCommand(object):
 
     def divide(self, args):
         self.require(args, 'id')
-        control = ActorControl('control', {'kafka_config': self.kafka_config()})
+        control = ActorControl('control', {'kafka_config': self.get_kafka_config()})
         control.divide_cell(args['id'])
         control.shutdown()
 
     def experiment(self, args):
         self.require(args, 'number')
-        control = ActorControl('control', {'kafka_config': self.kafka_config()})
+        control = ActorControl('control', {'kafka_config': self.get_kafka_config()})
         control.stub_experiment(args['number'])
         control.shutdown()
 
     def shutdown(self, args):
-        control = ActorControl('control', {'kafka_config': self.kafka_config()})
+        control = ActorControl('control', {'kafka_config': self.get_kafka_config()})
         control.shutdown_agent(args['id'])
         control.shutdown()
 

--- a/vivarium/environment/control.py
+++ b/vivarium/environment/control.py
@@ -407,49 +407,49 @@ class EnvironmentCommand(AgentCommand):
 
     def experiment(self, args):
         self.require(args, 'number', 'working_dir')
-        control = ShepherdControl({'kafka_config': self.kafka_config()})
+        control = ShepherdControl({'kafka_config': self.get_kafka_config()})
         control.lattice_experiment(args, self.actor_config)
         control.shutdown()
 
     def long_experiment(self, args):
         self.require(args, 'number', 'working_dir')
-        control = ShepherdControl({'kafka_config': self.kafka_config()})
+        control = ShepherdControl({'kafka_config': self.get_kafka_config()})
         control.long_lattice_experiment(args, self.actor_config)
         control.shutdown()
 
     def large_experiment(self, args):
         self.require(args, 'number', 'working_dir')
-        control = ShepherdControl({'kafka_config': self.kafka_config()})
+        control = ShepherdControl({'kafka_config': self.get_kafka_config()})
         control.large_lattice_experiment(args, self.actor_config)
         control.shutdown()
 
     def small_experiment(self, args):
         self.require(args, 'number', 'working_dir')
-        control = ShepherdControl({'kafka_config': self.kafka_config()})
+        control = ShepherdControl({'kafka_config': self.get_kafka_config()})
         control.small_lattice_experiment(args, self.actor_config)
         control.shutdown()
 
     def glc_g6p_experiment(self, args):
         self.require(args, 'number')
-        control = ShepherdControl({'kafka_config': self.kafka_config()})
+        control = ShepherdControl({'kafka_config': self.get_kafka_config()})
         control.glc_g6p_experiment(args, self.actor_config)
         control.shutdown()
 
     def ecoli_core_experiment(self, args):
         self.require(args, 'number')
-        control = ShepherdControl({'kafka_config': self.kafka_config})
-        control.ecoli_core_experiment(args)
+        control = ShepherdControl({'kafka_config': self.get_kafka_config()})
+        control.ecoli_core_experiment(args, self.actor_config)
         control.shutdown()
 
     def chemotaxis_experiment(self, args):
         self.require(args, 'number')
-        control = ShepherdControl({'kafka_config': self.kafka_config()})
+        control = ShepherdControl({'kafka_config': self.get_kafka_config()})
         control.chemotaxis_experiment(args, self.actor_config)
         control.shutdown()
 
     def swarm_experiment(self, args):
         self.require(args, 'number')
-        control = ShepherdControl({'kafka_config': self.kafka_config()})
+        control = ShepherdControl({'kafka_config': self.get_kafka_config()})
         control.swarm_experiment(args, self.actor_config)
         control.shutdown()
 


### PR DESCRIPTION
when running experiments, ```actor/control``` was attempting to call the function ```kafka_config()``` instead of the dict ```kafka_config```. The function is now called ```get_kafka_config()```.