### PR TITLE
debugging chemotaxis

### DIFF
--- a/vivarium/actor/outer.py
+++ b/vivarium/actor/outer.py
@@ -315,7 +315,7 @@ class Outer(Actor):
             else:
                 # compare the length of each simulation's run
                 ran = np.sort([
-                    math.ceil(simulation['time'])
+                    simulation['time']
                     for simulation
                     in self.simulations.values()])
 

--- a/vivarium/compartment/process.py
+++ b/vivarium/compartment/process.py
@@ -95,8 +95,9 @@ class Store(object):
         # get updaters from schema
         updaters = {}
         for state, state_schema in schema.items():
-            updater = schema[state].get('updater')
-            updaters.update({state: updater})
+            updater = state_schema.get('updater')
+            if updater:
+                updaters.update({state: updater})
         self.updaters = updaters
 
     def keys(self):

--- a/vivarium/compartment/process.py
+++ b/vivarium/compartment/process.py
@@ -94,10 +94,9 @@ class Store(object):
 
         # get updaters from schema
         updaters = {}
-        for state in self.state.keys():
-            if state in schema:
-                updater = schema[state].get('updater')
-                updaters.update({state: updater})
+        for state, state_schema in schema.items():
+            updater = schema[state].get('updater')
+            updaters.update({state: updater})
         self.updaters = updaters
 
     def keys(self):

--- a/vivarium/composites/simple_chemotaxis.py
+++ b/vivarium/composites/simple_chemotaxis.py
@@ -1,6 +1,16 @@
 from __future__ import absolute_import, division, print_function
 
-from vivarium.compartment.process import initialize_state, get_compartment_timestep
+import os
+
+from vivarium.compartment.composition import get_derivers
+from vivarium.compartment.process import (
+    initialize_state,
+    load_compartment,
+    get_compartment_timestep)
+from vivarium.compartment.composition import (
+    simulate_with_environment,
+    convert_to_timeseries,
+    plot_simulation_output)
 
 # processes
 from vivarium.processes.Endres2006_chemoreceptor import ReceptorCluster
@@ -31,22 +41,55 @@ def compose_simple_chemotaxis(config):
             'external': 'environment',
             'internal': 'cell'}}
 
+    # add derivers
+    derivers = get_derivers(processes, topology)
+    processes.extend(derivers['deriver_processes'])  # add deriver processes
+    topology.update(derivers['deriver_topology'])  # add deriver topology
+
     # initialize the states
     states = initialize_state(processes, topology, config.get('initial_state', {}))
-
-    # get the time step
-    time_step = get_compartment_timestep(processes)
 
     options = {
         'name': 'simple_chemotaxis_composite',
         'topology': topology,
         'initial_time': config.get('initial_time', 0.0),
-        'time_step': time_step,
         'environment_port': 'environment',
-        # 'exchange_port': 'exchange',
     }
 
     return {
         'processes': processes,
         'states': states,
         'options': options}
+
+
+if __name__ == '__main__':
+    out_dir = os.path.join('out', 'tests', 'simple_chemotaxis_composite')
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    boot_config = {'emitter': 'null'}
+    compartment = load_compartment(compose_simple_chemotaxis, boot_config)
+
+    # settings for simulation and plot
+    options = compartment.configuration
+    timeline = [(10, {})]
+
+    settings = {
+        'environment_port': options['environment_port'],
+        'environment_volume': 1e-13,  # L
+        'timeline': timeline}
+
+    plot_settings = {
+        'max_rows': 20,
+        'remove_zeros': True,
+        'overlay': {
+            'reactions': 'flux'},
+        'skip_ports': ['prior_state', 'null']}
+
+    # saved_state = simulate_compartment(compartment, settings)
+    saved_data = simulate_with_environment(compartment, settings)
+    del saved_data[0]
+    timeseries = convert_to_timeseries(saved_data)
+    volume_ts = timeseries['global']['volume']
+    print('growth: {}'.format(volume_ts[-1]/volume_ts[0]))
+    plot_simulation_output(timeseries, plot_settings, out_dir)

--- a/vivarium/environment/boot.py
+++ b/vivarium/environment/boot.py
@@ -289,7 +289,7 @@ def initialize_measp(boot_config):
         'new_media': new_media,
         'timeline_str': timeline_str,
         'emit_fields': ['MeAsp'],
-        'run_for': 1.0,
+        'run_for': 0.1,
         'static_concentrations': True,
         'emit_frequency': 20,
         'gradient': {
@@ -323,7 +323,7 @@ def initialize_measp_long(boot_config):
         'new_media': new_media,
         'timeline_str': timeline_str,
         'emit_fields': ['GLC','MeAsp'],
-        'run_for': 0.05,  # high coupling between cell and env requires short exchange timestep
+        'run_for': 0.1,  # high coupling between cell and env requires short exchange timestep
         'static_concentrations': True,
         'emit_frequency': 20,
         'cell_placement': [0.05, 0.5],  # place cells at bottom of gradient
@@ -373,7 +373,7 @@ def initialize_measp_large(boot_config):
         'cell_placement': [0.5, 0.5],  # place cells at center of lattice
         'timeline_str': timeline_str,
         'new_media': new_media,
-        'run_for': 2.0,
+        'run_for': 0.1,
         'emit_fields': ['MeAsp', 'GLC'],
         'static_concentrations': False,
         'diffusion': 0.001,

--- a/vivarium/environment/control.py
+++ b/vivarium/environment/control.py
@@ -126,33 +126,9 @@ class ShepherdControl(ActorControl):
         agents = {
             'minimal_chemotaxis': 4}
 
-
         # overwrite default environment config
         lattice_config = {
             'name': 'chemotaxis square experiment',
-            'description': 'a square environment with a static gradient of glucose and a-methyl-DL-aspartic acid (MeAsp) '
-               'for observing chemotactic cells in action. Optimal chemotaxis is observed in a narrow range '
-               'of CheA activity, where concentration of CheY-P falls into the operating range of flagellar motors.'}
-
-        exp_config = {
-            'default_experiment_id': experiment_id,
-            'lattice_config': lattice_config,
-            'environment_type': environment_type,
-            'actor_config': actor_config,
-            'agents': agents}
-
-        self.init_experiment(args, exp_config)
-
-    def chemotaxis_square(self, args, actor_config):
-        # define experiment: environment type and agent type
-        experiment_id = 'chemotaxis'
-        environment_type = 'measp'
-        agents = {
-            'minimal_chemotaxis': 4}
-
-        # overwrite default environment config
-        lattice_config = {
-            'name': 'chemotaxis experiment square',
             'description': 'a square environment with a static gradient of glucose and a-methyl-DL-aspartic acid (MeAsp) '
                'for observing chemotactic cells in action. Optimal chemotaxis is observed in a narrow range '
                'of CheA activity, where concentration of CheY-P falls into the operating range of flagellar motors.'}

--- a/vivarium/utils/multicell_physics.py
+++ b/vivarium/utils/multicell_physics.py
@@ -75,9 +75,8 @@ def random_body_position(body):
 
 class MultiCellPhysics(object):
     ''''''
-    def __init__(self, bounds, jitter_force, debug=False):
-        self.pygame_scale = 700 / bounds[0]
-        self.pygame_viz = debug
+    def __init__(self, bounds, jitter_force, debug=False, debug_scale=20):
+
         self.elasticity = ELASTICITY
         self.friction = FRICTION
         self.damping = DAMPING
@@ -91,9 +90,14 @@ class MultiCellPhysics(object):
         # Physics
         self.physics_dt = PHYSICS_TS
 
+        # Debugging with pygame
+        self.pygame_viz = debug
+        self.pygame_scale = 1
         if self.pygame_viz:
+            self.pygame_scale = debug_scale
             pygame.init()
-            self._screen = pygame.display.set_mode((710, 710))
+            self._screen = pygame.display.set_mode((
+                int(bounds[0]*self.pygame_scale), int(bounds[1]*self.pygame_scale)))
             self._clock = pygame.time.Clock()
             self._draw_options = pymunk.pygame_util.DrawOptions(self._screen)
 
@@ -261,7 +265,11 @@ class MultiCellPhysics(object):
         width, length = body.dimensions
         corner_position = body.position
         angle = body.angle
-        front_position = front_from_corner(width*self.pygame_scale, length*self.pygame_scale, corner_position, angle)
+        front_position = front_from_corner(
+            width,
+            length,
+            corner_position,
+            angle)
         return np.array([front_position[0] / self.pygame_scale, front_position[1] / self.pygame_scale, angle])
 
     def get_center(self, cell_id):
@@ -276,8 +284,8 @@ class MultiCellPhysics(object):
         center_position = body.position
         angle = body.angle
         corner_position = corner_from_center(
-            width * self.pygame_scale,
-            length * self.pygame_scale,
+            width,
+            length,
             center_position,
             angle)
         return np.array([corner_position[0] / self.pygame_scale, corner_position[1] / self.pygame_scale, angle])
@@ -300,35 +308,8 @@ class MultiCellPhysics(object):
         self.space.add(static_lines)
 
 
+
 # testing functions
-def set_motile_force(physics, agent_id, object_id):
-    body, shape = physics.cells[agent_id]
-    obj_body, obj_shape = physics.cells[object_id]
-
-    obj_position = physics.get_center(object_id)  # obj_body.position
-    position = physics.get_front(agent_id)
-    angle = body.angle
-
-    obj_distance = obj_position - position
-    obj_angle = math.atan2(obj_distance[1],obj_distance[0])
-    obj_relative_angle = obj_angle - angle
-
-    # run/tumble
-    if abs(obj_relative_angle) < PI/4:
-        # run
-        force = 15000.0
-        torque = 0.0
-        print('RUN!')
-    else:
-        # tumble
-        force = 5000.0
-        torque = random.normalvariate(0, 0.02)  #random.uniform(-0.005, 0.005)  #random.uniform(-50000.0, 50000.0)  # random.normalvariate(0, 5000.0) #5000.0 #random.uniform(0.0, 2*PI)
-        print('TUMBLE!')
-
-    physics.update_motile_force(agent_id, force, torque)
-
-
-# For testing with pygame
 if __name__ == '__main__':
 
     total_time = 100
@@ -348,7 +329,7 @@ if __name__ == '__main__':
     agent_ids = list(range(n_agents))
 
     # agent initial conditions
-    growth = 0.01
+    growth = 0.1
     volume = 1.0
     width = 0.5
     length = 2.0
@@ -380,6 +361,4 @@ if __name__ == '__main__':
             (width, length) = body.dimensions
             length += growth
             physics.update_cell(agent_id, length, width, mass)
-            # set_motile_force(physics, agent_id, object_id)
-
             physics.run_incremental(time_step)

--- a/vivarium/utils/multicell_physics.py
+++ b/vivarium/utils/multicell_physics.py
@@ -27,10 +27,27 @@ FRICTION = 0.9  # TODO -- does this do anything?
 PHYSICS_TS = 0.005
 FORCE_SCALING = 17000  # scales from pN
 
+
 def get_force_with_angle(force, angle):
     x = force * math.cos(angle)
     y = force * math.sin(angle)
     return [x, y]
+
+def front_from_corner(width, length, corner_position, angle):
+    half_width = width/2
+    dx = length * math.cos(angle) + half_width * math.cos(angle + PI/2)  # PI/2 gives a half-rotation for the width component
+    dy = length * math.sin(angle) + half_width * math.sin(angle + PI/2)
+    front_position = [corner_position[0] + dx, corner_position[1] + dy]
+    return np.array([front_position[0], front_position[1], angle])
+
+def corner_from_center(width, length, center_position, angle):
+    half_length = length/2
+    half_width = width/2
+    dx = half_length * math.cos(angle) + half_width * math.cos(angle + PI/2)
+    dy = half_length * math.sin(angle) + half_width * math.sin(angle + PI/2)
+    corner_position = [center_position[0] - dx, center_position[1] - dy]
+
+    return np.array([corner_position[0], corner_position[1], angle])
 
 def random_body_position(body):
     ''' pick a random point along the boundary'''
@@ -244,7 +261,7 @@ class MultiCellPhysics(object):
         width, length = body.dimensions
         corner_position = body.position
         angle = body.angle
-        front_position = self.front_from_corner(width*self.pygame_scale, length*self.pygame_scale, corner_position, angle)
+        front_position = front_from_corner(width*self.pygame_scale, length*self.pygame_scale, corner_position, angle)
         return np.array([front_position[0] / self.pygame_scale, front_position[1] / self.pygame_scale, angle])
 
     def get_center(self, cell_id):
@@ -258,28 +275,12 @@ class MultiCellPhysics(object):
         width, length = body.dimensions
         center_position = body.position
         angle = body.angle
-        corner_position = self.corner_from_center(
+        corner_position = corner_from_center(
             width * self.pygame_scale,
             length * self.pygame_scale,
             center_position,
             angle)
         return np.array([corner_position[0] / self.pygame_scale, corner_position[1] / self.pygame_scale, angle])
-
-    def front_from_corner(self, width, length, corner_position, angle):
-        half_width = width/2
-        dx = length * math.cos(angle) + half_width * math.cos(angle + PI/2)  # PI/2 gives a half-rotation for the width component
-        dy = length * math.sin(angle) + half_width * math.sin(angle + PI/2)
-        front_position = [corner_position[0] + dx, corner_position[1] + dy]
-        return np.array([front_position[0], front_position[1], angle])
-
-    def corner_from_center(self, width, length, center_position, angle):
-        half_length = length/2
-        half_width = width/2
-        dx = half_length * math.cos(angle) + half_width * math.cos(angle + PI/2)
-        dy = half_length * math.sin(angle) + half_width * math.sin(angle + PI/2)
-        corner_position = [center_position[0] - dx, center_position[1] - dy]
-
-        return np.array([corner_position[0], corner_position[1], angle])
 
     def add_barriers(self, bounds):
         """ Create static barriers """


### PR DESCRIPTION
I was reworking ```minimal_chemotaxis``` following the recent update to ```multicellular_physics``` in #151, and came upon a few bugs that are fixed here.  The t_exchange for chemotaxis agents needs to be fairly short, to support the high level of coupling between cell and environment. Previously, it appears we were assuming integer time steps in ```outer```.  Also, Store's schema was assuming all states with schema are in the initial_state -- not true, and now fixed.