### PR TITLE
initialize flagella concentrations

### DIFF
--- a/vivarium/processes/Mears2014_flagella_activity.py
+++ b/vivarium/processes/Mears2014_flagella_activity.py
@@ -153,7 +153,7 @@ class FlagellaActivity(Process):
             'state': default_state,
             'emitter_keys': default_emitter_keys,
             'updaters': default_updaters,
-            'time_step': 0.001}
+            'time_step': 0.01}  # 0.001
 
         return default_settings
 

--- a/vivarium/processes/ode_expression.py
+++ b/vivarium/processes/ode_expression.py
@@ -6,6 +6,8 @@ from vivarium.actor.process import Process
 from vivarium.utils.dict_utils import deep_merge, tuplify_role_dicts
 from vivarium.actor.composition import process_in_compartment, simulate_with_environment, convert_to_timeseries, plot_simulation_output
 from vivarium.utils.regulation_logic import build_rule
+from vivarium.utils.units import units
+from vivarium.processes.derive_globals import AVOGADRO
 
 
 class ODE_expression(Process):
@@ -154,15 +156,21 @@ def get_flagella_expression():
     protein_map = {
         'flagella': 'flag_RNA'}
 
+    # get initial concentrations from counts
+    volume = 1.2 * units.fL
+    mmol_to_counts = (AVOGADRO * volume).to('L/mmol')
+    counts = {
+        'flagella': 5,
+        'flag_RNA': 30}
+    concentrations = {}
+    for state_id, count in counts.items():
+        concentrations[state_id] = (count / mmol_to_counts).magnitude
+
     initial_state = {
-        'counts': {
-            'flagella': 5,
-            'flag_RNA': 30},
-        'internal': {
-            'flagella': 0,
-            'flag_RNA': 0},
+        'counts': counts,
+        'internal': concentrations,
         'global': {
-            'volume': 1.2}}
+            'volume': volume}}
 
     return  {
         'transcription_rates': transcription,


### PR DESCRIPTION
minor tweak to initialize flagella concentrations in ode_expression in addition to counts. We will need a better way to initialize counts/concs if one is provided but not the other.