### PR TITLE
Tuple to string keys in actor

### DIFF
--- a/vivarium/actor/actor.py
+++ b/vivarium/actor/actor.py
@@ -7,6 +7,7 @@ import struct
 from confluent_kafka import Producer, Consumer, KafkaError
 
 import vivarium.actor.event as event
+from vivarium.utils.dict_utils import tuple_to_str_keys, str_to_tuple_keys
 
 # Chunk header: type and size.
 # TODO(jerry): Move CHUNK_HEADER to a shared module.
@@ -168,6 +169,8 @@ class Actor(object):
                 # suggests it needs a `payload` argument. Suppress the warning.
                 # noinspection PyArgumentList
                 message = self.decode_payload(raw.value())
+                str_to_tuple_keys(message)
+
                 if not message:
                     continue
 
@@ -196,7 +199,8 @@ class Actor(object):
         if print_send:
             self.print_message(topic, message, False)
 
-        payload = self.encode_payload(message)
+        str_message = tuple_to_str_keys(message)  # convert tuple keys to str keys
+        payload = self.encode_payload(str_message)
 
         self.producer.produce(
             topic,

--- a/vivarium/composites/glc_lct_shifter.py
+++ b/vivarium/composites/glc_lct_shifter.py
@@ -4,7 +4,6 @@ import os
 
 from vivarium.environment.make_media import Media
 from vivarium.utils.units import units
-from vivarium.utils.dict_utils import tuple_to_str_dict
 from vivarium.composites.master import compose_master
 
 
@@ -131,8 +130,6 @@ def compose_glc_lct_shifter(config):
         'metabolism': get_metabolism_config(),
         'expression': get_expression_config(),
         'deriver': get_expression_config()}
-
-    tuple_to_str_dict(shifter_config)
     config.update(shifter_config)
 
     return compose_master(config)

--- a/vivarium/composites/glc_lct_shifter.py
+++ b/vivarium/composites/glc_lct_shifter.py
@@ -78,12 +78,12 @@ def get_transport_config():
 
 def get_metabolism_config():
 
-    # regulation functions
-    def regulation(state):
-        regulation_logic = {
-            'EX_lac__D_e': bool(not state[('external', 'glc__D_e')] > 0.1),
-        }
-        return regulation_logic
+    # # regulation functions
+    # def regulation(state):
+    #     regulation_logic = {
+    #         'EX_lac__D_e': bool(not state[('external', 'glc__D_e')] > 0.1),
+    #     }
+    #     return regulation_logic
 
     metabolism_file = os.path.join('models', 'e_coli_core.json')
 
@@ -110,7 +110,7 @@ def get_metabolism_config():
             'EX_glc__D_e': [1.05, 1.0],
             'EX_lac__D_e': [1.05, 1.0]},
         'model_path': metabolism_file,
-        'regulation': regulation,
+        # 'regulation': regulation,
         'initial_state': initial_state}
 
 def get_expression_config():

--- a/vivarium/composites/glc_lct_shifter.py
+++ b/vivarium/composites/glc_lct_shifter.py
@@ -4,7 +4,7 @@ import os
 
 from vivarium.environment.make_media import Media
 from vivarium.utils.units import units
-
+from vivarium.utils.dict_utils import tuple_to_str_dict
 from vivarium.composites.master import compose_master
 
 
@@ -131,6 +131,8 @@ def compose_glc_lct_shifter(config):
         'metabolism': get_metabolism_config(),
         'expression': get_expression_config(),
         'deriver': get_expression_config()}
+
+    tuple_to_str_dict(shifter_config)
     config.update(shifter_config)
 
     return compose_master(config)

--- a/vivarium/processes/convenience_kinetics.py
+++ b/vivarium/processes/convenience_kinetics.py
@@ -9,6 +9,7 @@ from vivarium.actor.process import Process, convert_to_timeseries, plot_simulati
 from vivarium.utils.kinetic_rate_laws import KineticFluxModel
 from vivarium.utils.dict_utils import tuplify_role_dicts
 from vivarium.utils.units import units
+from vivarium.utils.dict_utils import str_to_tuple_dict
 
 EMPTY_ROLES = {
     'internal': [],
@@ -25,13 +26,17 @@ class ConvenienceKinetics(Process):
         self.nAvogadro = constants.N_A * 1 / units.mol
 
         # retrieve initial parameters
-        self.reactions = initial_parameters.get('reactions')
+        reactions = initial_parameters.get('reactions')
         self.initial_state = initial_parameters.get('initial_state', EMPTY_STATES)
         kinetic_parameters = initial_parameters.get('kinetic_parameters')
         roles = initial_parameters.get('roles', EMPTY_ROLES)
 
         # make the kinetic model
-        self.kinetic_rate_laws = KineticFluxModel(self.reactions, kinetic_parameters)
+        kinetic_params = copy.deepcopy(kinetic_parameters)
+        str_to_tuple_dict(kinetic_params)
+        self.reactions = copy.deepcopy(reactions)
+        str_to_tuple_dict(self.reactions)
+        self.kinetic_rate_laws = KineticFluxModel(self.reactions, kinetic_params)
 
         # roles
         # add volume to internal role

--- a/vivarium/processes/convenience_kinetics.py
+++ b/vivarium/processes/convenience_kinetics.py
@@ -9,7 +9,6 @@ from vivarium.actor.process import Process, convert_to_timeseries, plot_simulati
 from vivarium.utils.kinetic_rate_laws import KineticFluxModel
 from vivarium.utils.dict_utils import tuplify_role_dicts
 from vivarium.utils.units import units
-from vivarium.utils.dict_utils import str_to_tuple_dict
 
 EMPTY_ROLES = {
     'internal': [],
@@ -26,17 +25,13 @@ class ConvenienceKinetics(Process):
         self.nAvogadro = constants.N_A * 1 / units.mol
 
         # retrieve initial parameters
-        reactions = initial_parameters.get('reactions')
+        self.reactions = initial_parameters.get('reactions')
         self.initial_state = initial_parameters.get('initial_state', EMPTY_STATES)
         kinetic_parameters = initial_parameters.get('kinetic_parameters')
         roles = initial_parameters.get('roles', EMPTY_ROLES)
 
         # make the kinetic model
-        kinetic_params = copy.deepcopy(kinetic_parameters)
-        str_to_tuple_dict(kinetic_params)
-        self.reactions = copy.deepcopy(reactions)
-        str_to_tuple_dict(self.reactions)
-        self.kinetic_rate_laws = KineticFluxModel(self.reactions, kinetic_params)
+        self.kinetic_rate_laws = KineticFluxModel(self.reactions, kinetic_parameters)
 
         # roles
         # add volume to internal role

--- a/vivarium/utils/dict_utils.py
+++ b/vivarium/utils/dict_utils.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
 
+tuple_separator = '___'
+
 def merge_dicts(dicts):
     merge = {}
     for d in dicts:
@@ -32,3 +34,27 @@ def tuplify_role_dicts(dicts):
         for state, value in states_dict.items():
             merge.update({(role, state): value})
     return merge
+
+def tuple_key_to_string(dictionary):
+
+    # get down to the leaves first
+    for k, v in dictionary.items():
+        if isinstance(v, dict):
+            tuple_key_to_string(v)
+
+        # convert tuples in lists
+        if isinstance(v, list):
+            for idx, var in enumerate(v):
+                if isinstance(var, tuple):
+                    v[idx] = tuple_separator.join(var)
+                if isinstance(var, dict):
+                    tuple_key_to_string(var)
+
+    # which keys are tuples?
+    tuple_ks = [k for k in dictionary.keys() if isinstance(k, tuple)]
+    for tuple_k in tuple_ks:
+        str_k = tuple_separator.join(tuple_k)
+        dictionary[str_k] = dictionary[tuple_k]
+        del dictionary[tuple_k]
+
+    return dictionary

--- a/vivarium/utils/dict_utils.py
+++ b/vivarium/utils/dict_utils.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import copy
 
 tuple_separator = '___'
 
@@ -35,13 +36,17 @@ def tuplify_role_dicts(dicts):
             merge.update({(role, state): value})
     return merge
 
-def tuple_to_str_dict(dictionary):
+def tuple_to_str_keys(dictionary):
     # take a dict with tuple keys, and convert them to strings with tuple_separator as a delimiter
+    new_dict = copy.deepcopy(dictionary)
+    make_str_dict(new_dict)
+    return new_dict
 
+def make_str_dict(dictionary):
     # get down to the leaves first
     for k, v in dictionary.items():
         if isinstance(v, dict):
-            tuple_to_str_dict(v)
+            make_str_dict(v)
 
         # convert tuples in lists
         if isinstance(v, list):
@@ -49,7 +54,7 @@ def tuple_to_str_dict(dictionary):
                 if isinstance(var, tuple):
                     v[idx] = tuple_separator.join(var)
                 if isinstance(var, dict):
-                    tuple_to_str_dict(var)
+                    make_str_dict(var)
 
     # which keys are tuples?
     tuple_ks = [k for k in dictionary.keys() if isinstance(k, tuple)]
@@ -60,13 +65,13 @@ def tuple_to_str_dict(dictionary):
 
     return dictionary
 
-def str_to_tuple_dict(dictionary):
+def str_to_tuple_keys(dictionary):
     # take a dict with keys that have tuple_separator, and convert them to tuples
 
     # get down to the leaves first
     for k, v in dictionary.items():
         if isinstance(v, dict):
-            str_to_tuple_dict(v)
+            str_to_tuple_keys(v)
 
         # convert strings in lists
         if isinstance(v, list):
@@ -74,7 +79,7 @@ def str_to_tuple_dict(dictionary):
                 if isinstance(var, str) and tuple_separator in var:
                     v[idx] = tuple(var.split(tuple_separator))
                 if isinstance(var, dict):
-                    str_to_tuple_dict(var)
+                    str_to_tuple_keys(var)
 
     # which keys are tuples?
     str_ks = [k for k in dictionary.keys() if isinstance(k, str) and tuple_separator in k]

--- a/vivarium/utils/dict_utils.py
+++ b/vivarium/utils/dict_utils.py
@@ -35,12 +35,12 @@ def tuplify_role_dicts(dicts):
             merge.update({(role, state): value})
     return merge
 
-def tuple_key_to_string(dictionary):
+def tuple_to_str_dict(dictionary):
 
     # get down to the leaves first
     for k, v in dictionary.items():
         if isinstance(v, dict):
-            tuple_key_to_string(v)
+            tuple_to_str_dict(v)
 
         # convert tuples in lists
         if isinstance(v, list):
@@ -48,7 +48,7 @@ def tuple_key_to_string(dictionary):
                 if isinstance(var, tuple):
                     v[idx] = tuple_separator.join(var)
                 if isinstance(var, dict):
-                    tuple_key_to_string(var)
+                    tuple_to_str_dict(var)
 
     # which keys are tuples?
     tuple_ks = [k for k in dictionary.keys() if isinstance(k, tuple)]
@@ -56,5 +56,30 @@ def tuple_key_to_string(dictionary):
         str_k = tuple_separator.join(tuple_k)
         dictionary[str_k] = dictionary[tuple_k]
         del dictionary[tuple_k]
+
+    return dictionary
+
+def str_to_tuple_dict(dictionary):
+    # take a dict with keys that have tuple_separator, and convert them to tuples
+
+    # get down to the leaves first
+    for k, v in dictionary.items():
+        if isinstance(v, dict):
+            str_to_tuple_dict(v)
+
+        # convert strings in lists
+        if isinstance(v, list):
+            for idx, var in enumerate(v):
+                if isinstance(var, str) and tuple_separator in var:
+                    v[idx] = tuple(var.split(tuple_separator))
+                if isinstance(var, dict):
+                    str_to_tuple_dict(var)
+
+    # which keys are tuples?
+    str_ks = [k for k in dictionary.keys() if isinstance(k, str) and tuple_separator in k]
+    for str_k in str_ks:
+        tuple_k = tuple(str_k.split(tuple_separator))
+        dictionary[tuple_k] = dictionary[str_k]
+        del dictionary[str_k]
 
     return dictionary

--- a/vivarium/utils/dict_utils.py
+++ b/vivarium/utils/dict_utils.py
@@ -36,6 +36,7 @@ def tuplify_role_dicts(dicts):
     return merge
 
 def tuple_to_str_dict(dictionary):
+    # take a dict with tuple keys, and convert them to strings with tuple_separator as a delimiter
 
     # get down to the leaves first
     for k, v in dictionary.items():


### PR DESCRIPTION
This PR introduces the new ```utils/dict_util``` functions ```tuple_to_str_keys``` and the inverse ```str_to_tuple_keys```, which can be used to convert parameters or states that use tuples as keys to string keys.  

Tuples are an attractive way to specify embedded states, especially with roles included -- for example ```('internal', 'g6p_c')``` rather than ```'internal_g6p_c'```. But tuples are not json serializable, which is required by ```actor/actor.py``` in ```encoded = json.dumps(message, ensure_ascii=False).encode('utf-8')``` when Kafka initializes a compartment.

Edit: all tuple to string conversions are now being handled entirely in ```actor/actor.py``` when messages are sent/received.  Thanks everyone for the suggestions.