### PR TITLE
Create Function to Simulate Process in Environment

### DIFF
--- a/vivarium/actor/process.py
+++ b/vivarium/actor/process.py
@@ -563,6 +563,34 @@ def simulate_compartment(compartment, settings={}):
 
     return saved_state
 
+def simulate_process_with_environment(process, settings={}):
+    '''
+    Simulate running a process in an environment. In settings,
+    exchange_role and environment_role must be specified.
+    '''
+    process_settings = process.default_settings()
+    state_dict = process_settings['state']
+    states = initialize_state(
+        [{"process": process}],
+        {"process": {role: role for role in process.roles}},
+        state_dict,
+    )
+
+    # hook up the roles in each process to compartment states
+    topology = {
+        'process': {key: key for key in states},
+    }
+
+
+    options = {
+        'topology': topology,
+    }
+    processes = [{
+        'process': process,
+    }]
+    compartment = Compartment(processes, states, options)
+    return simulate_with_environment(compartment, settings)
+
 def simulate_with_environment(compartment, settings={}):
     '''
     run a compartment simulation with an environment.


### PR DESCRIPTION
The `simulate_process_with_environment` function creates a compartment
with the process and an environment. Then, it simulates running the
process by passing the compartment to `simulate_with_environment`.

This function can be used to replace redundant code across many
processes' test functions.