### PR TITLE
state schema

### DIFF
--- a/vivarium/actor/composition.py
+++ b/vivarium/actor/composition.py
@@ -147,7 +147,7 @@ def process_in_compartment(process):
     # get schema
     schema = get_schema(processes, topology)
 
-    # # make the state
+    # make the state
     state_dict = process_settings['state']
     states = initialize_state(processes, topology, schema, state_dict)
 

--- a/vivarium/actor/composition.py
+++ b/vivarium/actor/composition.py
@@ -3,7 +3,7 @@ import os
 
 import matplotlib.pyplot as plt
 
-from vivarium.utils.dict_utils import deep_merge
+from vivarium.utils.dict_utils import deep_merge, deep_merge_check
 from vivarium.actor.process import initialize_state, simulate_compartment, Compartment
 from vivarium.utils.units import units
 
@@ -121,7 +121,7 @@ def get_schema(process_list, topology):
                     compartment_role: settings}
 
                 ## TODO -- check for mismatch
-                deep_merge(schema, compartment_schema)
+                deep_merge_check(schema, compartment_schema)
 
     return schema
 

--- a/vivarium/actor/process.py
+++ b/vivarium/actor/process.py
@@ -7,7 +7,7 @@ import os
 import numpy as np
 
 import vivarium.actor.emitter as emit
-from vivarium.utils.dict_utils import merge_dicts, deep_merge
+from vivarium.utils.dict_utils import merge_dicts, deep_merge, deep_merge_check
 
 
 COMPARTMENT_STATE = '__compartment_state__'
@@ -268,11 +268,12 @@ def initialize_state(process_layers, topology, schema, initial_state):
                     updaters.update({state: updater})
 
             # update the states
+            # TODO -- make this a deep_merge_check, requires better handling of initial state conflicts
             c_states = deep_merge(default_states, compartment_states.get(compartment_role, {}))
             compartment_states[compartment_role] = c_states
 
             # update the updaters
-            c_updaters = deep_merge(updaters, compartment_updaters.get(compartment_role, {}))
+            c_updaters = deep_merge_check(updaters, compartment_updaters.get(compartment_role, {}))
             compartment_updaters[compartment_role] = c_updaters
 
     # initialize state for each compartment role

--- a/vivarium/actor/process.py
+++ b/vivarium/actor/process.py
@@ -24,21 +24,15 @@ def npize(d):
 
     return keys, values
 
-def update_delta(key, state_dict, current_value, new_value):
+def update_accumulate(key, state_dict, current_value, new_value):
     return current_value + new_value, {}
 
 def update_set(key, state_dict, current_value, new_value):
     return new_value, {}
 
-# def accumulate_delta(key, state_dict, current_value, new_value):
-#     new_key = key + exchange_key
-#     return current_value, {new_key: state_dict[new_key] + new_value}
-
 updater_library = {
-    'delta': update_delta,
-    'set': update_set,
-    'accumulate': update_delta,  # TODO -- remove accumulate
-}
+    'accumulate': update_accumulate,
+    'set': update_set}
 
 
 KEY_TYPE = 'U31'
@@ -86,7 +80,7 @@ class State(object):
 
         for key, value in update.items():
             # updater can be a function or a key into the updater library
-            updater = self.updaters.get(key, 'delta')
+            updater = self.updaters.get(key, 'accumulate')
             if not callable(updater):
                 updater = updater_library[updater]
 

--- a/vivarium/actor/process.py
+++ b/vivarium/actor/process.py
@@ -332,7 +332,8 @@ class Compartment(State):
         data = {
             'type': 'compartment',
             'name': configuration.get('name', 'compartment'),
-            'topology': self.topology}
+            'topology': self.topology,
+            'schema': self.schema}
 
         emit_config = {
             'table': 'configuration',
@@ -535,9 +536,13 @@ def toy_composite(config):
             'periplasm': ['GLC', 'MASS'],
             'cytoplasm': ['MASS']}})
 
+    # schema for states
+    schema = {}
+
     options = {
         # 'environment_role': 'environment',
         # 'exchange_role': 'exchange',
+        'schema': schema,
         'emitter': emitter,
         'topology': topology,
         'initial_time': 0.0}

--- a/vivarium/composites/PMF_chemotaxis.py
+++ b/vivarium/composites/PMF_chemotaxis.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, division, print_function
 import os
 
 from vivarium.actor.process import initialize_state, load_compartment
-from vivarium.actor.composition import get_derivers
-from vivarium.actor.composition import simulate_with_environment, convert_to_timeseries, plot_simulation_output
+from vivarium.actor.composition import get_derivers, get_schema, simulate_with_environment, \
+    convert_to_timeseries, plot_simulation_output
 
 # processes
 from vivarium.processes.ode_expression import ODE_expression, get_flagella_expression
@@ -84,12 +84,16 @@ def compose_pmf_chemotaxis(config):
     processes.extend(derivers['deriver_processes'])  # add deriver processes
     topology.update(derivers['deriver_topology'])  # add deriver topology
 
+    # get schema
+    schema = get_schema(processes, topology)
+
     # initialize the states
-    states = initialize_state(processes, topology, config.get('initial_state', {}))
+    states = initialize_state(processes, topology, schema, config.get('initial_state', {}))
 
     options = {
         'name': 'PMF_chemotaxis_composite',
         'topology': topology,
+        'schema': schema,
         'initial_time': config.get('initial_time', 0.0),
         'environment_role': 'environment',
         'exchange_role': 'exchange',

--- a/vivarium/composites/gene_expression.py
+++ b/vivarium/composites/gene_expression.py
@@ -5,7 +5,7 @@ import os
 import matplotlib.pyplot as plt
 
 from vivarium.actor.process import initialize_state
-from vivarium.actor.composition import get_derivers
+from vivarium.actor.composition import get_derivers, get_schema
 
 # processes
 from vivarium.processes.transcription import Transcription, UNBOUND_RNAP_KEY
@@ -56,14 +56,18 @@ def compose_gene_expression(config):
     processes.extend(derivers['deriver_processes'])  # add deriver processes
     topology.update(derivers['deriver_topology'])  # add deriver topology
 
+    # get schema
+    schema = get_schema(processes, topology)
+
     # initialize the states
-    states = initialize_state(processes, topology, config.get('initial_state', {}))
+    states = initialize_state(processes, topology, schema, config.get('initial_state', {}))
 
     options = {
         'name': 'gene_expression_composite',
         'environment_role': 'environment',
         'exchange_role': 'exchange',
         'topology': topology,
+        'schema': schema,
         'initial_time': config.get('initial_time', 0.0),
         'divide_condition': divide_condition,
         'divide_state': divide_state}

--- a/vivarium/composites/growth_division.py
+++ b/vivarium/composites/growth_division.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import os
 
 from vivarium.actor.process import initialize_state
-from vivarium.actor.composition import get_derivers
+from vivarium.actor.composition import get_derivers, get_schema
 
 # processes
 from vivarium.processes.growth import Growth
@@ -51,14 +51,18 @@ def compose_growth_division(config):
     processes.extend(derivers['deriver_processes'])  # add deriver processes
     topology.update(derivers['deriver_topology'])  # add deriver topology
 
+    # get schema
+    schema = get_schema(processes, topology)
+
     # initialize the states
-    states = initialize_state(processes, topology, config.get('initial_state', {}))
+    states = initialize_state(processes, topology, schema, config.get('initial_state', {}))
 
     options = {
         'name': 'growth_division_composite',
         'environment_role': 'environment',
         'exchange_role': 'exchange',
         'topology': topology,
+        'schema': schema,
         'initial_time': config.get('initial_time', 0.0),
         'divide_condition': divide_condition,
         'divide_state': divide_state}

--- a/vivarium/composites/master.py
+++ b/vivarium/composites/master.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import os
 
 from vivarium.actor.process import initialize_state
-from vivarium.actor.composition import get_derivers
+from vivarium.actor.composition import get_derivers, get_schema
 
 # processes
 from vivarium.processes.division import Division, divide_condition, divide_state
@@ -96,14 +96,18 @@ def compose_master(config):
     processes.extend(derivers['deriver_processes'])  # add deriver processes
     topology.update(derivers['deriver_topology'])  # add deriver topology
 
+    # get schema
+    schema = get_schema(processes, topology)
+
     # initialize the states
-    states = initialize_state(processes, topology, config.get('initial_state', {}))
+    states = initialize_state(processes, topology, schema, config.get('initial_state', {}))
 
     options = {
         'name': config.get('name', 'master_composite'),
         'environment_role': 'environment',
         'exchange_role': 'exchange',
         'topology': topology,
+        'schema': schema,
         'initial_time': config.get('initial_time', 0.0),
         'divide_condition': divide_condition,
         'divide_state': divide_state}

--- a/vivarium/composites/ode_expression.py
+++ b/vivarium/composites/ode_expression.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, division, print_function
 import os
 
 from vivarium.actor.process import initialize_state, load_compartment
-from vivarium.actor.composition import get_derivers
-from vivarium.actor.composition import simulate_with_environment, convert_to_timeseries, plot_simulation_output
+from vivarium.actor.composition import get_derivers, get_schema, simulate_with_environment, \
+    convert_to_timeseries, plot_simulation_output
 
 # processes
 from vivarium.processes.division import Division, divide_condition, divide_state
@@ -77,14 +77,18 @@ def compose_ode_expression(config):
     processes.extend(derivers['deriver_processes'])  # add deriver processes
     topology.update(derivers['deriver_topology'])  # add deriver topology
 
+    # get schema
+    schema = get_schema(processes, topology)
+
     # Initialize the states
-    states = initialize_state(processes, topology, config.get('initial_state', {}))
+    states = initialize_state(processes, topology, schema, config.get('initial_state', {}))
 
     options = {
         'name': config.get('name', 'master_composite'),
         'environment_role': 'environment',
         'exchange_role': 'exchange',
         'topology': topology,
+        'schema': schema,
         'initial_time': config.get('initial_time', 0.0),
         'divide_condition': divide_condition,
         'divide_state': divide_state}

--- a/vivarium/composites/simple_chemotaxis.py
+++ b/vivarium/composites/simple_chemotaxis.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from vivarium.actor.process import initialize_state, get_compartment_timestep
+from vivarium.actor.composition import get_schema
 
 # processes
 from vivarium.processes.Endres2006_chemoreceptor import ReceptorCluster
@@ -17,7 +18,7 @@ def compose_simple_chemotaxis(config):
     motor = MotorActivity(config)
 
     # place processes in layers
-    processes_layers = [
+    processes = [
         {'receptor': receptor},
         {'motor': motor}]
 
@@ -31,15 +32,19 @@ def compose_simple_chemotaxis(config):
             'external': 'environment',
             'internal': 'cell'}}
 
+    # get schema
+    schema = get_schema(processes, topology)
+
     # initialize the states
-    states = initialize_state(processes_layers, topology, config.get('initial_state', {}))
+    states = initialize_state(processes, topology, schema, config.get('initial_state', {}))
 
     # get the time step
-    time_step = get_compartment_timestep(processes_layers)
+    time_step = get_compartment_timestep(processes)
 
     options = {
         'name': 'simple_chemotaxis_composite',
         'topology': topology,
+        'schema': schema,
         'initial_time': config.get('initial_time', 0.0),
         'time_step': time_step,
         'environment_role': 'environment',
@@ -47,6 +52,6 @@ def compose_simple_chemotaxis(config):
     }
 
     return {
-        'processes': processes_layers,
+        'processes': processes,
         'states': states,
         'options': options}

--- a/vivarium/composites/variable_flagella.py
+++ b/vivarium/composites/variable_flagella.py
@@ -5,7 +5,7 @@ import os
 import random
 
 from vivarium.actor.process import initialize_state
-from vivarium.actor.composition import get_derivers
+from vivarium.actor.composition import get_derivers, get_schema
 
 # processes
 from vivarium.processes.Endres2006_chemoreceptor import ReceptorCluster
@@ -70,13 +70,17 @@ def compose_variable_flagella(config):
     processes.extend(derivers['deriver_processes'])  # add deriver processes
     topology.update(derivers['deriver_topology'])  # add deriver topology
 
+    # get schema
+    schema = get_schema(processes, topology)
+
     # initialize the states
-    states = initialize_state(processes, topology, config.get('initial_state', {}))
+    states = initialize_state(processes, topology, schema, config.get('initial_state', {}))
 
     options = {
         'environment_role': 'environment',
         # 'exchange_role': 'exchange',
         'topology': topology,
+        'schema': schema,
         'initial_time': config.get('initial_time', 0.0),
         'divide_condition': divide_condition,
         'divide_state': divide_state}

--- a/vivarium/processes/Endres2006_chemoreceptor.py
+++ b/vivarium/processes/Endres2006_chemoreceptor.py
@@ -66,16 +66,18 @@ class ReceptorCluster(Process):
             'internal': set_keys,
             'external': [self.ligand_id]}
 
-        # default updaters
-        default_updaters = {
-            'internal': {state_id: 'set' for state_id in set_keys},
-            'external': {}}
+        # schema
+        schema = {
+            'internal': {
+                state_id : {
+                    'updater': 'set'}
+                for state_id in set_keys}}
 
         default_settings = {
             'process_id': 'receptor',
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters,
+            'schema': schema,
             'time_step': 1.0}
 
         return default_settings

--- a/vivarium/processes/Kremling2007_transport.py
+++ b/vivarium/processes/Kremling2007_transport.py
@@ -154,19 +154,30 @@ class Transport(Process):
             'external': ['G6P', 'GLC', 'LAC'],
             'fluxes': self.target_fluxes}
 
-        # default updaters
-        default_updaters = {
-            'internal': {state_id: 'set' for state_id in [
-                'mass', 'UHPT', 'LACZ', 'PTSG', 'G6P', 'PEP', 'PYR', 'XP']},  # reactions set values directly
-            'external': {},  # reactions set values directly
-            'exchange': {mol_id: 'accumulate' for mol_id in self.environment_ids},  # all external values use default 'delta' udpater
-            'fluxes': {state_id: 'set' for state_id in self.target_fluxes}}
+        # schema
+        set_internal = ['mass', 'UHPT', 'LACZ', 'PTSG', 'G6P', 'PEP', 'PYR', 'XP']
+        internal_schema = {
+            state_id: {
+                'updater': 'set'}
+            for state_id in set_internal}
+        fluxes_schema = {
+            state_id: {
+                'updater': 'set'}
+            for state_id in self.target_fluxes}
+        exchange_schema = {
+            mol_id: {
+                'updater': 'accumulate'}
+            for mol_id in self.environment_ids}
 
+        schema = {
+            'internal': internal_schema,
+            'fluxes': fluxes_schema,
+            'exchange': exchange_schema}
 
         default_settings = {
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters}
+            'schema': schema}
 
         return default_settings
 

--- a/vivarium/processes/Mears2014_flagella_activity.py
+++ b/vivarium/processes/Mears2014_flagella_activity.py
@@ -142,17 +142,21 @@ class FlagellaActivity(Process):
             'motile_force',
             'motile_torque']
 
-        default_updaters = {
-            'internal': {state_id: 'set' for state_id in internal_set_states},
-            'membrane': {'PROTONS': 'accumulate'},
-            'flagella': {'flagella_activity': 'set'},
-            'external': {}}
+        # schema
+        internal_schema = {
+            state_id: {
+                'updater': 'set'}
+            for state_id in internal_set_states}
+        schema = {
+            'internal': internal_schema,
+            'membrane': {'PROTONS': {'updater': 'accumulate'}},
+            'flagella': {'flagella_activity': {'updater': 'set'}}}
 
         default_settings = {
             'process_id': 'motor',
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters,
+            'schema': schema,
             'time_step': 0.001}
 
         return default_settings

--- a/vivarium/processes/Vladimirov2008_motor.py
+++ b/vivarium/processes/Vladimirov2008_motor.py
@@ -85,7 +85,7 @@ class MotorActivity(Process):
                 'CheY_P'],
             'external': []}
 
-        # default updaters
+        # schema
         set_states = [
             'ccw_motor_bias',
             'ccw_to_cw',
@@ -94,16 +94,17 @@ class MotorActivity(Process):
             'motor_state',
             'CheA',
             'CheY_P']
-
-        default_updaters = {
-            'internal': {state_id: 'set' for state_id in set_states},
-            'external': {}}
+        schema = {
+            'internal': {
+                state_id : {
+                    'updater': 'set'}
+                for state_id in set_states}}
 
         default_settings = {
             'process_id': 'motor',
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters,
+            'schema': schema,
             'time_step': 0.1}
 
         return default_settings

--- a/vivarium/processes/Vladimirov2008_motor.py
+++ b/vivarium/processes/Vladimirov2008_motor.py
@@ -58,8 +58,8 @@ class MotorActivity(Process):
                          'motile_force',
                          'motile_torque',
                          'motor_state'],
-            'external': []
-        }
+            'external': []}
+
         parameters = DEFAULT_PARAMETERS
         parameters.update(initial_parameters)
 

--- a/vivarium/processes/convenience_kinetics.py
+++ b/vivarium/processes/convenience_kinetics.py
@@ -55,15 +55,18 @@ class ConvenienceKinetics(Process):
         # default emitter keys
         default_emitter_keys = {}
 
-        # default updaters
-        default_updaters = {
-            'fluxes': {flux_id: 'set' for flux_id in self.kinetic_rate_laws.reaction_ids}}
+        # schema
+        schema = {
+            'fluxes': {
+                flux_id : {
+                    'updater': 'set'}
+                for flux_id in self.kinetic_rate_laws.reaction_ids}}
 
         default_settings = {
             'process_id': 'convenience_kinetics',
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters,
+            'schema': schema,
             'time_step': 1.0}
 
         return default_settings

--- a/vivarium/processes/degradation.py
+++ b/vivarium/processes/degradation.py
@@ -84,16 +84,9 @@ class RnaDegradation(Process):
             'molecules': self.molecule_order,
             'global': []}
 
-        default_updaters = {
-            'transcripts': {},
-            'proteins': {},
-            'molecules': {},
-            'global': {}}
-
         return {
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters,
             'parameters': self.parameters}
 
     def next_update(self, timestep, states):

--- a/vivarium/processes/derive_concentrations.py
+++ b/vivarium/processes/derive_concentrations.py
@@ -35,16 +35,17 @@ class DeriveConcs(Process):
         # default emitter keys
         default_emitter_keys = {}
 
-        # default updaters
-        default_updaters = {
-            'concentrations': {state_id: 'set'
+        # schema
+        schema = {
+            'concentrations': {
+                state_id : {
+                    'updater': 'set'}
                 for state_id in self.roles['concentrations']}}
-
 
         default_settings = {
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters}
+            'schema': schema}
 
         return default_settings
 

--- a/vivarium/processes/derive_counts.py
+++ b/vivarium/processes/derive_counts.py
@@ -5,13 +5,25 @@ from vivarium.actor.process import Process
 from vivarium.utils.units import units
 
 
+def get_default_state():
+    mass = 1339 * units.fg  # wet mass in fg
+    density = 1100 * units.g / units.L
+    volume = mass / density
+    mmol_to_counts = (AVOGADRO * volume).to('L/mmol')
+
+    return {
+        'global': {
+            'volume': volume.magnitude,
+            'mmol_to_counts': mmol_to_counts.magnitude}}
+
 
 class DeriveCounts(Process):
     """
     Process for deriving counts from concentrations
     """
     def __init__(self, initial_parameters={}):
-        self.avogadro = AVOGADRO
+
+        self.initial_state = initial_parameters.get('initial_state', get_default_state())
 
         roles = initial_parameters.get('roles')
         roles.update({
@@ -23,14 +35,6 @@ class DeriveCounts(Process):
         super(DeriveCounts, self).__init__(roles, parameters)
 
     def default_settings(self):
-        volume = 1.2 * units.fL
-        mmol_to_counts = (self.avogadro * volume).to('L/mmol')
-
-        # default state
-        default_state = {
-            'global': {
-                'volume': volume.magnitude,
-                'mmol_to_counts': mmol_to_counts.magnitude}}
 
         # default emitter keys
         default_emitter_keys = {}
@@ -43,7 +47,7 @@ class DeriveCounts(Process):
                 for state_id in self.roles['counts']}}
 
         default_settings = {
-            'state': default_state,
+            'state': self.initial_state,
             'emitter_keys': default_emitter_keys,
             'schema': schema}
 

--- a/vivarium/processes/derive_counts.py
+++ b/vivarium/processes/derive_counts.py
@@ -35,15 +35,17 @@ class DeriveCounts(Process):
         # default emitter keys
         default_emitter_keys = {}
 
-        # default updaters
-        default_updaters = {
-            'counts': {state_id: 'set'
+        # schema
+        schema = {
+            'counts': {
+                state_id : {
+                    'updater': 'set'}
                 for state_id in self.roles['counts']}}
 
         default_settings = {
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters}
+            'schema': schema}
 
         return default_settings
 

--- a/vivarium/processes/derive_globals.py
+++ b/vivarium/processes/derive_globals.py
@@ -50,15 +50,18 @@ class DeriveGlobals(Process):
         default_emitter_keys = {
             'global': ['volume', 'growth_rate']}
 
-        # default updaters
+        # schema
         set_states = ['volume', 'growth_rate', 'prior_mass', 'mmol_to_counts']
-        default_updaters = {
-            'global': {state_id: 'set' for state_id in set_states}}
+        schema = {
+            'global': {
+                state_id : {
+                    'updater': 'set'}
+                for state_id in set_states}}
 
         default_settings = {
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters}
+            'schema': schema}
 
         return default_settings
 

--- a/vivarium/processes/division.py
+++ b/vivarium/processes/division.py
@@ -58,14 +58,15 @@ class Division(Process):
         # default emitter keys
         default_emitter_keys = {}
 
-        # default updaters
-        default_updaters = {
-            'global': {'division': 'set'}}
+        # schema
+        schema = {
+            'global': {
+                'division': {'updater': 'set'}}}
 
         default_settings = {
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters}
+            'schema': schema}
 
         return default_settings
 

--- a/vivarium/processes/growth.py
+++ b/vivarium/processes/growth.py
@@ -24,13 +24,15 @@ class Growth(Process):
         # default emitter keys
         default_emitter_keys = {'global': ['mass']}
 
-        # default updaters
-        default_updaters = {'global': {'mass': 'set'}}
+        # schema
+        schema = {
+            'global': {
+                'mass': {'updater': 'set'}}}
 
         default_settings = {
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters}
+            'schema': schema}
 
         return default_settings
 

--- a/vivarium/processes/membrane_potential.py
+++ b/vivarium/processes/membrane_potential.py
@@ -91,17 +91,19 @@ class MembranePotential(Process):
         # default emitter keys
         default_emitter_keys = {'membrane': ['d_V', 'd_pH', 'PMF']}
 
-        # default updaters
-        default_updaters = {
+
+        # schema
+        set_membrane = ['d_V', 'd_pH', 'PMF']
+        schema = {
             'membrane': {
-                'd_V': 'set',
-                'd_pH': 'set',
-                'PMF': 'set'}}
+                state_id : {
+                    'updater': 'set'}
+                for state_id in set_membrane}}
 
         default_settings = {
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters}
+            'schema': schema}
 
         return default_settings
 

--- a/vivarium/processes/metabolism.py
+++ b/vivarium/processes/metabolism.py
@@ -93,23 +93,23 @@ class Metabolism(Process):
             'external': self.fba.external_molecules,
             'reactions': self.reaction_ids}
 
-        # default updaters
-        set_internal_states = {state_id: 'set'
+        # schema
+        set_internal_states = {state_id: {'updater': 'set'}
             for state_id in self.reaction_ids}
-        accumulate_internal_states = {state_id: 'accumulate'
+        accumulate_internal_states = {state_id: {'updater': 'accumulate'}
             for state_id in self.objective_molecules}
-        default_updaters = {
+        schema = {
             'internal': deep_merge(dict(set_internal_states), accumulate_internal_states),
-            'external': {mol_id: 'accumulate' for mol_id in self.fba.external_molecules},
-            'reactions': {rxn_id: 'set' for rxn_id in self.reaction_ids},
-            'exchange': {rxn_id: 'set' for rxn_id in self.fba.external_molecules},
-            'flux_bounds': {rxn_id: 'set' for rxn_id in self.constrained_reaction_ids},
-            'global': {'mass': 'accumulate'}}
+            'external': {mol_id: {'updater': 'accumulate'} for mol_id in self.fba.external_molecules},
+            'reactions': {rxn_id: {'updater': 'set'} for rxn_id in self.reaction_ids},
+            'exchange': {rxn_id: {'updater': 'set'} for rxn_id in self.fba.external_molecules},
+            'flux_bounds': {rxn_id: {'updater': 'set'} for rxn_id in self.constrained_reaction_ids},
+            'global': {'mass': {'updater': 'accumulate'}}}
 
         return {
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters}
+            'schema': schema}
 
     def next_update(self, timestep, states):
 

--- a/vivarium/processes/minimal_expression.py
+++ b/vivarium/processes/minimal_expression.py
@@ -56,9 +56,6 @@ class MinimalExpression(Process):
         # default emitter keys
         default_emitter_keys = {'internal': self.internal_states}
 
-        # default updaters
-        default_updaters = {}
-
         deriver_setting = [{
             'type': 'counts_to_mmol',
             'source_role': 'internal',
@@ -68,7 +65,6 @@ class MinimalExpression(Process):
         default_settings = {
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters,
             'deriver_setting': deriver_setting}
 
         return default_settings

--- a/vivarium/processes/ode_expression.py
+++ b/vivarium/processes/ode_expression.py
@@ -167,9 +167,9 @@ def get_flagella_expression():
             'flag_RNA': 30},
         'internal': {
             'flagella': 0,
-            'flag_RNA': 0},
-        'global': {
-            'volume': 1.2}}
+            'flag_RNA': 0}}
+        # 'global': {
+        #     'volume': 1.2}}
 
     return  {
         'transcription_rates': transcription,

--- a/vivarium/processes/ode_expression.py
+++ b/vivarium/processes/ode_expression.py
@@ -54,11 +54,18 @@ class ODE_expression(Process):
         # default state
         default_state = self.initial_state
 
+        # schema
+        # don't include if it uses the default
+        schema = {
+            'internal': {
+                state : {
+                    'divide': 'set',
+                    'units': 'mmol',
+                    'updater': 'delta'}
+                for state in self.roles['internal']}}
+
         # default emitter keys
         default_emitter_keys = {}
-
-        # default updaters
-        default_updaters = {}
 
         # default derivers
         deriver_setting = [{
@@ -70,7 +77,7 @@ class ODE_expression(Process):
         default_settings = {
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters,
+            'schema': schema,
             'deriver_setting': deriver_setting}
 
         return default_settings

--- a/vivarium/processes/ode_expression.py
+++ b/vivarium/processes/ode_expression.py
@@ -61,7 +61,7 @@ class ODE_expression(Process):
                 state : {
                     'divide': 'set',
                     'units': 'mmol',
-                    'updater': 'delta'}
+                    'updater': 'accumulate'}
                 for state in self.roles['internal']}}
 
         # default emitter keys

--- a/vivarium/processes/template_process.py
+++ b/vivarium/processes/template_process.py
@@ -47,14 +47,26 @@ class Template(Process):
             'internal': ['states'],
             'external': ['states']}
 
-        # default updaters
-        default_updaters = {'state': 'accumulate'}
+        # schema -- define how each state is updater, divided, and its units
+        schema = {
+            'internal': {
+                state_id : {
+                    'updater': 'accumulate'}
+                for state_id in self.roles['internal']}}
+
+        # default derivers -- create a new derived role for these roles: keys
+        deriver_setting = [{
+            'type': 'mmol_to_counts',
+            'source_role': 'internal',
+            'derived_role': 'counts',
+            'keys': self.roles['internal']}]
 
         default_settings = {
             'process_id': 'template',
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters,
+            'schema': schema,
+            'deriver_setting': deriver_setting,
             'time_step': 1.0}
 
         return default_settings

--- a/vivarium/processes/transcription.py
+++ b/vivarium/processes/transcription.py
@@ -135,24 +135,26 @@ class Transcription(Process):
             'molecules': self.monomer_ids + [UNBOUND_RNAP_KEY],
             'transcripts': operons}
 
-        default_updaters = {
+        # schema
+        set_states = [
+            'sequence',
+            'genes',
+            'promoters',
+            'domains',
+            'root_domain',
+            'promoter_order',
+            'rnap_id',
+            'rnaps']
+        schema = {
             'chromosome': {
-                'sequence': 'set',
-                'genes': 'set',
-                'promoters': 'set',
-                'domains': 'set',
-                'root_domain': 'set',
-                'promoter_order': 'set',
-                'rnap_id': 'set',
-                'rnaps': 'set'},
-            'molecules': {},
-            'transcripts': {},
-            'factors': {}}
+                state_id : {
+                    'updater': 'set'}
+                for state_id in set_states}}
 
         return {
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters,
+            'set_states': set_states,
             'parameters': self.parameters}
 
     def next_update(self, timestep, states):

--- a/vivarium/processes/translation.py
+++ b/vivarium/processes/translation.py
@@ -155,16 +155,15 @@ class Translation(Process):
             'transcripts': operons,
             'proteins': self.protein_ids}
 
-        default_updaters = {
-            'ribosomes': {'ribosomes': 'set'},
-            'molecules': {},
-            'transcripts': {},
-            'proteins': {}}
+        # schema
+        schema = {
+            'ribosomes': {
+                'ribosomes': {'updater': 'set'}}}
 
         return {
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters,
+            'schema': schema,
             'parameters': self.parameters}
 
     def next_update(self, timestep, states):

--- a/vivarium/processes/transport_lookup.py
+++ b/vivarium/processes/transport_lookup.py
@@ -98,16 +98,17 @@ class TransportLookup(Process):
             'external': self.external_molecule_ids,
             'exchange': []}
 
-        # default updaters
-        default_updaters = {
-            'internal': {},  # reactions set values directly
-            'external': {},  # reactions set values directly
-            'exchange': {mol_id: 'accumulate' for mol_id in self.external_molecule_ids}}  # all external values use default 'delta' udpater
+        # schema
+        schema = {
+            'exchange': {
+                mol_id : {
+                    'updater': 'accumulate'}
+                for mol_id in self.external_molecule_ids}}
 
         default_settings = {
             'state': default_state,
             'emitter_keys': default_emitter_keys,
-            'updaters': default_updaters}
+            'schema': schema}
 
         return default_settings
 

--- a/vivarium/utils/dict_utils.py
+++ b/vivarium/utils/dict_utils.py
@@ -23,9 +23,9 @@ def deep_merge_check(dct, merge_dct):
             try:
                 deep_merge_check(dct[k], merge_dct[k])
             except:
-                raise Exception('merge dictionary error: {} AND {}'.format(dct[k], merge_dct[k]))
+                raise Exception('dict merge mismatch: key "{}" has values {} AND {}'.format(k, dct[k], merge_dct[k]))
         elif k in dct and (dct[k] is not merge_dct[k]):
-            raise Exception
+            raise Exception('dict merge mismatch: key "{}" has values {} AND {}'.format(k, dct[k], merge_dct[k]))
         else:
             dct[k] = merge_dct[k]
     return dct

--- a/vivarium/utils/dict_utils.py
+++ b/vivarium/utils/dict_utils.py
@@ -11,6 +11,25 @@ def merge_dicts(dicts):
         merge.update(d)
     return merge
 
+def deep_merge_check(dct, merge_dct):
+    '''
+    Recursive dict merge, which throws exceptions for conflicting values
+    This mutates dct - the contents of merge_dct are added to dct (which is also returned).
+    If you want to keep dct you could call it like deep_merge(dict(dct), merge_dct)'''
+
+    for k, v in merge_dct.items():
+        if (k in dct and isinstance(dct[k], dict)
+                and isinstance(merge_dct[k], collections.Mapping)):
+            try:
+                deep_merge_check(dct[k], merge_dct[k])
+            except:
+                raise Exception('merge dictionary error: {} AND {}'.format(dct[k], merge_dct[k]))
+        elif k in dct and (dct[k] is not merge_dct[k]):
+            raise Exception
+        else:
+            dct[k] = merge_dct[k]
+    return dct
+
 def deep_merge(dct, merge_dct):
     '''
     Recursive dict merge


### PR DESCRIPTION
This begins the transition to the schema framework, in which states have a schema for updaters, units, and division. These specify how to update those states, what units are expected (which will also allow us to keep units within the states), and how to divide them upon division.  I'm pacing myself by putting updaters in first. Once all the updaters are working, I'll add in units and division to the schema in a separate PR.