### PR TITLE
Diffusion process

### DIFF
--- a/vivarium/processes/diffusion.py
+++ b/vivarium/processes/diffusion.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
+import matplotlib.pyplot as plt
 import numpy as np
 from scipy.ndimage import convolve
 
@@ -17,6 +18,52 @@ from vivarium.compartment.composition import (
 LAPLACIAN_2D = np.array([[0.0, 1.0, 0.0], [1.0, -4.0, 1.0], [0.0, 1.0, 0.0]])
 
 
+def make_fields(molecules, n_bins):
+    # Create lattice and fill each site with concentrations dictionary
+    # Molecule identities are defined along the major axis, with spatial dimensions along the other two axes.
+    fields = {}
+    for molecule_id, conc in molecules.items():
+        fields[molecule_id] = np.full((n_bins), conc, dtype=np.float64)
+    return fields
+
+def fields_to_locations(fields, n_bins):
+    bins_x = n_bins[0]
+    bins_y = n_bins[1]
+    locations = {}
+    for x in range(bins_x):
+        for y in range(bins_y):
+            concs = {
+                mol_id: field[x][y]
+                for mol_id, field in fields.items()}
+            locations[(x,y)]= concs
+    return locations
+
+def locations_to_fields(locations, molecule_ids, n_bins):
+    fields = {}
+    for molecule_id in molecule_ids:
+        field = np.empty((n_bins), dtype=np.float64)
+        for x in range(n_bins[0]):
+            for y in range(n_bins[1]):
+                field[x,y] = locations[(x,y)][molecule_id]
+        fields[molecule_id] = field
+    return fields
+
+def field_from_locations_series(locations_series, molecule_ids, n_bins, times):
+    n_times = len(times)
+    field_series = {
+        mol_id: np.zeros((n_times, n_bins[0], n_bins[1]), dtype=np.float64)
+        for mol_id in molecule_ids}
+
+    for molecule_id in molecule_ids:
+        for time_index in range(n_times):
+            field = np.empty((n_bins), dtype=np.float64)
+            for x in range(n_bins[0]):
+                for y in range(n_bins[1]):
+                    field[x, y] = locations_series[(x, y)][molecule_id][time_index]
+            field_series[molecule_id][time_index] = field
+    return field_series
+
+
 
 class Diffusion(Process):
     '''
@@ -27,35 +74,34 @@ class Diffusion(Process):
         # initial state
         initial_state = initial_parameters.get('initial_state', {})
         self.initial_sites = initial_state.get('sites', {})
-        self.initial_membrane = initial_state.get('membrane', {})
+        self.initial_membrane = initial_state.get('membrane_composition', {})
 
         # locations
         self.molecules = initial_parameters.get('molecules', {'glc': 1})
         self.molecule_ids = list(self.molecules.keys())
 
         # membranes
-        self.membranes = initial_parameters.get('membranes', [])
+        self.membrane_locations = initial_parameters.get('membranes', [])
         self.channels = initial_parameters.get('channels', {})
 
         # parameters
         self.length_x = initial_parameters.get('length_x', 2)
-        self.bins_x = initial_parameters.get('bins_x', 2)
         self.length_y = initial_parameters.get('length_y', 1)
-        self.bins_y = initial_parameters.get('bins_y', 1)
+        bins_x = initial_parameters.get('bins_x', 2)
+        bins_y = initial_parameters.get('bins_y', 1)
+        self.n_bins = (bins_x, bins_y)
         self.diffusion = initial_parameters.get('diffusion', 1e-1)
 
-        self.dx = self.length_x / self.bins_x
-        self.dy = self.length_y / self.bins_y
+        self.dx = self.length_x / bins_x
+        self.dy = self.length_y / bins_y
         self.dx2 = self.dx * self.dy
         self.diffusion_dt = 0.5 * self.dx ** 2 * self.dy ** 2 / (2 * self.diffusion * (self.dx ** 2 + self.dy ** 2))
 
         # make fields
-        fields = self.fill_fields(self.molecules)
-
-        # make ports from fields
-        ports = self.make_ports(fields)
+        fields = make_fields(self.molecules, self.n_bins)
+        ports = fields_to_locations(fields, self.n_bins)
         ports.update(
-            {'membrane': list(self.channels.keys())})
+            {'membrane_composition': list(self.channels.keys())})
 
         parameters = {}
         parameters.update(initial_parameters)
@@ -65,74 +111,47 @@ class Diffusion(Process):
 
     def default_settings(self):
         initial_state = {
-            'membrane': self.initial_membrane}
+            'membrane_composition': self.initial_membrane}
         initial_state.update(self.initial_sites)
 
         return {
             'state': initial_state}
 
     def next_update(self, timestep, states):
-        sites = {
+        locations = {
             state_id: concs
-            for state_id, concs in states.items() if state_id is not 'membrane'}
-        fields = self.make_fields(sites)
+            for state_id, concs in states.items() if state_id is not 'membrane_composition'}
+        fields = locations_to_fields(locations, self.molecule_ids, self.n_bins)
+
+        # run diffusion
         field_update = self.run_diffusion(fields, timestep)
-        ports_update = self.make_ports(field_update)
+        locations_update = fields_to_locations(field_update, self.n_bins)
 
-        return ports_update
-
-
-    def make_ports(self, fields):
-        ports = {}
-        for x in range(self.bins_x):
-            for y in range(self.bins_y):
-                concs = {
-                    mol_id: fields[mol_index][x][y]
-                    for mol_index, mol_id in enumerate(self.molecule_ids)}
-                ports[(x,y)]= concs
-        return ports
-
-    def make_fields(self, ports):
-        fields = np.empty((len(self.molecule_ids), self.bins_x, self.bins_y), dtype=np.float64)
-        for (x,y), conc_dict in ports.items():
-            concs = [conc_dict[mol_id] for mol_id in self.molecule_ids]
-            fields[:,x,y] = concs
-        return fields
-
-    def fill_fields(self, molecules={}):
-        # Create lattice and fill each site with concentrations dictionary
-        # Molecule identities are defined along the major axis, with spatial dimensions along the other two axes.
-        fields = np.empty((len(self.molecule_ids), self.bins_x, self.bins_y), dtype=np.float64)
-        for index, molecule_id in enumerate(self.molecule_ids):
-            fields[index].fill(molecules[molecule_id])
-        return fields
-
-
+        return locations_update
 
     # diffusion functions
-    def diffusion_timestep(self, field, dt):
-        ''' calculate concentration changes cause by diffusion'''
-        change_field = self.diffusion * dt * convolve(field, LAPLACIAN_2D, mode='reflect') / self.dx2
+    def diffusion_timestep(self, field):
+        change_field = self.diffusion * self.diffusion_dt * convolve(field, LAPLACIAN_2D, mode='reflect') / self.dx2
         return change_field
 
     def run_diffusion(self, fields, timestep):
-        change_field = np.zeros((len(self.molecule_ids), self.bins_x, self.bins_y), dtype=np.float64)
-        for index in range(len(fields)):
-            field = fields[index]
-            # run diffusion if field is not uniform
-            if len(set(field.flatten())) != 1:
-                t = 0.0
-                while t < timestep:
-                    change_field[index] += self.diffusion_timestep(field, self.diffusion_dt)
-                    t += self.diffusion_dt
+        fields_change = {}
+        for mol_id, field in fields.items():
+            delta = field.copy()
+            t = 0.0
+            while t < timestep:
+                field += self.diffusion_timestep(field)
+                t += self.diffusion_dt
+            delta -= field
+            fields_change[mol_id] = delta
+        return fields_change
 
-        return change_field
 
 
-# testing
+# testing functions
 def get_two_compartment_config():
     initial_state = {
-        'membrane': {
+        'membrane_composition': {
             'porin': 1},
         'sites': {
             (0, 0): {
@@ -159,7 +178,18 @@ def get_two_compartment_config():
         'diffusion': 1e-1}
 
 def get_cell_config():
+    initial_state = {
+        'membrane_composition': {
+            'porin': 1},
+        'sites': {
+            (2, 2): {
+                'glc': 20.0},
+            (6, 2): {
+                'glc': 20.0}
+        }}
+
     return {
+        'initial_state': initial_state,
         'molecules': {
             'glc': 1},
         'membranes': [],
@@ -169,10 +199,7 @@ def get_cell_config():
         'bins_y': 4,
         'diffusion': 1e-1}
 
-def test_diffusion(time=10):
-    # config = get_cell_config()
-    config = get_two_compartment_config()
-
+def test_diffusion(config = get_two_compartment_config(), time=10):
     # load process
     diffusion = Diffusion(config)
 
@@ -185,19 +212,72 @@ def test_diffusion(time=10):
     compartment = process_in_compartment(diffusion)
     return simulate_with_environment(compartment, settings)
 
+def plot_diffusion_output(data, config, out_dir='out', filename='field'):
 
-def plot_diffusion_output(timeseries, settings, out_dir):
-    pass
+    n_snapshots = 6
+
+    # parameters
+    molecules = config.get('molecules')
+    molecule_ids = list(molecules)
+    n_fields = len(molecule_ids)
+    length_x = config.get('length_x')
+    length_y = config.get('length_y')
+    bins_x = config.get('bins_x')
+    bins_y = config.get('bins_y')
+    n_bins = (bins_x, bins_y)
+
+    # data
+    times = data.get('time')
+    locations_series = {(x,y): data[(x,y)]
+        for x in range(bins_x)
+        for y in range(bins_y)}
+
+    field_series = field_from_locations_series(locations_series, molecule_ids, n_bins, times)
+
+     # plot fields
+    time_vec = times
+    plot_steps = np.round(np.linspace(0, len(time_vec) - 1, n_snapshots)).astype(int).tolist()
+    snapshot_times = [time_vec[i] for i in plot_steps]
+
+    # make figure
+    fig = plt.figure(figsize=(20 * n_snapshots, 10*n_fields))
+    grid = plt.GridSpec(n_fields, n_snapshots, wspace=0.2, hspace=0.2)
+    plt.rcParams.update({'font.size': 36})
+
+    for mol_idx, mol_id in enumerate(molecule_ids):
+        field_data = field_series[mol_id]
+
+        for time_index, time_step in enumerate(plot_steps, 0):
+            this_field = field_data[time_index]
+
+            ax = fig.add_subplot(grid[mol_idx, time_index])  # grid is (row, column)
+            # ax.title.set_text('time: {:.4f} hr | field: {}'.format(float(time) / 60. / 60., field_id))
+            ax.set(xlim=[0, length_x], ylim=[0, length_y], aspect=1)
+            ax.set_yticklabels([])
+            ax.set_xticklabels([])
+
+            plt.imshow(this_field,
+                       # vmin=0,
+                       # vmax=15.0,
+                       origin='lower',
+                       # extent=[0, length_y, 0, length_x],
+                       interpolation='nearest',
+                       cmap='YlGn')
+
+    plt.colorbar()
+    fig_path = os.path.join(out_dir, filename)
+    plt.subplots_adjust(wspace=0.7, hspace=0.1)
+    plt.savefig(fig_path, bbox_inches='tight')
+    plt.close(fig)
 
 if __name__ == '__main__':
     out_dir = os.path.join('out', 'tests', 'diffusion')
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    saved_data = test_diffusion(20)
+    # config = get_two_compartment_config()
+    config = get_cell_config()
+    saved_data = test_diffusion(config, 10)
     del saved_data[0]
     timeseries = convert_to_timeseries(saved_data)
-
-    import ipdb; ipdb.set_trace()
-
-    plot_diffusion_output(timeseries, {}, out_dir)
+    plot_diffusion_output(timeseries, config, out_dir)

--- a/vivarium/processes/diffusion.py
+++ b/vivarium/processes/diffusion.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import math
 
 import matplotlib.pyplot as plt
 import numpy as np
-from scipy.ndimage import convolve
 
 from vivarium.compartment.process import Process
 from vivarium.compartment.composition import (
@@ -89,17 +89,12 @@ def make_location_network(molecules, n_bins):
 class Diffusion(Process):
     '''
     '''
-
     def __init__(self, initial_parameters={}):
 
         # initial state
         initial_state = initial_parameters.get('initial_state', {})
         self.initial_membrane = initial_state.get('membrane_composition', {})
         self.initial_sites = initial_state.get('sites', {})
-
-        # membranes
-        self.membrane_locations = initial_parameters.get('membrane_locations', [])
-        self.channels = initial_parameters.get('channels', {})
 
         # parameters
         n_bins = initial_parameters.get('n_bins', (2,1))
@@ -109,11 +104,24 @@ class Diffusion(Process):
         length_x = size[0]
         length_y = size[1]
 
-        ## make diffusion network
+        # make diffusion network
         molecule_ids = initial_parameters.get('molecules', ['glc'])
         diffusion = initial_parameters.get('diffusion', DIFFUSION_CONSTANT)
         locations, edges = make_location_network(molecule_ids, n_bins)
-        self.diffusion_network = DiffusionNetwork(locations, edges, molecule_ids, diffusion)
+
+        # membranes
+        membrane_locations = initial_parameters.get('membrane_locations', [])
+        channels = initial_parameters.get('channels', {})
+
+        diffusion_config = {
+            'nodes': locations,
+            'edges': edges,
+            'molecule_ids': molecule_ids,
+            'diffusion': diffusion,
+            'membrane_locations': membrane_locations,
+            'channels': channels}
+
+        self.diffusion_network = DiffusionNetwork(diffusion_config)
 
         self.dx = length_x / bins_x
         self.dy = length_y / bins_y
@@ -126,7 +134,7 @@ class Diffusion(Process):
             site: molecule_ids
             for site in locations}
         ports.update(
-            {'membrane_composition': list(self.channels.keys())})
+            {'membrane_composition': list(channels.keys())})
 
         parameters = {}
         parameters.update(initial_parameters)
@@ -146,21 +154,24 @@ class Diffusion(Process):
         concentrations = {
             state_id: concs
             for state_id, concs in states.items() if state_id is not 'membrane_composition'}
+        membrane = states['membrane_composition']
 
-        diffusion_delta = self.diffusion_network.diffusion_delta(concentrations, timestep)
+        diffusion_delta = self.diffusion_network.diffusion_delta(concentrations, membrane, timestep)
 
         return diffusion_delta
 
 
 class DiffusionNetwork(object):
 
-    def __init__(self, nodes, edges, molecule_ids, diffusion):
-        self.nodes = nodes
-        self.edges = edges
-        self.molecule_ids = molecule_ids
-        self.diffusion = diffusion
+    def __init__(self, config):
+        self.nodes = config.get('nodes')
+        self.edges = config.get('edges')
+        self.molecule_ids = config.get('molecule_ids')
+        self.diffusion = config.get('diffusion')
+        self.membrane_locations = config.get('membrane_locations')
+        self.channel_diffusion = config.get('channels')
 
-    def diffusion_delta(self, concentrations, timestep):
+    def diffusion_delta(self, locations, membrane, timestep):
         diffusion_delta = {
             site: {mol_id: 0 for mol_id in self.molecule_ids}
             for site in self.nodes}
@@ -168,10 +179,18 @@ class DiffusionNetwork(object):
         for edge in self.edges:
             node1 = edge[0]
             node2 = edge[1]
-            concs1 = concentrations[node1]
-            concs2 = concentrations[node2]
+            concs1 = locations[node1]
+            concs2 = locations[node2]
+
+            if edge in self.membrane_locations:
+                diffusion = 0
+                for channel_id, channel_conc in membrane.items():
+                    diffusion += channel_conc * self.channel_diffusion[channel_id]
+            else:
+                diffusion = self.diffusion
+
             for mol_id in self.molecule_ids:
-                delta1 = self.diffusion * timestep * (concs2[mol_id] - concs1[mol_id])
+                delta1 = diffusion * timestep * (concs2[mol_id] - concs1[mol_id])
                 delta2 = -delta1
                 diffusion_delta[node1][mol_id] += delta1
                 diffusion_delta[node2][mol_id] += delta2
@@ -179,11 +198,12 @@ class DiffusionNetwork(object):
         return diffusion_delta
 
 
+
 # testing functions
 def get_two_compartment_config():
     initial_state = {
         'membrane_composition': {
-            'porin': 1},
+            'porin': 5},
         'sites': {
             (0, 0): {
                 'glc': 20.0},
@@ -196,35 +216,49 @@ def get_two_compartment_config():
         'molecules': ['glc'],
         'membrane_locations': [((0,0),(1,0))],
         'channels':{
-            'porin': 1e-1  # diffusion rate through porin
+            'porin': 2e-2  # diffusion rate through porin
         },
         'n_bins': (2, 1),
         'size': (2e-2, 1e-2),
         'diffusion': 1e-1}
 
-def get_cell_config():
+def get_grid_config():
     initial_state = {
         'membrane_composition': {
             'porin': 1},
         'sites': {
-            (2, 2): {
+            (2, 1): {
                 'glc': 20.0},
-            (6, 2): {
+            (2, 2): {
+                'glc': 10.0},
+            (3, 2): {
+                'glc': 20.0},
+            (6, 1): {
                 'glc': 20.0}
         }}
 
     return {
         'initial_state': initial_state,
         'molecules': ['glc'],
-        'membrane_locations': [],
+        'membrane_locations': [
+            ((1, 0), (2, 0)),
+            ((1, 1), (2, 1)),
+            ((1, 2), (2, 2)),
+            ((2, 3), (2, 2)),
+            ((3, 3), (3, 2)),
+            ((4, 3), (4, 2)),
+            ((5, 3), (5, 2)),
+            ((6, 2), (6, 3)),
+        ],
+        'channels': {
+            'porin': 1e-3  # diffusion rate through porin
+        },
         'n_bins': (10, 4),
         'size': (10e-1, 4e-1),
-        'diffusion': 1e-1}
+        'diffusion': 5e-2}
 
 def test_diffusion(config = get_two_compartment_config(), time=10):
-    # load process
     diffusion = Diffusion(config)
-
     settings = {
         'total_time': time,
         # 'exchange_port': 'exchange',
@@ -241,6 +275,7 @@ def plot_diffusion_output(data, config, out_dir='out', filename='field'):
     molecules = config.get('molecules')
     molecule_ids = list(molecules)
     n_fields = len(molecule_ids)
+    membrane_locations = config.get('membrane_locations')
 
     n_bins = config.get('n_bins')
     size = config.get('size')
@@ -248,6 +283,8 @@ def plot_diffusion_output(data, config, out_dir='out', filename='field'):
     bins_y = n_bins[1]
     length_x = size[0]
     length_y = size[1]
+    bin_size_x = length_x / bins_x
+    bin_size_y = length_y / bins_y
 
     # data
     times = data.get('time')
@@ -275,12 +312,12 @@ def plot_diffusion_output(data, config, out_dir='out', filename='field'):
             this_field = field_data[time_index]
 
             ax = fig.add_subplot(grid[mol_idx, time_index])  # grid is (row, column)
-            # ax.title.set_text('time: {:.4f} hr | field: {}'.format(float(time) / 60. / 60., field_id))
             ax.set(xlim=[0, length_x], ylim=[0, length_y], aspect=1)
             ax.set_yticklabels([])
             ax.set_xticklabels([])
 
-            plt.imshow(np.rot90(this_field),
+            # plot field
+            plt.imshow(np.transpose(this_field),
                        vmin=vmin,
                        vmax=vmax,
                        origin='lower',
@@ -288,7 +325,29 @@ def plot_diffusion_output(data, config, out_dir='out', filename='field'):
                        interpolation='nearest',
                        cmap='YlGn')
 
-    # plt.colorbar()
+            # plot membrane
+            for membrane in membrane_locations:
+                site1 = membrane[0]
+                site2 = membrane[1]
+                middle = (
+                    (site1[0]+site2[0])/2 + 0.5,
+                    (site1[1]+site2[1])/2 + 0.5)
+                delta = (
+                    (site1[1] - site2[1]),
+                    (site1[0] - site2[0]))  # swap x and y
+                point_0 = (
+                    middle[0] + delta[0]/2,
+                    middle[1] + delta[1]/2)
+                point_1 = (
+                    (middle[0] - delta[0]/2),
+                    (middle[1] - delta[1]/2))
+                x_0 = point_0[0] * bin_size_x
+                y_0 = point_0[1] * bin_size_y
+                x_1 = point_1[0] * bin_size_x
+                y_1 = point_1[1] * bin_size_y
+
+                plt.plot([x_0, x_1], [y_0, y_1], linewidth=5, color='r')
+
     fig_path = os.path.join(out_dir, filename)
     plt.subplots_adjust(wspace=0.7, hspace=0.1)
     plt.savefig(fig_path, bbox_inches='tight')
@@ -299,8 +358,12 @@ if __name__ == '__main__':
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    # config = get_two_compartment_config()
-    config = get_cell_config()
-    saved_data = test_diffusion(config, 10)
+    config = get_two_compartment_config()
+    saved_data = test_diffusion(config, 20)
     timeseries = convert_to_timeseries(saved_data)
-    plot_diffusion_output(timeseries, config, out_dir)
+    plot_diffusion_output(timeseries, config, out_dir, '2_sites')
+
+    config = get_grid_config()
+    saved_data = test_diffusion(config, 20)
+    timeseries = convert_to_timeseries(saved_data)
+    plot_diffusion_output(timeseries, config, out_dir, 'grid')

--- a/vivarium/processes/diffusion.py
+++ b/vivarium/processes/diffusion.py
@@ -1,0 +1,119 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+
+import numpy as np
+from scipy.ndimage import convolve
+
+from vivarium.compartment.process import Process
+from vivarium.utils.dict_utils import deep_merge, tuplify_port_dicts
+from vivarium.compartment.composition import (
+    process_in_compartment,
+    simulate_with_environment,
+    convert_to_timeseries,
+    plot_simulation_output)
+
+# constants
+DIFFUSION_CONSTANT = 1e3
+
+# laplacian kernel for diffusion
+LAPLACIAN_2D = np.array([[0.0, 1.0, 0.0], [1.0, -4.0, 1.0], [0.0, 1.0, 0.0]])
+
+
+class Diffusion(Process):
+    '''
+    '''
+
+    def __init__(self, initial_parameters={}):
+
+        # locations
+        self.fields = initial_parameters.get('fields', [])
+        self.membranes = initial_parameters.get('membranes', [])
+
+        # diffusion parameters
+        self.edge_length_x = 2
+        self.patches_per_edge_x = 2
+        self.edge_length_y = 1
+        self.patches_per_edge_y = 1
+
+        self.diffusion = initial_parameters.get('diffusion', DIFFUSION_CONSTANT)
+
+        self.dx = self.edge_length_x / self.patches_per_edge_x
+        self.dy = self.edge_length_y / self.patches_per_edge_y
+        self.dx2 = self.dx * self.dy
+        self.diffusion_dt = 0.5 * self.dx ** 2 * self.dy ** 2 / (2 * self.diffusion * (self.dx ** 2 + self.dy ** 2))
+
+        # # get initial state
+        # states = list(self.transcription.keys()) + list(self.translation.keys())
+        # null_states = {'internal': {
+        #     state_id: 0 for state_id in states}}
+        # initialized_states = initial_parameters.get('initial_state', {})
+        # self.initial_state = deep_merge(null_states, initialized_states)
+        # internal = list(self.initial_state.get('internal', {}).keys())
+        # external = list(self.initial_state.get('external', {}).keys())
+
+        import ipdb; ipdb.set_trace()
+
+        ports = {}
+
+        parameters = {}
+        parameters.update(initial_parameters)
+
+        super(Diffusion, self).__init__(ports, parameters)
+
+    def default_settings(self):
+        default_settings = {}
+        return default_settings
+
+    def next_update(self, timestep, states):
+        internal_state = states['internal']
+
+        update = {}
+        return update
+
+    # diffusion ufnctions
+    def diffusion_timestep(self, field, dt):
+        ''' calculate concentration changes cause by diffusion'''
+        change_field = self.diffusion * dt * convolve(field, LAPLACIAN_2D, mode='reflect') / self.dx2
+        return change_field
+
+    def run_diffusion(self, timestep):
+        for index in range(len(self.fields)):
+            molecule = self.fields[index]
+            # run diffusion if molecule field is not uniform
+            if len(set(molecule.flatten())) != 1:
+                t = 0.0
+                while t < timestep:
+                    molecule += self.diffusion_timestep(molecule, self.diffusion_dt)
+                    t += self.diffusion_dt
+
+
+# testing
+def get_cell_config():
+    return {}
+
+def test_diffusion(time=10):
+    config = get_cell_config()
+
+    # load process
+    diffusion = Diffusion(config)
+
+    settings = {
+        'total_time': time,
+        # 'exchange_port': 'exchange',
+        'environment_port': 'external',
+        'environment_volume': 1e-12}
+
+    compartment = process_in_compartment(diffusion)
+    return simulate_with_environment(compartment, settings)
+
+
+if __name__ == '__main__':
+    out_dir = os.path.join('out', 'tests', 'diffusion')
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    saved_data = test_diffusion(20)
+    del saved_data[0]
+    timeseries = convert_to_timeseries(saved_data)
+    plot_simulation_output(timeseries, {}, out_dir)

--- a/vivarium/processes/diffusion.py
+++ b/vivarium/processes/diffusion.py
@@ -13,9 +13,6 @@ from vivarium.compartment.composition import (
     convert_to_timeseries,
     plot_simulation_output)
 
-# constants
-DIFFUSION_CONSTANT = 1e3
-
 # laplacian kernel for diffusion
 LAPLACIAN_2D = np.array([[0.0, 1.0, 0.0], [1.0, -4.0, 1.0], [0.0, 1.0, 0.0]])
 
@@ -27,51 +24,63 @@ class Diffusion(Process):
     def __init__(self, initial_parameters={}):
 
         # locations
-        self.fields = initial_parameters.get('fields', [])
+        self.molecules = initial_parameters.get('molecules', {'glc': 1})
+        self.molecule_ids = list(self.molecules.keys())
         self.membranes = initial_parameters.get('membranes', [])
 
         # diffusion parameters
-        self.edge_length_x = 2
-        self.patches_per_edge_x = 2
-        self.edge_length_y = 1
-        self.patches_per_edge_y = 1
+        self.length_x = initial_parameters.get('length_x', 2)
+        self.bins_x = initial_parameters.get('bins_x', 2)
+        self.length_y = initial_parameters.get('length_y', 1)
+        self.bins_y = initial_parameters.get('bins_y', 1)
+        self.diffusion = initial_parameters.get('diffusion', 1e3)
 
-        self.diffusion = initial_parameters.get('diffusion', DIFFUSION_CONSTANT)
-
-        self.dx = self.edge_length_x / self.patches_per_edge_x
-        self.dy = self.edge_length_y / self.patches_per_edge_y
+        self.dx = self.length_x / self.bins_x
+        self.dy = self.length_y / self.bins_y
         self.dx2 = self.dx * self.dy
         self.diffusion_dt = 0.5 * self.dx ** 2 * self.dy ** 2 / (2 * self.diffusion * (self.dx ** 2 + self.dy ** 2))
 
-        # # get initial state
-        # states = list(self.transcription.keys()) + list(self.translation.keys())
-        # null_states = {'internal': {
-        #     state_id: 0 for state_id in states}}
-        # initialized_states = initial_parameters.get('initial_state', {})
-        # self.initial_state = deep_merge(null_states, initialized_states)
-        # internal = list(self.initial_state.get('internal', {}).keys())
-        # external = list(self.initial_state.get('external', {}).keys())
+        # make fields
+        fields = self.fill_fields(self.molecules)
 
-        import ipdb; ipdb.set_trace()
-
+        # make ports
         ports = {}
+        for x in range(self.bins_x):
+            for y in range(self.bins_y):
+                concs = {
+                    mol_id: fields[mol_index][x][y]
+                    for mol_index, mol_id in enumerate(self.molecule_ids)}
+                ports[(x,y)]= concs
 
         parameters = {}
         parameters.update(initial_parameters)
 
         super(Diffusion, self).__init__(ports, parameters)
 
+    def fill_fields(self, molecules={}):
+        # Create lattice and fill each site with concentrations dictionary
+        # Molecule identities are defined along the major axis, with spatial dimensions along the other two axes.
+
+
+        fields = np.empty((len(self.molecule_ids), self.bins_x, self.bins_y), dtype=np.float64)
+        for index, molecule_id in enumerate(self.molecule_ids):
+            fields[index].fill(molecules[molecule_id])
+        return fields
+
     def default_settings(self):
-        default_settings = {}
+        default_settings = {
+            'state': {},
+        }
         return default_settings
 
     def next_update(self, timestep, states):
-        internal_state = states['internal']
+        import ipdb; ipdb.set_trace()
+
 
         update = {}
         return update
 
-    # diffusion ufnctions
+    # diffusion functions
     def diffusion_timestep(self, field, dt):
         ''' calculate concentration changes cause by diffusion'''
         change_field = self.diffusion * dt * convolve(field, LAPLACIAN_2D, mode='reflect') / self.dx2
@@ -90,6 +99,8 @@ class Diffusion(Process):
 
 # testing
 def get_cell_config():
+
+
     return {}
 
 def test_diffusion(time=10):

--- a/vivarium/processes/diffusion.py
+++ b/vivarium/processes/diffusion.py
@@ -215,7 +215,9 @@ def get_grid_config():
             (2, 1): {
                 'glc': 20.0},
             (2, 2): {
-                'glc': 10.0},
+                'glc': 20.0},
+            (3, 1): {
+                'glc': 20.0},
             (3, 2): {
                 'glc': 20.0},
             (6, 1): {
@@ -236,11 +238,11 @@ def get_grid_config():
             ((6, 2), (6, 3)),
         ],
         'channels': {
-            'porin': 1e-3  # diffusion rate through porin
+            'porin': 5e-4  # diffusion rate through porin
         },
         'n_bins': (10, 4),
         'size': (10, 4),
-        'diffusion': 5e-2}
+        'diffusion': 2e-1}
 
 def test_diffusion(config = get_two_compartment_config(), time=10):
     diffusion = Diffusion(config)


### PR DESCRIPTION
This adds a diffusion process that can do 1D and 2D spatial diffusion with arbitrary membranes that have configurable channels/pores. This is the first process that allows for dynamic ports -- each location in the spatial grid gets its own port, with a key set by its coordinate (```(0,0)```, ```(0,1)```, etc). These ports can be connected to ```Stores``` such as ```environment``` or ```internal```.

The most basic application addresses #156. You can make a grid with 2 location s, and a membrane between them. One location will be connected to the environment store, the other to the internal store. Diffusion through the membrane is determined by channels' concentrations and diffusion constant:
![2_sites](https://user-images.githubusercontent.com/6809431/76032958-e2979100-5eef-11ea-8392-c5e3ed8bf70e.png)

A more complex example shows off a 2D grid with membranes:
![grid](https://user-images.githubusercontent.com/6809431/76039481-732a9d00-5f01-11ea-8417-dc5ac0ca99f5.png)

