### PR TITLE
Regulation logic thresholds

### DIFF
--- a/vivarium/composites/glc_lct_shifter.py
+++ b/vivarium/composites/glc_lct_shifter.py
@@ -77,12 +77,9 @@ def get_transport_config():
 
 def get_metabolism_config():
 
-    # # regulation functions
-    # def regulation(state):
-    #     regulation_logic = {
-    #         'EX_lac__D_e': bool(not state[('external', 'glc__D_e')] > 0.1),
-    #     }
-    #     return regulation_logic
+    # regulation definitions
+    regulation = {
+        'EX_lac__D_e': 'if not (external, glc__D_e) > 0.1'}
 
     metabolism_file = os.path.join('models', 'e_coli_core.json')
 
@@ -109,7 +106,7 @@ def get_metabolism_config():
             'EX_glc__D_e': [1.05, 1.0],
             'EX_lac__D_e': [1.05, 1.0]},
         'model_path': metabolism_file,
-        # 'regulation': regulation,
+        'regulation': regulation,
         'initial_state': initial_state}
 
 def get_expression_config():

--- a/vivarium/composites/glc_lct_shifter.py
+++ b/vivarium/composites/glc_lct_shifter.py
@@ -77,10 +77,6 @@ def get_transport_config():
 
 def get_metabolism_config():
 
-    # regulation definitions
-    regulation = {
-        'EX_lac__D_e': 'if not (external, glc__D_e) > 0.1'}
-
     metabolism_file = os.path.join('models', 'e_coli_core.json')
 
     # initial state
@@ -93,9 +89,8 @@ def get_metabolism_config():
         'volume': volume.to('fL').magnitude}
 
     # external
-    # TODO -- generalize external to whatever BiGG model is loaded
     make_media = Media()
-    external = make_media.get_saved_media('ecoli_core_GLC')
+    external = make_media.get_saved_media('ecoli_core_GLC')  # TODO -- generalize external to whatever BiGG model is loaded
     initial_state = {
         'internal': internal,
         'external': external}
@@ -106,12 +101,18 @@ def get_metabolism_config():
             'EX_glc__D_e': [1.05, 1.0],
             'EX_lac__D_e': [1.05, 1.0]},
         'model_path': metabolism_file,
-        'regulation': regulation,
         'initial_state': initial_state}
 
 def get_expression_config():
+    # define regulation
+    regulators = [('external', 'glc__D_e')]
+    regulation = {
+        'LacY': 'if not (external, glc__D_e) > 0.1'}
+
     expression_rates = {'LacY': 0.005}
     return {
+        'regulators': regulators,
+        'regulation': regulation,
         'counted_molecules': list(expression_rates.keys()),
         'expression_rates': expression_rates}
 

--- a/vivarium/composites/master.py
+++ b/vivarium/composites/master.py
@@ -78,7 +78,8 @@ def compose_master(config):
             'exchange': 'exchange',
             'flux_bounds': 'flux_bounds'},
         'expression' : {
-            'internal': 'cell_counts'},  # updates counts, which the deriver converts to concentrations
+            'internal': 'cell_counts',  # updates counts, which the deriver converts to concentrations
+            'external': 'environment'},
         'degradation': {
             'internal': 'cell_counts'},
         'division': {

--- a/vivarium/composites/master.py
+++ b/vivarium/composites/master.py
@@ -110,11 +110,9 @@ def compose_master(config):
 
 # toy functions/ defaults
 def default_metabolism_config():
-    def regulation(state):
-        regulation_logic = {
-            'EX_lac__D_e': bool(not state[('external', 'glc__D_e')] > 0.1),
-        }
-        return regulation_logic
+
+    regulation = {
+        'EX_lac__D_e': 'if not (external, glc__D_e) > 0.1'}
 
     metabolism_file = os.path.join('models', 'e_coli_core.json')
 
@@ -191,7 +189,8 @@ if __name__ == '__main__':
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    compartment = load_compartment(compose_master)
+    boot_config = {'emitter': 'null'}
+    compartment = load_compartment(compose_master, boot_config)
 
     # settings for simulation and plot
     options = compose_master({})['options']

--- a/vivarium/processes/metabolism.py
+++ b/vivarium/processes/metabolism.py
@@ -11,13 +11,10 @@ from vivarium.actor.process import Process, deep_merge, convert_to_timeseries, p
 from vivarium.utils.units import units
 from vivarium.utils.cobra_fba import CobraFBA
 from vivarium.utils.dict_utils import tuplify_role_dicts
+from vivarium.utils.regulation_logic import build_rule
 
 # concentrations are lower than threshold are considered depleted
 EXCHANGE_THRESHOLD = 0.1
-
-
-def null_function(state):
-    return {}
 
 
 class Metabolism(Process):
@@ -45,8 +42,9 @@ class Metabolism(Process):
         self.default_upper_bound = initial_parameters.get('default_upper_bound', 1000.0)
 
         # get regulation functions
-        # TODO -- pass regulation logic in as data, and construct functions in init
-        self.regulation = initial_parameters.get('regulation', null_function)
+        regulation_logic = initial_parameters.get('regulation')
+        self.regulation = {
+            reaction: build_rule(logic) for reaction, logic in regulation_logic.items()}
 
         # get molecules in objective
         self.objective_molecules = []
@@ -130,7 +128,9 @@ class Metabolism(Process):
 
         # get state of regulated reactions (True/False)
         flattened_states = tuplify_role_dicts(states)
-        regulation_state = self.regulation(flattened_states)
+        regulation_state = {}
+        for reaction_id, reg_logic in self.regulation.items():
+            regulation_state[reaction_id] = reg_logic(flattened_states)
 
         ## apply flux constraints
         # first, add exchange constraints

--- a/vivarium/processes/metabolism.py
+++ b/vivarium/processes/metabolism.py
@@ -42,7 +42,7 @@ class Metabolism(Process):
         self.default_upper_bound = initial_parameters.get('default_upper_bound', 1000.0)
 
         # get regulation functions
-        regulation_logic = initial_parameters.get('regulation')
+        regulation_logic = initial_parameters.get('regulation', {})
         self.regulation = {
             reaction: build_rule(logic) for reaction, logic in regulation_logic.items()}
 

--- a/vivarium/utils/regulation_logic.py
+++ b/vivarium/utils/regulation_logic.py
@@ -15,10 +15,10 @@ def convert_number(s):
 
 
 # each function returns a tuple
-def symbol(): return RegExMatch(r'[a-zA-Z0-9.\[\]\-\_]+')  # TODO -- surplus can be evaluated if there is a threshold, ignored for now
+def symbol(): return RegExMatch(r'[a-zA-Z0-9.\-\_]+')  # TODO -- surplus can be evaluated if there is a threshold, ignored for now
 def operator(): return [Kwd('>'), Kwd('<')]
 def compare(): return symbol, Optional(operator, symbol)
-def group(): return Kwd("("), logic, Kwd(")")
+def group(): return Kwd("["), logic, Kwd("]")
 def term(): return Optional(Kwd("not")), [compare, group]
 def logic(): return term, ZeroOrMore([Kwd("and"), Kwd("or")], term)
 def rule(): return Kwd("if"), logic, EOF
@@ -95,13 +95,16 @@ def build_rule(expression):
     evaluates that logic with respect to actual values for the various symbols. 
     '''
     tree = rule_parser.parse(expression)
+
+    print("{}: {}".format(expression, tree))
+
     def logic(state):
         return evaluate_rule(tree, state)
 
     return logic
 
 def test_arpeggio():
-    test = "if not (GLCxt or LCTSxt or RUBxt) and FNR and not GlpR"
+    test = "if not [GLCxt or LCTSxt or RUBxt] and FNR and not GlpR"
     state_false = {'GLCxt': True, 'LCTSxt': False, 'RUBxt': True, 'FNR': True, 'GlpR': False}
     state_true = {'GLCxt': False, 'LCTSxt': False, 'RUBxt': False, 'FNR': True, 'GlpR': False}
     run_rule = build_rule(test)
@@ -109,7 +112,7 @@ def test_arpeggio():
     assert run_rule(state_true) == True
 
     # test surplus in statement
-    test = "if not (FDP > 10 or F6P)"
+    test = "if not [FDP > 10 or F6P]"
     state_false = {'FDP': 20, 'F6P': False}
     state_true = {'FDP': 5, 'F6P': False}
     run_rule = build_rule(test)


### PR DESCRIPTION
This PR updates ```utils/regulation_logic.py``` to include thresholds and tuple keys in the string definition.  Strings are JSON serializable, and so they can be passed into compartments, which use ```utils/regulation_logic.py``` to build the regulation functions. 

Here's an example of how to build a function that can be given the current state and returns a Boolean variable: 
> reg_logic = "if not [(external, glc) > 0.1 and (external, lct) < 0.1]"
> reg_function = build_rule(reg_logic)
> reg_boolean = reg_function(state)

The composite ```glc_lct_shifter``` now utilizes this feature by defining regulation logic for LacY expression based on external glucose. The resulting behavior (shown in the attached figure) has LacY inhibited while there is glucose in the environment. Once glucose is sufficiently depleted, LacY begins to be expressed, and this allows for lactose uptake by the transport process.

![simulation](https://user-images.githubusercontent.com/6809431/73876514-f88c3600-480b-11ea-8c51-e228b7680e09.png)