### PR TITLE
Schema in Store

### DIFF
--- a/vivarium/compartment/composition.py
+++ b/vivarium/compartment/composition.py
@@ -102,29 +102,6 @@ def get_derivers(process_list, topology):
         'deriver_processes': processes,
         'deriver_topology': deriver_topology}
 
-def get_schema(process_list, topology):
-    schema = {}
-    for level in process_list:
-        for process_id, process in level.items():
-            process_settings = process.default_settings()
-            process_schema = process_settings.get('schema', {})
-            try:
-                port_map = topology[process_id]
-            except:
-                print('{} topology port mismatch'.format(process_id))
-                raise
-
-            # go through each port, and get the schema
-            for process_port, settings in process_schema.items():
-                compartment_port = port_map[process_port]
-                compartment_schema = {
-                    compartment_port: settings}
-
-                ## TODO -- check for mismatch
-                deep_merge_check(schema, compartment_schema)
-
-    return schema
-
 def process_in_compartment(process):
     ''' put a process in a compartment, with all derivers added '''
     process_settings = process.default_settings()
@@ -144,16 +121,12 @@ def process_in_compartment(process):
     topology = {'process': {key: key for key in process_ports}}
     topology.update(deriver_topology)
 
-    # get schema
-    schema = get_schema(processes, topology)
-
     # make the state
     state_dict = process_settings['state']
-    states = initialize_state(processes, topology, schema, state_dict)
+    states = initialize_state(processes, topology, state_dict)
 
     options = {
-        'topology': topology,
-        'schema': schema}  # TODO -- does compartment need schema?
+        'topology': topology}
 
     return Compartment(processes, states, options)
 

--- a/vivarium/compartment/composition.py
+++ b/vivarium/compartment/composition.py
@@ -153,7 +153,7 @@ def process_in_compartment(process):
 
     options = {
         'topology': topology,
-        'schema': schema}
+        'schema': schema}  # TODO -- does compartment need schema?
 
     return Compartment(processes, states, options)
 

--- a/vivarium/composites/PMF_chemotaxis.py
+++ b/vivarium/composites/PMF_chemotaxis.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import os
 
 from vivarium.compartment.process import initialize_state, load_compartment
-from vivarium.compartment.composition import get_derivers, get_schema, simulate_with_environment, \
+from vivarium.compartment.composition import get_derivers, simulate_with_environment, \
     convert_to_timeseries, plot_simulation_output
 
 # processes
@@ -84,16 +84,12 @@ def compose_pmf_chemotaxis(config):
     processes.extend(derivers['deriver_processes'])  # add deriver processes
     topology.update(derivers['deriver_topology'])  # add deriver topology
 
-    # get schema
-    schema = get_schema(processes, topology)
-
     # initialize the states
-    states = initialize_state(processes, topology, schema, config.get('initial_state', {}))
+    states = initialize_state(processes, topology, config.get('initial_state', {}))
 
     options = {
         'name': 'PMF_chemotaxis_composite',
         'topology': topology,
-        'schema': schema,
         'initial_time': config.get('initial_time', 0.0),
         'environment_port': 'environment',
         'exchange_port': 'exchange',

--- a/vivarium/composites/gene_expression.py
+++ b/vivarium/composites/gene_expression.py
@@ -5,7 +5,7 @@ import os
 import matplotlib.pyplot as plt
 
 from vivarium.compartment.process import initialize_state
-from vivarium.compartment.composition import get_derivers, get_schema
+from vivarium.compartment.composition import get_derivers
 
 # processes
 from vivarium.processes.transcription import Transcription, UNBOUND_RNAP_KEY
@@ -56,18 +56,14 @@ def compose_gene_expression(config):
     processes.extend(derivers['deriver_processes'])  # add deriver processes
     topology.update(derivers['deriver_topology'])  # add deriver topology
 
-    # get schema
-    schema = get_schema(processes, topology)
-
     # initialize the states
-    states = initialize_state(processes, topology, schema, config.get('initial_state', {}))
+    states = initialize_state(processes, topology, config.get('initial_state', {}))
 
     options = {
         'name': 'gene_expression_composite',
         'environment_port': 'environment',
         'exchange_port': 'exchange',
         'topology': topology,
-        'schema': schema,
         'initial_time': config.get('initial_time', 0.0),
         'divide_condition': divide_condition}
 

--- a/vivarium/composites/growth_division.py
+++ b/vivarium/composites/growth_division.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import os
 
 from vivarium.compartment.process import initialize_state
-from vivarium.compartment.composition import get_derivers, get_schema
+from vivarium.compartment.composition import get_derivers
 
 # processes
 from vivarium.processes.growth import Growth
@@ -51,18 +51,14 @@ def compose_growth_division(config):
     processes.extend(derivers['deriver_processes'])  # add deriver processes
     topology.update(derivers['deriver_topology'])  # add deriver topology
 
-    # get schema
-    schema = get_schema(processes, topology)
-
     # initialize the states
-    states = initialize_state(processes, topology, schema, config.get('initial_state', {}))
+    states = initialize_state(processes, topology, config.get('initial_state', {}))
 
     options = {
         'name': 'growth_division_composite',
         'environment_port': 'environment',
         'exchange_port': 'exchange',
         'topology': topology,
-        'schema': schema,
         'initial_time': config.get('initial_time', 0.0),
         'divide_condition': divide_condition}
 

--- a/vivarium/composites/master.py
+++ b/vivarium/composites/master.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import os
 
 from vivarium.compartment.process import initialize_state
-from vivarium.compartment.composition import get_derivers, get_schema
+from vivarium.compartment.composition import get_derivers
 
 # processes
 from vivarium.processes.division import Division, divide_condition
@@ -96,18 +96,14 @@ def compose_master(config):
     processes.extend(derivers['deriver_processes'])  # add deriver processes
     topology.update(derivers['deriver_topology'])  # add deriver topology
 
-    # get schema
-    schema = get_schema(processes, topology)
-
     # initialize the states
-    states = initialize_state(processes, topology, schema, config.get('initial_state', {}))
+    states = initialize_state(processes, topology, config.get('initial_state', {}))
 
     options = {
         'name': config.get('name', 'master_composite'),
         'environment_port': 'environment',
         'exchange_port': 'exchange',
         'topology': topology,
-        'schema': schema,
         'initial_time': config.get('initial_time', 0.0),
         'divide_condition': divide_condition}
 

--- a/vivarium/composites/ode_expression.py
+++ b/vivarium/composites/ode_expression.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import os
 
 from vivarium.compartment.process import initialize_state, load_compartment
-from vivarium.compartment.composition import get_derivers, get_schema, simulate_with_environment, \
+from vivarium.compartment.composition import get_derivers, simulate_with_environment, \
     convert_to_timeseries, plot_simulation_output
 
 # processes
@@ -77,18 +77,14 @@ def compose_ode_expression(config):
     processes.extend(derivers['deriver_processes'])  # add deriver processes
     topology.update(derivers['deriver_topology'])  # add deriver topology
 
-    # get schema
-    schema = get_schema(processes, topology)
-
     # Initialize the states
-    states = initialize_state(processes, topology, schema, config.get('initial_state', {}))
+    states = initialize_state(processes, topology, config.get('initial_state', {}))
 
     options = {
         'name': config.get('name', 'master_composite'),
         'environment_port': 'environment',
         'exchange_port': 'exchange',
         'topology': topology,
-        'schema': schema,
         'initial_time': config.get('initial_time', 0.0),
         'divide_condition': divide_condition}
 

--- a/vivarium/composites/simple_chemotaxis.py
+++ b/vivarium/composites/simple_chemotaxis.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 from vivarium.compartment.process import initialize_state, get_compartment_timestep
-from vivarium.compartment.composition import get_schema
 
 # processes
 from vivarium.processes.Endres2006_chemoreceptor import ReceptorCluster
@@ -32,11 +31,8 @@ def compose_simple_chemotaxis(config):
             'external': 'environment',
             'internal': 'cell'}}
 
-    # get schema
-    schema = get_schema(processes, topology)
-
     # initialize the states
-    states = initialize_state(processes, topology, schema, config.get('initial_state', {}))
+    states = initialize_state(processes, topology, config.get('initial_state', {}))
 
     # get the time step
     time_step = get_compartment_timestep(processes)
@@ -44,7 +40,6 @@ def compose_simple_chemotaxis(config):
     options = {
         'name': 'simple_chemotaxis_composite',
         'topology': topology,
-        'schema': schema,
         'initial_time': config.get('initial_time', 0.0),
         'time_step': time_step,
         'environment_port': 'environment',

--- a/vivarium/composites/variable_flagella.py
+++ b/vivarium/composites/variable_flagella.py
@@ -5,7 +5,7 @@ import os
 import random
 
 from vivarium.compartment.process import initialize_state
-from vivarium.compartment.composition import get_derivers, get_schema
+from vivarium.compartment.composition import get_derivers
 
 # processes
 from vivarium.processes.Endres2006_chemoreceptor import ReceptorCluster
@@ -70,17 +70,13 @@ def compose_variable_flagella(config):
     processes.extend(derivers['deriver_processes'])  # add deriver processes
     topology.update(derivers['deriver_topology'])  # add deriver topology
 
-    # get schema
-    schema = get_schema(processes, topology)
-
     # initialize the states
-    states = initialize_state(processes, topology, schema, config.get('initial_state', {}))
+    states = initialize_state(processes, topology, config.get('initial_state', {}))
 
     options = {
         'environment_port': 'environment',
         # 'exchange_port': 'exchange',
         'topology': topology,
-        'schema': schema,
         'initial_time': config.get('initial_time', 0.0),
         'divide_condition': divide_condition}
 

--- a/vivarium/environment/lattice_compartment.py
+++ b/vivarium/environment/lattice_compartment.py
@@ -200,8 +200,11 @@ def simulate_lattice_compartment(compartment, settings={}):
     while time < total_time:
         time += timestep
         compartment.update(timestep)
-        compartment.generate_inner_update()
         saved_state[time] = compartment.current_state()
+
+        values = compartment.generate_inner_update()
+        if 'division' in values:
+            break
 
     return saved_state
 
@@ -284,11 +287,7 @@ def divide_composite(config):
         'keys': {
             'cell': ['MASS']}})
 
-    # schema for states
-    schema = {}
-
     options = {
-        'schema': schema,
         'emitter': emitter,
         'topology': topology,
         'initial_time': 0.0,
@@ -314,6 +313,10 @@ def test_divide(composite=divide_composite):
         'total_time': 20}
 
     saved_state = simulate_lattice_compartment(lattice_compartment, settings)
+
+    # assert division
+    times = list(saved_state.keys())
+    assert saved_state[times[-1]]['cell']['division'] == 1
     return saved_state
 
 if __name__ == '__main__':

--- a/vivarium/environment/lattice_compartment.py
+++ b/vivarium/environment/lattice_compartment.py
@@ -52,7 +52,7 @@ class LatticeCompartment(Compartment, Simulation):
         self.division_port = False
         for port, state in states.items():
             state_ids = state.keys()
-            assert 'volume' in state_ids, 'no port contains volume'
+            assert 'volume' in state_ids, 'no port includes volume'
             self.volume_port = port
             if all(item in state_ids for item in ['motile_force', 'motile_torque']):
                 self.motile_port = port

--- a/vivarium/environment/lattice_compartment.py
+++ b/vivarium/environment/lattice_compartment.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 import uuid
 
-from vivarium.compartment.process import Compartment, initialize_state, get_compartment_timestep
+from vivarium.compartment.process import Compartment, initialize_state, get_compartment_timestep, load_compartment, \
+    Process, Store
 from vivarium.compartment.emitter import get_emitter
 from vivarium.actor.inner import Simulation
 from vivarium.compartment.composition import get_derivers
@@ -51,8 +52,8 @@ class LatticeCompartment(Compartment, Simulation):
         self.division_port = False
         for port, state in states.items():
             state_ids = state.keys()
-            if 'volume' in state_ids:
-                self.volume_port = port
+            assert 'volume' in state_ids, 'no port contains volume'
+            self.volume_port = port
             if all(item in state_ids for item in ['motile_force', 'motile_torque']):
                 self.motile_port = port
             if 'division' in state_ids:
@@ -178,3 +179,144 @@ def generate_lattice_compartment(process, config):
 
     # create the lattice compartment
     return LatticeCompartment(processes_layers, states, options)
+
+
+
+## functions for testing
+def simulate_lattice_compartment(compartment, settings={}):
+    '''
+    run a compartment simulation
+    '''
+
+    timestep = settings.get('timestep', 1)
+    total_time = settings.get('total_time', 10)
+
+    # save initial state
+    time = 0
+    saved_state = {}
+    saved_state[time] = compartment.current_state()
+
+    # run simulation
+    while time < total_time:
+        time += timestep
+        compartment.update(timestep)
+        compartment.generate_inner_update()
+        saved_state[time] = compartment.current_state()
+
+    return saved_state
+
+
+def divide_composite(config):
+
+    def divide_condition(compartment):
+        division_port = compartment.division_port
+        division = compartment.states[division_port].state_for(['division'])
+        if division.get('division', 0) == 0:  # 0 means false
+            divide = False
+        else:
+            divide = True
+        return divide
+
+    # toy processes
+    class ToyGrowth(Process):
+        def __init__(self, initial_parameters={}):
+            ports = {'pool': ['MASS', 'volume']}
+            parameters = {
+                'growth_rate': 0.1}
+            parameters.update(initial_parameters)
+
+            super(ToyGrowth, self).__init__(ports, parameters)
+
+        def next_update(self, timestep, states):
+            mass = states['pool']['MASS']
+            volume = states['pool']['volume']
+            new_mass = mass * self.parameters['growth_rate'] * timestep
+            new_volume = volume * self.parameters['growth_rate'] * timestep
+            return {
+                'pool':
+                    {'MASS': new_mass,
+                     'volume': new_volume}}
+
+    class ToyDivide(Process):
+        def __init__(self, initial_parameters={}):
+            self.division = 0
+            ports = {'pool': ['MASS', 'division']}
+            parameters = {
+                'division_mass': 20}
+            parameters.update(initial_parameters)
+
+            super(ToyDivide, self).__init__(ports, parameters)
+
+        def next_update(self, timestep, states):
+            mass = states['pool']['MASS']
+
+            if mass >= self.parameters['division_mass']:
+                self.division = 1
+
+            return {
+                'pool': {
+                    'division': self.division}}
+
+    # declare processes in list
+    processes = [
+        {'growth': ToyGrowth()},
+        {'divide': ToyDivide()}]
+
+    # declare the states
+    states = {
+        'cell': Store(
+            initial_state={'MASS': 10, 'volume': 1, 'division': 0},
+            schema={
+                'division': {
+                    'updater': 'set',
+                    'divide': 'zero'}})}
+
+    # hook up the ports in each process to compartment states
+    topology = {
+        'growth': {
+            'pool': 'cell'},
+        'divide': {
+            'pool': 'cell'}}
+
+    # emitter that prints to the terminal
+    emitter = get_emitter({
+        'type': 'print',
+        'keys': {
+            'cell': ['MASS']}})
+
+    # schema for states
+    schema = {}
+
+    options = {
+        'schema': schema,
+        'emitter': emitter,
+        'topology': topology,
+        'initial_time': 0.0,
+        'divide_condition': divide_condition}
+
+    return {
+        'processes': processes,
+        'states': states,
+        'options': options}
+
+def test_divide(composite=divide_composite):
+    # set up the the composite
+    composite_config = composite({})
+    processes = composite_config['processes']
+    states = composite_config['states']
+    options = composite_config['options']
+    # topology = options['topology']
+
+    lattice_compartment = LatticeCompartment(processes, states, options)
+
+    settings = {
+        'timestep': 1,
+        'total_time': 20}
+
+    saved_state = simulate_lattice_compartment(lattice_compartment, settings)
+    return saved_state
+
+if __name__ == '__main__':
+    saved_state = test_divide()
+    for time, state in saved_state.items():
+        print('{}: {}'.format(time,state))


### PR DESCRIPTION
This PR moves ```schema``` from ```Compartment``` to ```Store``` and introduces a test for ```lattice_compartment```.  ```schema``` defines properties of state variables such as dividers, updaters; units and mass are coming soon.  As such, it is a better fit in Store, which contains the state variables.  One simplification has ```initialize_state``` get the schema with ```get_schema```, rather than having schema created within the composite functions.  The test in ```lattice_compartment``` makes a simple compartment that includes a ```divide_condition```; this allowed me to test that dividers are working properly