### PR TITLE
multicell physics debug with pygame

### DIFF
--- a/vivarium/environment/lattice.py
+++ b/vivarium/environment/lattice.py
@@ -141,9 +141,11 @@ class EnvironmentSpatialLattice(EnvironmentSimulation):
 
         # make physics object by passing in bounds and jitter
         bounds = [self.edge_length_x, self.edge_length_y]
+        debug_multicell_physics = config.get('debug_multicell_physics', False)
         self.multicell_physics = MultiCellPhysics(
             bounds,
-            jitter_force)
+            jitter_force,
+            debug_multicell_physics)
 
         # configure emitter and emit lattice configuration
         self.emitter = config['emitter'].get('object')
@@ -678,6 +680,7 @@ def test_lattice(config=motile_config):
     jitter_force = config.get('jitter_force', JITTER_FORCE)
     depth = config.get('depth', 0.01)  # 3000 um is default
     motile_cells = config.get('motile_cells', False)  # if True, run/tumble applied to bodies
+    debug_multicell_physics = config.get('debug_multicell_physics', False)
 
     # get emitter
     emitter = get_emitter({'type': 'null'})  # TODO -- is an emitter really necessary?
@@ -690,8 +693,8 @@ def test_lattice(config=motile_config):
         'edge_length_x': edge_length,
         'patches_per_edge_x': patches_per_edge_x,
         'cell_placement': [0.5, 0.5],  # place cells at center of lattice
-        'emitter': emitter
-    }
+        'emitter': emitter,
+        'debug_multicell_physics': debug_multicell_physics}
 
     # configure lattice
     lattice = EnvironmentSpatialLattice(boot_config)
@@ -946,7 +949,8 @@ if __name__ == '__main__':
         'edge_length': 3,
         'jitter_force': 1e-1,
         'patches_per_edge': 1,
-        'motile_cells': False}
+        'motile_cells': False,
+        'debug_multicell_physics': True}
 
     jitter_output = test_lattice(jitter_config)
     plot_trajectory(jitter_output, 'jitter_trajectory', out_dir)
@@ -961,7 +965,8 @@ if __name__ == '__main__':
         'timestep': 0.1,
         'edge_length': 50,
         'jitter_force': 1e-1,
-        'motile_cells': True}
+        'motile_cells': True,
+        'debug_multicell_physics': True}
 
     motile_output = test_lattice(motile_config)
     plot_motility(motile_output, 'motility_state', out_dir)
@@ -973,6 +978,6 @@ if __name__ == '__main__':
     plot_motility(motile_output, 'motility_state_short_ts', out_dir)
     plot_trajectory(motile_output, 'motility_trajectory_short_ts', out_dir)
 
-
+    # test diffusion
     diffusion_out = test_diffusion()
     plot_field(diffusion_out, 'diffusion', out_dir)

--- a/vivarium/utils/multicell_physics.py
+++ b/vivarium/utils/multicell_physics.py
@@ -140,8 +140,8 @@ class MultiCellPhysics(object):
                 body.velocity -= (0.5 * body.velocity * self.physics_dt)
                 body.angular_velocity -= (0.5 * body.angular_velocity * self.physics_dt)
 
-            if self.pygame_viz:
-                self._update_screen()
+        if self.pygame_viz:
+            self._update_screen()
 
     def update_cell(self, cell_id, length, width, mass):
         ''' create a new body and new shape at the cell's same center position and angle '''
@@ -313,18 +313,11 @@ def set_motile_force(physics, agent_id, object_id):
 # For testing with pygame
 if __name__ == '__main__':
 
-    bounds = [20.0, 20.0]
+    total_time = 100
+    time_step = 1
 
-    agent_id = 1
-    volume = 1.0
-    width = 0.5
-    length = 2.0
-    cell_density = 1100
-    mass = volume * cell_density
-    jitter_force = 0.5
-
-    position = (2.0, 2.0)
-    angle = PI/2
+    bounds = [10.0, 10.0]
+    jitter_force = 1.0
 
     # make physics instance
     physics = MultiCellPhysics(
@@ -332,31 +325,44 @@ if __name__ == '__main__':
         jitter_force,
         True)
 
-    # add cell
-    physics.add_cell_from_center(
-        cell_id = agent_id,
-        width = width,
-        length = length,
-        mass = mass,
-        position = position,
-        angle = angle,
-    )
 
-    # add object
-    object_id = 999
-    physics.add_cell_from_center(
-        cell_id=object_id,    # agent_id,
-        width=0.5,          # width
-        length=0.5,          # length
-        mass=100000.0,       # mass
-        position=(14.0, 14.0),     # position
-        angle=0.0,          # angle
-    )
+    # initialize n agents
+    n_agents = 3
+    agent_ids = list(range(n_agents))
 
-    running = True
-    growth = 0.1  # 0.02
-    while running:
-        length += growth
-        physics.update_cell(agent_id, length, width, mass)
-        # set_motile_force(physics, agent_id, object_id)
-        physics.run_incremental(5)
+    # agent initial conditions
+    growth = 0.01
+    volume = 1.0
+    width = 0.5
+    length = 2.0
+    cell_density = 1100
+    mass = volume * cell_density
+
+    # add cells
+    for agent_id in agent_ids:
+        position = np.array([
+            np.random.uniform(0, bounds[0]),
+            np.random.uniform(0, bounds[1])])
+        angle = np.random.uniform(0, 2 * PI)
+
+        physics.add_cell_from_center(
+            cell_id=agent_id,
+            width=width,
+            length=length,
+            mass=mass,
+            center_position=position,
+            angle=angle)
+
+    # run simulation
+    time = 0
+    while time < total_time:
+        time += time_step
+
+        for agent_id in agent_ids:
+            (body, shape) = physics.cells[agent_id]
+            (width, length) = body.dimensions
+            length += growth
+            physics.update_cell(agent_id, length, width, mass)
+            # set_motile_force(physics, agent_id, object_id)
+
+            physics.run_incremental(time_step)

--- a/vivarium/utils/multicell_physics.py
+++ b/vivarium/utils/multicell_physics.py
@@ -109,14 +109,6 @@ class MultiCellPhysics(object):
         for body in self.space.bodies:
             width, length = body.dimensions
 
-            # jitter forces
-            jitter_location = self.random_body_position(body)
-            jitter_force = [
-                random.normalvariate(0, self.jitter_force),
-                random.normalvariate(0, self.jitter_force)]
-            scaled_jitter_force = [force * self.force_scaling for force in jitter_force]
-            body.apply_force_at_local_point(scaled_jitter_force, jitter_location)
-
             # motile forces
             motile_location = (width / 2, 0)  # apply force at back end of body
             motile_torque = 0.0
@@ -124,9 +116,17 @@ class MultiCellPhysics(object):
             if hasattr(body, 'motile_force'):
                 force, motile_torque = body.motile_force
                 motile_force = [force, 0.0]  # force is applied in the positive x-direction (forward)
-            body.angular_velocity = motile_torque
+            body.angular_velocity += motile_torque
             scaled_motile_force = [force * self.force_scaling for force in motile_force]
             body.apply_force_at_local_point(scaled_motile_force, motile_location)
+
+            # jitter forces
+            jitter_location = self.random_body_position(body)
+            jitter_force = [
+                random.normalvariate(0, self.jitter_force),
+                random.normalvariate(0, self.jitter_force)]
+            scaled_jitter_force = [force * self.force_scaling for force in jitter_force]
+            body.apply_force_at_local_point(scaled_jitter_force, jitter_location)
 
         # run physics
         time = 0
@@ -138,7 +138,7 @@ class MultiCellPhysics(object):
             # TODO (Eran) this should be function of viscosity
             for body in self.space.bodies:
                 body.velocity -= (0.5 * body.velocity * self.physics_dt)
-                body.angular_velocity -= (0.5 * body.angular_velocity * self.physics_dt)
+                body.angular_velocity -= (0.1 * body.angular_velocity * self.physics_dt)
 
         if self.pygame_viz:
             self._update_screen()
@@ -317,14 +317,13 @@ if __name__ == '__main__':
     time_step = 1
 
     bounds = [10.0, 10.0]
-    jitter_force = 1.0
+    jitter_force = 5.0e0
 
     # make physics instance
     physics = MultiCellPhysics(
         bounds,
         jitter_force,
         True)
-
 
     # initialize n agents
     n_agents = 3


### PR DESCRIPTION
this adds the option for lattice to use the pygame option in ```multicellular_physics```, which supports live visualization of the cells as the move, grow, and divide in the physics engine.  This helped me debug jitter to support more torque.