### PR TITLE
Simple stochastic complexation process for flagella

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,5 +29,5 @@ pytest==4.6.5
 pytest-benchmark==3.2.2
 scipy==1.4.1
 scs==2.0.2
-stochastic-arrow==0.3.0
+stochastic-arrow==0.3.1
 swiglpk==1.4.4

--- a/vivarium/data/chromosomes/flagella_chromosome.py
+++ b/vivarium/data/chromosomes/flagella_chromosome.py
@@ -293,6 +293,12 @@ class FlagellaChromosome(object):
 
         self.transcription_factors = ['flhD', 'CsgD', 'CRP', 'GadE', 'H-NS']
 
+        self.complexation_monomer_ids = [
+            'fliG', 'fliM', 'fliN', 'flhA', 'flhB', 'fliO', 'fliP', 'fliQ', 'fliR', 'fliJ', 'fliI', 'fliH', 'fliL', 'flgH', 'MotA', 'MotB', 'flgB', 'flgC', 'flgF', 'flgG', 'flgI', 'fliF', 'fliE','fliC','flgL','flgK','fliD','flgE']
+
+        self.complexation_complex_ids = [
+            'flagellar motor switch','flagellum', 'flagellar export apparatus', 'flagellar motor']
+
         self.complexation_stoichiometry = {
             'flagellar motor switch reaction': {
                 'flagellar motor switch': 1.0,
@@ -334,7 +340,7 @@ class FlagellaChromosome(object):
                 'fliD': -5.0,
                 'flgE': -120.0}}
 
-        reaction_default = 1.0
+        reaction_default = 1e-30
         self.complexation_rates = {
             'flagellar motor switch reaction': reaction_default,
             'flagellar export apparatus reaction': reaction_default,

--- a/vivarium/data/chromosomes/flagella_chromosome.py
+++ b/vivarium/data/chromosomes/flagella_chromosome.py
@@ -292,3 +292,51 @@ class FlagellaChromosome(object):
             for operon in self.config['genes'].keys()}
 
         self.transcription_factors = ['flhD', 'CsgD', 'CRP', 'GadE', 'H-NS']
+
+        self.complexation_stoichiometry = {
+            'flagellar motor switch reaction': {
+                'flagellar motor switch': 1.0,
+                'fliG': -26.0,
+                'fliM': -34.0,
+                'fliN': -1.0},
+            'flagellar export apparatus reaction': {
+                'flagellar export apparatus': 1.0,
+                'flhA': -1.0,
+                'flhB': -1.0,
+                'fliO': -1.0,
+                'fliP': -1.0,
+                'fliQ': -1.0,
+                'fliR': -1.0,
+                'fliJ': -1.0,
+                'fliI': -6.0,
+                'fliH': -12.0},
+            'flagellar motor reaction': {
+                'flagellar motor': 1.0,
+                'flagellar motor switch': -1.0,
+                'fliL': -2.0,
+                'flgH': -1.0,
+                'MotA': -1.0,
+                'MotB': -1.0,
+                'flgB': -1.0,
+                'flgC': -1.0,
+                'flgF': -1.0,
+                'flgG': -1.0,
+                'flgI': -1.0,
+                'fliF': -1.0,
+                'fliE': -1.0},
+            'flagellum reaction': {
+                'flagellum': 1.0,
+                'flagellar export apparatus': -1.0,
+                'flagellar motor': -1.0,
+                'fliC': -1.0,
+                'flgL': -1.0,
+                'flgK': -1.0,
+                'fliD': -5.0,
+                'flgE': -120.0}}
+
+        reaction_default = 1.0
+        self.complexation_rates = {
+            'flagellar motor switch reaction': reaction_default,
+            'flagellar export apparatus reaction': reaction_default,
+            'flagellar motor reaction': reaction_default,
+            'flagellum reaction': reaction_default}

--- a/vivarium/processes/complexation.py
+++ b/vivarium/processes/complexation.py
@@ -10,8 +10,8 @@ from vivarium.data.chromosomes.flagella_chromosome import FlagellaChromosome
 chromosome = FlagellaChromosome()
 
 default_complexation_parameters = {
-    'monomer_ids': ['fliG', 'fliM', 'fliN', 'flhA', 'flhB', 'fliO', 'fliP', 'fliQ', 'fliR', 'fliJ', 'fliI', 'fliH', 'fliL', 'flgH', 'MotA', 'MotB', 'flgB', 'flgC', 'flgF', 'flgG', 'flgI', 'fliF', 'fliE','fliC','flgL','flgK','fliD','flgE'],
-    'complex_ids': ['flagellar motor switch','flagellum', 'flagellar export apparatus', 'flagellar motor'],
+    'monomer_ids': chromosome.complexation_monomer_ids,
+    'complex_ids': chromosome.complexation_complex_ids,
     'stoichiometry': chromosome.complexation_stoichiometry,
     'rates': chromosome.complexation_rates}
 

--- a/vivarium/processes/complexation.py
+++ b/vivarium/processes/complexation.py
@@ -1,0 +1,126 @@
+from __future__ import absolute_import, division, print_function
+
+import copy
+import numpy as np
+from arrow import StochasticSystem
+
+from vivarium.compartment.process import Process, keys_list
+from vivarium.data.chromosomes.flagella_chromosome import FlagellaChromosome
+
+chromosome = FlagellaChromosome()
+
+default_complexation_parameters = {
+    'monomer_ids': ['fliG', 'fliM', 'fliN', 'flhA', 'flhB', 'fliO', 'fliP', 'fliQ', 'fliR', 'fliJ', 'fliI', 'fliH', 'fliL', 'flgH', 'MotA', 'MotB', 'flgB', 'flgC', 'flgF', 'flgG', 'flgI', 'fliF', 'fliE','fliC','flgL','flgK','fliD','flgE'],
+    'complex_ids': ['flagellar motor switch','flagellum', 'flagellar export apparatus', 'flagellar motor'],
+    'stoichiometry': chromosome.complexation_stoichiometry,
+    'rates': chromosome.complexation_rates}
+
+def build_complexation_stoichiometry(
+        stoichiometry,
+        rates,
+        reaction_ids,
+        monomer_ids,
+        complex_ids):
+
+    molecule_ids = monomer_ids + complex_ids
+    matrix = np.zeros((len(stoichiometry), len(molecule_ids)), dtype=np.int64)
+    rates_array = np.zeros(len(stoichiometry))
+
+    reverse_index = {
+        molecule_id: index
+        for index, molecule_id in enumerate(molecule_ids)}
+
+    for reaction_index, reaction_id in enumerate(reaction_ids):
+        reaction = stoichiometry[reaction_id]
+        rates_array[reaction_index] = rates[reaction_id]
+        for molecule_id, level in reaction.items():
+            matrix[reaction_index][reverse_index[molecule_id]] = level
+
+    return matrix, rates_array
+    
+
+class Complexation(Process):
+    def __init__(self, initial_parameters={}):
+        self.default_parameters = copy.deepcopy(default_complexation_parameters)
+        self.derive_defaults(initial_parameters, 'stoichiometry', 'reaction_ids', keys_list)
+
+        self.parameters = self.default_parameters
+        self.parameters.update(initial_parameters)
+
+        self.monomer_ids = self.parameters['monomer_ids']
+        self.complex_ids = self.parameters['complex_ids']
+        self.reaction_ids = self.parameters['reaction_ids']
+
+        self.stoichiometry = self.parameters['stoichiometry']
+        self.rates = self.parameters['rates']
+
+        self.complexation_stoichiometry, self.complexation_rates = build_complexation_stoichiometry(
+            self.stoichiometry,
+            self.rates,
+            self.reaction_ids,
+            self.monomer_ids,
+            self.complex_ids)
+
+        print(self.complexation_stoichiometry)
+
+        self.complexation = StochasticSystem(self.complexation_stoichiometry)
+
+        self.ports = {
+            'monomers': self.monomer_ids,
+            'complexes': self.complex_ids}
+
+    def default_settings(self):
+        default_state = {
+            'monomers': {monomer_id: 1000 for monomer_id in self.monomer_ids},
+            'complexes': {complex_id: 0 for complex_id in self.complex_ids}}
+
+        return {
+            'state': default_state,
+            'parameters': self.parameters}
+
+    def next_update(self, timestep, states):
+        monomers = states['monomers']
+        complexes = states['complexes']
+
+        substrate = np.zeros(len(self.monomer_ids) + len(self.complex_ids), dtype=np.int64)
+
+        for index, monomer_id in enumerate(self.monomer_ids):
+            substrate[index] = monomers[monomer_id]
+        for index, complex_id in enumerate(self.complex_ids):
+            substrate[index + len(self.monomer_ids)] = complexes[complex_id]
+
+        result = self.complexation.evolve(
+            timestep,
+            substrate,
+            self.complexation_rates)
+
+        print(result)
+
+        outcome = result['outcome'] - substrate
+
+        monomers_update = {
+            monomer_id: outcome[index]
+            for index, monomer_id in enumerate(self.monomer_ids)}
+
+        complexes_update = {
+            complex_id: outcome[index + len(self.monomer_ids)]
+            for index, complex_id in enumerate(self.complex_ids)}
+
+        update = {
+            'monomers': monomers_update,
+            'complexes': complexes_update}
+
+        print('complexation update: {}'.format(update))
+
+        return update
+
+def test_complexation():
+    complexation = Complexation()
+    settings = complexation.default_settings()
+    state = settings['state']
+
+    update = complexation.next_update(1.0, state)
+    print(update)
+
+if __name__ == '__main__':
+    test_complexation()

--- a/vivarium/processes/complexation.py
+++ b/vivarium/processes/complexation.py
@@ -61,8 +61,6 @@ class Complexation(Process):
             self.monomer_ids,
             self.complex_ids)
 
-        print(self.complexation_stoichiometry)
-
         self.complexation = StochasticSystem(self.complexation_stoichiometry)
 
         self.ports = {
@@ -94,8 +92,6 @@ class Complexation(Process):
             substrate,
             self.complexation_rates)
 
-        print(result)
-
         outcome = result['outcome'] - substrate
 
         monomers_update = {
@@ -110,8 +106,6 @@ class Complexation(Process):
             'monomers': monomers_update,
             'complexes': complexes_update}
 
-        print('complexation update: {}'.format(update))
-
         return update
 
 def test_complexation():
@@ -120,7 +114,7 @@ def test_complexation():
     state = settings['state']
 
     update = complexation.next_update(1.0, state)
-    print(update)
+    print('complexation update: {}'.format(update))
 
 if __name__ == '__main__':
     test_complexation()


### PR DESCRIPTION
This introduces a complexation process using Arrow (https://github.com/CovertLab/arrow) for the stochastic simulation of complex formation out of independent monomers. 

This process has two main parameters, `stoichiometry` and `rates`, and three additional supplementary parameters (`monomer_ids`, `complex_ids` and `reaction_ids`) for describing the order of the arrays for translating states into the stochastic simulation. It has two ports, one for `monomers` and one for `complexes`, which could both point to the same `Store` if we just have a general `proteins` store for instance. 

The default process has been configured with the complexation reactions for the flagella, as provided by @eagmon, currently living in `vivarium/data/chromosomes/flagella_chromosome.py`, for want of a better place to put them. 

Sample output:

```
initial state: {'monomers': {'fliG': 1000, 'fliM': 1000, 'fliN': 1000, 'flhA': 1000, 'flhB': 1000, 'fliO': 1000, 'fliP': 1000, 'fliQ': 1000, 'fliR': 1000, 'fliJ': 1000, 'fliI': 1000, 'fliH': 1000, 'fliL': 1000, 'flgH': 1000, 'MotA': 1000, 'MotB': 1000, 'flgB': 1000, 'flgC': 1000, 'flgF': 1000, 'flgG': 1000, 'flgI': 1000, 'fliF': 1000, 'fliE': 1000, 'fliC': 1000, 'flgL': 1000, 'flgK': 1000, 'fliD': 1000, 'flgE': 1000}, 'complexes': {'flagellar motor switch': 0, 'flagellum': 0, 'flagellar export apparatus': 0, 'flagellar motor': 0}}
complexation update: {'monomers': {'fliG': -754, 'fliM': -986, 'fliN': -29, 'flhA': -83, 'flhB': -83, 'fliO': -83, 'fliP': -83, 'fliQ': -83, 'fliR': -83, 'fliJ': -83, 'fliI': -498, 'fliH': -996, 'fliL': -58, 'flgH': -29, 'MotA': -29, 'MotB': -29, 'flgB': -29, 'flgC': -29, 'flgF': -29, 'flgG': -29, 'flgI': -29, 'fliF': -29, 'fliE': -29, 'fliC': -8, 'flgL': -8, 'flgK': -8, 'fliD': -40, 'flgE': -960}, 'complexes': {'flagellar motor switch': 0, 'flagellum': 8, 'flagellar export apparatus': 75, 'flagellar motor': 21}}
```