### PR TITLE
fix all pytest errors

### DIFF
--- a/vivarium/environment/lattice.py
+++ b/vivarium/environment/lattice.py
@@ -576,7 +576,21 @@ def run():
     torque = 0.0
     return [force, torque]
 
-def test_diffusion(config):
+# default configs for tests
+diffusion_config = {
+    'total_time': 2,
+    'timestep': 0.05,
+    'diffusion': 1e2}
+
+motile_config = {
+    'total_time': 100,
+    'timestep': 0.1,
+    'edge_length': 50,
+    'jitter_force': 1e-1,
+    'motile_cells': True}
+
+
+def test_diffusion(config=diffusion_config):
     test_diffusion = 'GLC'
 
     total_time = config.get('total_time', 10)
@@ -650,7 +664,7 @@ def test_diffusion(config):
     }
     return data
 
-def test_lattice(config):
+def test_lattice(config=motile_config):
     # time of motor behavior without chemotaxis
     run_time = 0.42  # s (Berg)
     tumble_time = 0.14  # s (Berg)
@@ -957,11 +971,6 @@ if __name__ == '__main__':
     plot_motility(motile_output, 'motility_state_short_ts', out_dir)
     plot_trajectory(motile_output, 'motility_trajectory_short_ts', out_dir)
 
-    # test diffusion
-    diffusion_config = {
-        'total_time': 2,
-        'timestep': 0.05,
-        'diffusion': 1e2}
 
-    diffusion_out = test_diffusion(diffusion_config)
+    diffusion_out = test_diffusion()
     plot_field(diffusion_out, 'diffusion', out_dir)

--- a/vivarium/processes/metabolism.py
+++ b/vivarium/processes/metabolism.py
@@ -377,12 +377,12 @@ def get_toy_configuration():
     default_reaction_bounds = 1000.0
 
     exchange_bounds = {
-        'A': 0.02,
-        'D': -0.01,
-        'E': -0.01,
-        'F': 0.005,
-        'H': 0.005,
-        'O2': 0.1}
+        'A': -0.02,
+        'D': 0.01,
+        'E': 0.01,
+        'F': -0.005,
+        'H': -0.005,
+        'O2': -0.1}
 
     mass = 1339 * units.fg
     density = 1100 * units.g/units.L
@@ -468,7 +468,7 @@ def toy_transport():
     return transport_kinetics
 
 # tests
-def test_BiGG_metabolism(out_dir):
+def test_BiGG_metabolism(time=10):
     # metabolism_file = os.path.join('models', 'iAF1260b.json')
     metabolism_file = os.path.join('models', 'e_coli_core.json')
 
@@ -489,31 +489,19 @@ def test_BiGG_metabolism(out_dir):
     metabolism = Metabolism(metabolism_config)
 
     # simulate metabolism
-    timeline = [(2520, {})]  # 2520 sec (42 min) is the expected doubling time in minimal media
+    timeline = [(time, {})]
 
     simulation_config = {
         'process': metabolism,
         'timeline': timeline,
         'environment_volume': 1e-2}
 
-    plot_settings = {
-        'max_rows': 40,
-        'remove_zeros': True,
-        'skip_roles': ['exchange', 'flux_bounds', 'reactions'],
-        'overlay': {
-            'reactions': 'flux_bounds'}}
-
     saved_data = simulate_metabolism(simulation_config)
-    del saved_data[0]  # remove first state
-    timeseries = convert_to_timeseries(saved_data)
+    return saved_data
 
-    # get growth
-    volume_ts = timeseries['internal']['volume']
-    print('growth: {}'.format(volume_ts[-1]/volume_ts[0]))
 
-    plot_simulation_output(timeseries, plot_settings, out_dir)
 
-def test_toy_metabolism(out_dir):
+def test_toy_metabolism(out_dir='out'):
 
     regulation_logic = {
         'R4': 'if (external, O2) > 0.1 and not (external, F) < 0.1'}
@@ -542,16 +530,9 @@ def test_toy_metabolism(out_dir):
         'transport_kinetics': transport,
         'environment_volume': 1e-14}
 
-    plot_settings = {
-        'skip_roles': ['exchange'],
-        'overlay': {
-            'reactions': 'flux_bounds'}}
-
     saved_data = simulate_metabolism(simulation_config)
-    del saved_data[0]  # remove first state
-    timeseries = convert_to_timeseries(saved_data)
-    plot_simulation_output(timeseries, plot_settings, out_dir)
-    plot_exchanges(timeseries, simulation_config, out_dir)
+    return saved_data
+
 
 def make_network():
     # configure toy model
@@ -575,6 +556,30 @@ if __name__ == '__main__':
     if not os.path.exists(out_dir_BiGG):
         os.makedirs(out_dir_BiGG)
 
-    test_BiGG_metabolism(out_dir_BiGG)
-    # test_toy_metabolism(out_dir)
+    # run BiGG metabolism
+    plot_settings = {
+        'max_rows': 40,
+        'remove_zeros': True,
+        'skip_roles': ['exchange', 'flux_bounds', 'reactions'],
+        'overlay': {
+            'reactions': 'flux_bounds'}}
+
+    saved_data = test_BiGG_metabolism(2520) # 2520 sec (42 min) is the expected doubling time in minimal media
+    del saved_data[0]  # remove first state
+    timeseries = convert_to_timeseries(saved_data)
+    volume_ts = timeseries['internal']['volume']
+    print('growth: {}'.format(volume_ts[-1]/volume_ts[0]))
+    plot_simulation_output(timeseries, plot_settings, out_dir_BiGG)
+
+    # run toy model
+    plot_settings = {
+        'skip_roles': ['exchange'],
+        'overlay': {
+            'reactions': 'flux_bounds'}}
+
+    saved_data = test_toy_metabolism()
+    del saved_data[0]  # remove first state
+    timeseries = convert_to_timeseries(saved_data)
+    plot_simulation_output(timeseries, plot_settings, out_dir)
+
     # make_network()


### PR DESCRIPTION
Fix the pytest errors coming from metabolism and lattice.  Mostly, I failed to provide test configs. Metabolism's toy_config had opposite signs on its exchange bounds.