### PR TITLE
multiple agent types in experiment

### DIFF
--- a/vivarium/analysis/motor.py
+++ b/vivarium/analysis/motor.py
@@ -90,7 +90,10 @@ class Motor(Analysis):
             previous_motor_state = m_state
 
         avg_speed = sum(speed_vec) / len(speed_vec)
-        avg_angle_between_runs = sum(angle_between_runs) / len(angle_between_runs)
+        try:
+            avg_angle_between_runs = sum(angle_between_runs) / len(angle_between_runs)
+        except:
+            avg_angle_between_runs = 0
 
         # get length of runs, tumbles
         run_lengths = []

--- a/vivarium/environment/control.py
+++ b/vivarium/environment/control.py
@@ -16,7 +16,7 @@ class ShepherdControl(ActorControl):
     def add_cell(self, agent_type, actor_config):
         # TODO(jerry): Bring back the --variant choice?
         self.add_agent(
-            str(uuid.uuid1()),
+            agent_type + '-' + str(uuid.uuid1()),
             agent_type,
             actor_config)
 

--- a/vivarium/environment/control.py
+++ b/vivarium/environment/control.py
@@ -25,38 +25,38 @@ class ShepherdControl(ActorControl):
         lattice_config = exp_config.get('lattice_config')
         environment_type = exp_config.get('environment_type')
         actor_config = exp_config.get('actor_config')
-        agent_type = exp_config.get('agent_type')
-        num_cells = exp_config.get('num_cells', 1)
         actor_config['boot_config'].update(lattice_config)
+        agents = exp_config['agents']
 
         # get from args
         experiment_id = args.get('experiment_id')
-        number = args.get('number')
-        if number == 0:
-            number = num_cells
         if not experiment_id:
             experiment_id = self.get_experiment_id(default_experiment_id)
 
-        print('Creating experiment id {}: {} {} agents in {} environment\n'.format(
-            experiment_id, number, agent_type, environment_type))
+        print('Creating experiment id {}: {} environment, with agents {}\n'.format(
+            experiment_id, environment_type, agents))
 
         # boot environment
         self.add_agent(experiment_id, environment_type, actor_config)
         time.sleep(10) # wait for the environment to boot
 
         # boot agents
-        for index in range(number):
-            self.add_cell(agent_type or args['type'], dict(actor_config, **{
-                'boot': 'vivarium.environment.boot',
-                'outer_id': experiment_id,
-                'working_dir': args['working_dir'],
-                'seed': index}))
+        index = 0
+        for agent_type, number in agents.items():
+            for agent in range(number):
+                self.add_cell(agent_type or args['type'], dict(actor_config, **{
+                    'boot': 'vivarium.environment.boot',
+                    'outer_id': experiment_id,
+                    'working_dir': args['working_dir'],
+                    'seed': index}))
+                index += 1
 
     def lattice_experiment(self, args, actor_config):
         # define experiment: environment type and agent type
         experiment_id = 'lattice_experiment'
         environment_type = 'lattice'
-        agent_type = 'growth_division'
+        agents = {
+            'growth_division': 1}
 
         # overwrite default environment config
         lattice_config = {
@@ -68,8 +68,7 @@ class ShepherdControl(ActorControl):
             'lattice_config': lattice_config,
             'environment_type': environment_type,
             'actor_config': actor_config,
-            'agent_type': agent_type,
-            'num_cells': 1}
+            'agents': agents}
 
         self.init_experiment(args, exp_config)
 
@@ -78,7 +77,8 @@ class ShepherdControl(ActorControl):
         # define experimental environment and agents
         experiment_id = 'growth_division'
         environment_type = 'lattice'
-        agent_type = 'growth_division'
+        agents = {
+            'growth_division': 1}
 
         # overwrite default environment config
         lattice_config = {
@@ -90,8 +90,7 @@ class ShepherdControl(ActorControl):
             'lattice_config': lattice_config,
             'environment_type': environment_type,
             'actor_config': actor_config,
-            'agent_type': agent_type,
-            'num_cells': 1}
+            'agents': agents}
 
         self.init_experiment(args, exp_config)
 
@@ -100,7 +99,8 @@ class ShepherdControl(ActorControl):
         # define experiment: environment type and agent type
         experiment_id = 'gluc-lact'
         environment_type = 'ecoli_core_glc'
-        agent_type = 'shifter'
+        agents = {
+            'shifter': 2}
 
         # overwrite default environment config
         lattice_config = {
@@ -116,8 +116,7 @@ class ShepherdControl(ActorControl):
             'lattice_config': lattice_config,
             'environment_type': environment_type,
             'actor_config': actor_config,
-            'agent_type': agent_type,
-            'num_cells': 2}
+            'agents': agents}
 
         self.init_experiment(args, exp_config)
 
@@ -125,7 +124,9 @@ class ShepherdControl(ActorControl):
         # define experiment: environment type and agent type
         experiment_id = 'chemotaxis'
         environment_type = 'measp'
-        agent_type = 'minimal_chemotaxis'
+        agents = {
+            'minimal_chemotaxis': 4}
+
 
         # overwrite default environment config
         lattice_config = {
@@ -139,8 +140,7 @@ class ShepherdControl(ActorControl):
             'lattice_config': lattice_config,
             'environment_type': environment_type,
             'actor_config': actor_config,
-            'agent_type': agent_type,
-            'num_cells': 4}
+            'agents': agents}
 
         self.init_experiment(args, exp_config)
 
@@ -148,7 +148,8 @@ class ShepherdControl(ActorControl):
         # define experiment: environment type and agent type
         experiment_id = 'chemotaxis'
         environment_type = 'measp'
-        agent_type = 'minimal_chemotaxis'
+        agents = {
+            'minimal_chemotaxis': 4}
 
         # overwrite default environment config
         lattice_config = {
@@ -162,8 +163,7 @@ class ShepherdControl(ActorControl):
             'lattice_config': lattice_config,
             'environment_type': environment_type,
             'actor_config': actor_config,
-            'agent_type': agent_type,
-            'num_cells': 4}
+            'agents': agents}
 
         self.init_experiment(args, exp_config)
 
@@ -171,7 +171,9 @@ class ShepherdControl(ActorControl):
         # define experiment: environment type and agent type
         experiment_id = 'chemotaxis'
         environment_type = 'measp_long'
-        agent_type = 'minimal_chemotaxis'
+        agents = {
+            'minimal_chemotaxis': 1,
+            'motor': 1}
 
         # overwrite default environment config
         lattice_config = {
@@ -185,8 +187,7 @@ class ShepherdControl(ActorControl):
             'lattice_config': lattice_config,
             'environment_type': environment_type,
             'actor_config': actor_config,
-            'agent_type': agent_type,
-            'num_cells': 1}
+            'agents': agents}
 
         self.init_experiment(args, exp_config)
 
@@ -194,21 +195,20 @@ class ShepherdControl(ActorControl):
         # define experiment: environment type and agent type
         experiment_id = 'swarm'
         environment_type = 'measp_large'
-        agent_type = 'minimal_chemotaxis'
+        agents = {
+            'minimal_chemotaxis': 1}
 
         # overwrite default environment config
         lattice_config = {
             'name': 'swarm_experiment',
-            'description': 'a large experiment for running swarms of chemotactic cells',
-        }
+            'description': 'a large experiment for running swarms of chemotactic cells'}
 
         exp_config = {
             'default_experiment_id': experiment_id,
             'lattice_config': lattice_config,
             'environment_type': environment_type,
             'actor_config': actor_config,
-            'agent_type': agent_type,
-            'num_cells': 1}
+            'agents': agents}
 
         self.init_experiment(args, exp_config)
 

--- a/vivarium/environment/control.py
+++ b/vivarium/environment/control.py
@@ -14,7 +14,6 @@ class ShepherdControl(ActorControl):
         super(ShepherdControl, self).__init__(str(uuid.uuid1()), actor_config)
 
     def add_cell(self, agent_type, actor_config):
-        # TODO(jerry): Bring back the --variant choice?
         self.add_agent(
             agent_type + '-' + str(uuid.uuid1()),
             agent_type,

--- a/vivarium/environment/lattice_compartment.py
+++ b/vivarium/environment/lattice_compartment.py
@@ -59,9 +59,6 @@ class LatticeCompartment(Compartment, Simulation):
             if 'division' in state_ids:
                 self.division_port = port
 
-        if not self.volume_port:
-            print('no port includes volume')
-
         super(LatticeCompartment, self).__init__(processes, states, configuration)
 
     def run_incremental(self, run_until):

--- a/vivarium/environment/lattice_compartment.py
+++ b/vivarium/environment/lattice_compartment.py
@@ -52,12 +52,15 @@ class LatticeCompartment(Compartment, Simulation):
         self.division_port = False
         for port, state in states.items():
             state_ids = state.keys()
-            assert 'volume' in state_ids, 'no port includes volume'
-            self.volume_port = port
+            if 'volume' in state_ids:
+                self.volume_port = port
             if all(item in state_ids for item in ['motile_force', 'motile_torque']):
                 self.motile_port = port
             if 'division' in state_ids:
                 self.division_port = port
+
+        if not self.volume_port:
+            print('no port includes volume')
 
         super(LatticeCompartment, self).__init__(processes, states, configuration)
 


### PR DESCRIPTION
This PR changes how experiments are configured in ```environment/control```, to support multiple agent types.  Previously the experiment included one ```agent_type``` and a ```number``` for how many of them were added.  Now ```agents``` is a dict with ```{agent_type: number}```, and the function ```init_experiment``` boots each one. 

```chemotaxis_experiment``` uses this to boot one chemotaxis agent, and one motor agent.