### PR TITLE
emit frequency in lattice

### DIFF
--- a/vivarium/actor/boot.py
+++ b/vivarium/actor/boot.py
@@ -67,16 +67,16 @@ class BootAgent(object):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--id',
+            '-i', '--id',
             required=True,
             help='id of the new agent')
 
         parser.add_argument(
-            '--outer-id',
+            '-o', '--outer-id',
             help="ID of the new agent's outer environment agent")
 
         parser.add_argument(
-            '--type',
+            '-t', '--type',
             required=True,
             choices=self.agent_types,
             help='type of the new agent')

--- a/vivarium/environment/boot.py
+++ b/vivarium/environment/boot.py
@@ -291,6 +291,7 @@ def initialize_measp(boot_config):
         'emit_fields': ['MeAsp'],
         'run_for': 1.0,
         'static_concentrations': True,
+        'emit_frequency': 5,
         'gradient': {
             'type': 'linear',
             'molecules': {
@@ -324,6 +325,7 @@ def initialize_measp_long(boot_config):
         'emit_fields': ['GLC','MeAsp'],
         'run_for': 0.05,  # high coupling between cell and env requires short exchange timestep
         'static_concentrations': True,
+        'emit_frequency': 5,
         'cell_placement': [0.05, 0.5],  # place cells at bottom of gradient
         'gradient': {
             'type': 'linear',

--- a/vivarium/environment/lattice.py
+++ b/vivarium/environment/lattice.py
@@ -151,6 +151,8 @@ class EnvironmentSpatialLattice(EnvironmentSimulation):
         self.emitter = config['emitter'].get('object')
         self.emit_fields = config.get('emit_fields', [])
         self.emit_indices = [self._molecule_ids.index(mol_id) for mol_id in self.emit_fields]
+        self.emit_frequency = config.get('emit_frequency', 0) # emit every N steps
+        self.emit_step = 0
         self.emit_configuration()
 
 
@@ -513,38 +515,40 @@ class EnvironmentSpatialLattice(EnvironmentSimulation):
 
     # Emitters
     def emit_data(self):
+        if self.emit_step == self.emit_frequency:
+            self.emit_step = 0
 
-        # emit lattice data
-        emit_fields = {}
-        for index, molecule_id in zip(self.emit_indices, self.emit_fields):
-            emit_fields[molecule_id] = self.lattice[index].tolist()
-        data = {
-            'type': 'lattice-fields',
-            'fields': emit_fields,
-            'time': self.time()}
-        emit_config = {
-            'table': 'history',
-            'data': data}
-        self.emitter.emit(emit_config)
-
-        # emit data for each agent
-        for agent_id, simulation in self.simulations.items():
-            agent_location = self.locations[agent_id].tolist()  # [x, y, theta]
-            agent_state = self.simulations[agent_id]['state']
+            # emit lattice data
+            emit_fields = {}
+            for index, molecule_id in zip(self.emit_indices, self.emit_fields):
+                emit_fields[molecule_id] = self.lattice[index].tolist()
             data = {
-                'type': 'lattice-agent',
-                'agent_id': agent_id,
-                'location': agent_location,
-                'volume': agent_state['volume'],
-                'width': agent_state['width'],
-                'length': agent_state['length'],
+                'type': 'lattice-fields',
+                'fields': emit_fields,
                 'time': self.time()}
-
             emit_config = {
                 'table': 'history',
                 'data': data}
-
             self.emitter.emit(emit_config)
+
+            # emit data for each agent
+            for agent_id, simulation in self.simulations.items():
+                agent_location = self.locations[agent_id].tolist()  # [x, y, theta]
+                agent_state = self.simulations[agent_id]['state']
+                data = {
+                    'type': 'lattice-agent',
+                    'agent_id': agent_id,
+                    'location': agent_location,
+                    'volume': agent_state['volume'],
+                    'width': agent_state['width'],
+                    'length': agent_state['length'],
+                    'time': self.time()}
+                emit_config = {
+                    'table': 'history',
+                    'data': data}
+                self.emitter.emit(emit_config)
+        else:
+            self.emit_step += 1
 
     def emit_configuration(self):
         data = {


### PR DESCRIPTION
This PR adds the option to set ```emit_frequency``` in ```lattice```. Up to now, we have been emitting the fields and agent locations at every time step; this results in a large amount of data in the database, much of it redundant between time steps.  Reducing the frequency of emits will reduce the memory load on the DB and reduce analysis run time.