### PR TITLE
Base binding affinities on transcription factor states

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ cffi==1.13.2
 cobra==0.17.1
 confluent-kafka==0.11.5
 matplotlib==2.2.2
-numpy==1.14.6
+numpy==1.15.3
 parsimonious==0.8.1
 Pint==0.9
 pygame==1.9.6
@@ -29,5 +29,5 @@ pytest==4.6.5
 pytest-benchmark==3.2.2
 scipy==1.4.1
 scs==2.0.2
-stochastic-arrow==0.2.0
+stochastic-arrow==0.3.0
 swiglpk==1.4.4

--- a/vivarium/actor/process.py
+++ b/vivarium/actor/process.py
@@ -45,6 +45,9 @@ updater_library = {
 
 KEY_TYPE = 'U31'
 
+def keys_list(d):
+    return list(d.keys())
+
 class State(object):
     ''' Represents a set of named values. '''
 

--- a/vivarium/composites/gene_expression.py
+++ b/vivarium/composites/gene_expression.py
@@ -38,7 +38,8 @@ def compose_gene_expression(config):
         'transcription': {
             'chromosome': 'chromosome',
             'molecules': 'molecules',
-            'transcripts': 'transcripts'},
+            'transcripts': 'transcripts',
+            'factors': 'factors'},
         'translation': {
             'ribosomes': 'ribosomes',
             'molecules': 'molecules',

--- a/vivarium/composites/gfp_expression.py
+++ b/vivarium/composites/gfp_expression.py
@@ -51,7 +51,7 @@ def generate_gfp_compartment(config):
             'templates': gfp_plasmid_config['promoters'],
             'genes': gfp_plasmid_config['genes'],
             'promoter_affinities': {
-                'T7': 0.5},
+                ('T7',): 0.5},
 
             'advancement_rate': 10.0,
             'elongation_rate': 50},
@@ -102,5 +102,16 @@ if __name__ == '__main__':
     saved_state = simulate_compartment(gfp_expression_compartment, settings)
     del saved_state[0]  # remove the first state
     timeseries = convert_to_timeseries(saved_state)
-    plot_gene_expression_output(timeseries, 'gfp_expression', out_dir)
+
+    plot_config = {
+        'name': 'gfp_expression',
+        'roles': {
+            'transcripts': 'transcripts',
+            'molecules': 'molecules',
+            'proteins': 'proteins'}}
+
+    plot_gene_expression_output(
+        timeseries,
+        plot_config,
+        out_dir)
     

--- a/vivarium/data/chromosome.py
+++ b/vivarium/data/chromosome.py
@@ -17,7 +17,7 @@ test_chromosome_config = {
                 'position': 0,
                 'length': 3,
                 'thresholds': [
-                    ('tfX', 0.3)]}],
+                    ('tfA', 0.3)]}],
             'terminators': [
                 {
                     'position': 6,
@@ -35,7 +35,7 @@ test_chromosome_config = {
                 'position': 0,
                 'length': 3,
                 'thresholds': [
-                    ('tfX', 0.5)]}],
+                    ('tfB', 0.5)]}],
             'terminators': [
                 {
                     'position': -9,

--- a/vivarium/processes/degradation.py
+++ b/vivarium/processes/degradation.py
@@ -1,6 +1,6 @@
 import copy
 
-from vivarium.actor.process import Process
+from vivarium.actor.process import Process, keys_list
 from vivarium.data.nucleotides import nucleotides
 from vivarium.processes.deriver import AVOGADRO
 from vivarium.utils.units import units
@@ -13,9 +13,6 @@ def all_subkeys(d):
 
 def kinetics(E, S, kcat, km):
     return kcat * E * S / (S + km)
-
-def keys_list(d):
-    return list(d.keys())
 
 DEFAULT_TRANSCRIPT_DEGRADATION_KM = 1e-23
 

--- a/vivarium/processes/transcription.py
+++ b/vivarium/processes/transcription.py
@@ -78,14 +78,6 @@ class Transcription(Process):
         self.elongation_rate = self.parameters['elongation_rate']
         self.advancement_rate = self.parameters['advancement_rate']
 
-        # self.affinity_vector = np.array([
-        #     self.promoter_affinities[promoter_key]
-        #     for promoter_key in self.promoter_order], dtype=np.float64)
-
-        # self.rates = build_rates(
-        #     self.affinity_vector,
-        #     self.advancement_rate)
-
         self.stoichiometry = build_stoichiometry(self.promoter_count)
         self.initiation = StochasticSystem(self.stoichiometry)
 
@@ -313,7 +305,6 @@ class Transcription(Process):
 
         if VERBOSE:
             print('molecules update: {}'.format(update['molecules']))
-            # print('transcription update: {}'.format(update))
 
         return update
 

--- a/vivarium/processes/transcription.py
+++ b/vivarium/processes/transcription.py
@@ -59,9 +59,7 @@ class Transcription(Process):
 
         self.sequence = self.parameters['sequence']
         self.sequences = None # set when the chromosome first appears
-        self.templates = {
-            key: Promoter(template)
-            for key, template in self.parameters['templates'].items()}
+        self.templates = self.parameters['templates']
         self.genes = self.parameters['genes']
         self.symbol_to_monomer = self.parameters['symbol_to_monomer']
 
@@ -102,10 +100,10 @@ class Transcription(Process):
 
         super(Transcription, self).__init__(self.roles, self.parameters)
 
-    def build_affinity_vector(self, factors):
+    def build_affinity_vector(self, promoters, factors):
         vector = np.zeros(len(self.promoter_order), dtype=np.float64)
         for index, promoter_key in enumerate(self.promoter_order):
-            promoter = self.templates[promoter_key]
+            promoter = promoters[promoter_key]
             binding = promoter.binding_state(factors)
             affinity = self.promoter_affinities[binding]
             vector[index] = affinity
@@ -127,7 +125,7 @@ class Transcription(Process):
             'molecules': {UNBOUND_RNAP_KEY: 10},
             'factors': {
                 'tfA': 0.1,
-                'tfB': 0.1}}
+                'tfB': 1.0}}
 
         default_state['molecules'].update({
             nucleotide: 100
@@ -216,7 +214,7 @@ class Transcription(Process):
             self.symbol_to_monomer,
             self.elongation)
 
-        initiation_affinity = self.build_affinity_vector(factors)
+        initiation_affinity = self.build_affinity_vector(chromosome.promoters, factors)
         initiation_rates = build_rates(initiation_affinity, self.advancement_rate)
 
         while time < timestep:

--- a/vivarium/processes/translation.py
+++ b/vivarium/processes/translation.py
@@ -116,7 +116,7 @@ class Translation(Process):
             self.affinity_vector,
             self.advancement_rate)
 
-        self.initiation = StochasticSystem(self.stoichiometry, self.rates)
+        self.initiation = StochasticSystem(self.stoichiometry)
 
         self.ribosome_id = 0
 
@@ -230,7 +230,7 @@ class Translation(Process):
             interval = min(distance / self.elongation_rate, timestep - time)
 
             # run simulation for interval of time to next terminator
-            result = self.initiation.evolve(interval, substrate)
+            result = self.initiation.evolve(interval, substrate, self.rates)
 
             # go through each event in the simulation and update the state
             ribosome_bindings = 0

--- a/vivarium/utils/datum.py
+++ b/vivarium/utils/datum.py
@@ -25,6 +25,7 @@ class Datum(object):
 
     def __init__(self, config, default):
         self.keys = list(set(list(config.keys()) + list(default.keys()))) # a dance
+
         for key in self.keys:
             value = config.get(key, default[key])
             if value and key in self.schema:
@@ -54,5 +55,5 @@ class Datum(object):
         return to
 
     def __repr__(self):
-        return str(self.to_dict())
+        return str(type(self)) + ': ' + str(self.to_dict())
 

--- a/vivarium/utils/polymerize.py
+++ b/vivarium/utils/polymerize.py
@@ -75,7 +75,7 @@ class BindingSite(Datum):
         '''
 
         state = None
-        for factor, threshold in thresholds:
+        for factor, threshold in self.thresholds:
             if levels[factor] >= threshold:
                 state = factor
                 break
@@ -170,6 +170,11 @@ def all_products(templates):
         product
         for template in templates.values()
         for product in template.products()]))
+
+def template_products(config):
+    return all_products({
+        key: Template(config)
+        for key, config in config.items()})
 
 def polymerize_to(
         sequences,


### PR DESCRIPTION
This PR converts the binding affinities from static values for each promoter to a dynamic value based on the existing concentrations of relevant transcription factors. Affinities are indexed by a tuple which has one element for each binding site, in addition to the promoter id. In the absence of concentrations, these binding site states are `None`, but as the concentration rises if a configured threshold is passed that state becomes identified with the transcription factor id, which then provides a new index into the binding affinities mapping. 