### PR TITLE
Diffusion field

### DIFF
--- a/vivarium/compartment/composition.py
+++ b/vivarium/compartment/composition.py
@@ -281,7 +281,7 @@ def set_axes(ax, show_xaxis=False):
         ax.tick_params(bottom=False, labelbottom=False)
 
 
-def plot_simulation_output(timeseries, settings={}, out_dir='out'):
+def plot_simulation_output(timeseries, settings={}, out_dir='out', filename='simulation'):
     '''
     plot simulation output, with rows organized into separate columns.
 
@@ -415,7 +415,7 @@ def plot_simulation_output(timeseries, settings={}, out_dir='out'):
                 row_idx += 1
 
     # save figure
-    fig_path = os.path.join(out_dir, 'simulation')
+    fig_path = os.path.join(out_dir, filename)
     plt.subplots_adjust(wspace=0.3, hspace=0.5)
     plt.savefig(fig_path, bbox_inches='tight')
 

--- a/vivarium/processes/diffusion_field.py
+++ b/vivarium/processes/diffusion_field.py
@@ -12,6 +12,8 @@ from vivarium.compartment.composition import (
     simulate_with_environment,
     convert_to_timeseries)
 
+
+
 # laplacian kernel for diffusion
 LAPLACIAN_2D = np.array([[0.0, 1.0, 0.0], [1.0, -4.0, 1.0], [0.0, 1.0, 0.0]])
 
@@ -19,14 +21,6 @@ DIFFUSION_CONSTANT = 5e-1
 
 def gaussian(deviation, distance):
     return np.exp(-np.power(distance, 2.) / (2 * np.power(deviation, 2.)))
-
-def make_fields(molecule_ids, n_bins):
-    bins_x = n_bins[0]
-    bins_y = n_bins[1]
-    fields = {}
-    for molecule_id in molecule_ids:
-        fields[molecule_id] = np.empty((bins_x, bins_y), dtype=np.float64)
-    return fields
 
 def make_gradient(gradient, n_bins, size):
     bins_x = n_bins[0]
@@ -143,10 +137,9 @@ def make_gradient(gradient, n_bins, size):
     return fields
 
 
-class DiffusionField(Process):
-    '''
-    '''
 
+class DiffusionField(Process):
+    ''''''
     def __init__(self, initial_parameters={}):
 
         # initial state
@@ -170,8 +163,7 @@ class DiffusionField(Process):
         self.diffusion_dt = 0.01
         # self.diffusion_dt = 0.5 * dx ** 2 * dy ** 2 / (2 * self.diffusion * (dx ** 2 + dy ** 2))
 
-        # make fields
-        # fields = make_fields(molecule_ids, n_bins)
+        # initialize gradient fields
         gradient = initial_parameters.get('gradient', {})
         if gradient:
             gradient_fields = make_gradient(gradient, n_bins, size)
@@ -192,7 +184,6 @@ class DiffusionField(Process):
                 'fields': self.initial_state}}
 
     def next_update(self, timestep, states):
-        # fields = self.make_fields(states)
         fields = states['fields']
         delta_fields = self.diffuse(fields, timestep)
         return {

--- a/vivarium/processes/diffusion_field.py
+++ b/vivarium/processes/diffusion_field.py
@@ -1,0 +1,316 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+
+import numpy as np
+from scipy.ndimage import convolve
+import matplotlib.pyplot as plt
+
+from vivarium.compartment.process import Process
+from vivarium.compartment.composition import (
+    process_in_compartment,
+    simulate_with_environment,
+    convert_to_timeseries)
+
+# laplacian kernel for diffusion
+LAPLACIAN_2D = np.array([[0.0, 1.0, 0.0], [1.0, -4.0, 1.0], [0.0, 1.0, 0.0]])
+
+DIFFUSION_CONSTANT = 5e-1
+
+
+
+class DiffusionField(Process):
+    '''
+    '''
+
+    def __init__(self, initial_parameters={}):
+
+        # initial state
+        molecule_ids = initial_parameters.get('molecules', ['glc'])
+        self.initial_state = initial_parameters.get('initial_state', {})
+
+        # parameters
+        n_bins = initial_parameters.get('n_bins', (2,1))
+        size = initial_parameters.get('size', (2, 1))
+
+        # diffusion settings
+        diffusion = initial_parameters.get('diffusion', DIFFUSION_CONSTANT)
+        bins_x = n_bins[0]
+        bins_y = n_bins[1]
+        length_x = size[0]
+        length_y = size[1]
+        dx = length_x / bins_x
+        dy = length_y / bins_y
+        dx2 = dx * dy
+        self.diffusion = diffusion / dx2
+        self.diffusion_dt = 0.01
+        # self.diffusion_dt = 0.5 * dx ** 2 * dy ** 2 / (2 * self.diffusion * (dx ** 2 + dy ** 2))
+
+        # make fields
+        fields = self.make_fields(molecule_ids, n_bins)
+
+        # make ports
+        ports = {
+            'fields': molecule_ids}
+
+        parameters = {}
+        parameters.update(initial_parameters)
+
+        super(DiffusionField, self).__init__(ports, parameters)
+
+    # def make_ports(self, fields):
+    #     ports = {}
+    #     for x in range(self.bins_x):
+    #         for y in range(self.bins_y):
+    #             concs = {
+    #                 mol_id: fields[mol_index][x][y]
+    #                 for mol_index, mol_id in enumerate(self.molecule_ids)}
+    #             ports[(x,y)]= concs
+    #     return ports
+    #
+    # def make_fields(self, ports):
+    #     fields = np.empty((len(self.molecule_ids), self.bins_x, self.bins_y), dtype=np.float64)
+    #     for (x,y), conc_dict in ports.items():
+    #         concs = [conc_dict[mol_id] for mol_id in self.molecule_ids]
+    #         fields[:,x,y] = concs
+    #     return fields
+
+    def make_fields(self, molecule_ids, n_bins):
+        bins_x = n_bins[0]
+        bins_y = n_bins[1]
+        fields = {}
+        for molecule_id in molecule_ids:
+            fields[molecule_id] = np.empty((bins_x, bins_y), dtype=np.float64)
+        return fields
+
+    def default_settings(self):
+        return {
+            'state': {
+                'fields': self.initial_state}}
+
+    def next_update(self, timestep, states):
+        # fields = self.make_fields(states)
+        fields = states['fields']
+        delta_fields = self.diffuse(fields, timestep)
+        return {
+            'fields': delta_fields}
+
+    # diffusion functions
+    def diffusion_delta(self, field, timestep):
+        ''' calculate concentration changes cause by diffusion'''
+        field_new = field.copy()
+        t = 0.0
+        dt = min(timestep, self.diffusion_dt)
+        while t < timestep:
+            field_new += self.diffusion * dt * convolve(field_new, LAPLACIAN_2D, mode='reflect')
+            t += dt
+
+        return field_new - field
+
+    def diffuse(self, fields, timestep):
+        delta_fields = {}
+        for mol_id, field in fields.items():
+
+            # run diffusion if molecule field is not uniform
+            if len(set(field.flatten())) != 1:
+                delta = self.diffusion_delta(field, timestep)
+            else:
+                delta = np.zeros_like(field)
+            delta_fields[mol_id] = delta
+
+        return delta_fields
+
+    def make_gradient(self, gradient):
+        if gradient.get('type') == 'gaussian':
+            """
+            gaussian gradient multiplies the base concentration of the given molecule
+            by a gaussian function of distance from center and deviation
+
+            'gradient': {
+                'type': 'gradient',
+                'molecules': {
+                    'mol_id1':{
+                        'center': [0.25, 0.5],
+                        'deviation': 30},
+                    'mol_id2': {
+                        'center': [0.75, 0.5],
+                        'deviation': 30}
+                }},
+            """
+
+            for molecule_id, specs in gradient['molecules'].items():
+                mol_index = self._molecule_ids.index(molecule_id)
+                center = [specs['center'][0] * self.edge_length_x,
+                          specs['center'][1] * self.edge_length_y]
+                deviation = specs['deviation']
+
+                for x_patch in range(self.patches_per_edge_x):
+                    for y_patch in range(self.patches_per_edge_y):
+                        # distance from middle of patch to center coordinates
+                        dx = (x_patch + 0.5) * self.edge_length_x / self.patches_per_edge_x - center[0]
+                        dy = (y_patch + 0.5) * self.edge_length_y / self.patches_per_edge_y - center[1]
+                        distance = np.sqrt(dx ** 2 + dy ** 2)
+                        scale = gaussian(deviation, distance)
+                        # multiply gradient by scale
+                        self.lattice[mol_index][x_patch][y_patch] *= scale
+
+        elif gradient.get('type') == 'linear':
+            """
+            linear gradient adds to the base concentration of the given molecule
+            as a function of distance from center and slope.
+
+            'gradient': {
+                'type': 'linear',
+                'molecules': {
+                    'mol_id1':{
+                        'center': [0.0, 0.0],
+                        'slope': -10},
+                    'mol_id2': {
+                        'center': [1.0, 1.0],
+                        'slope': -5}
+                }},
+            """
+
+            for molecule_id, specs in gradient['molecules'].items():
+                mol_index = self._molecule_ids.index(molecule_id)
+                center = [specs['center'][0] * self.edge_length_x,
+                          specs['center'][1] * self.edge_length_y]
+                slope = specs['slope']
+
+                for x_patch in range(self.patches_per_edge_x):
+                    for y_patch in range(self.patches_per_edge_y):
+                        # distance from middle of patch to center coordinates
+                        dx = (x_patch + 0.5) * self.edge_length_x / self.patches_per_edge_x - center[0]
+                        dy = (y_patch + 0.5) * self.edge_length_y / self.patches_per_edge_y - center[1]
+                        distance = np.sqrt(dx ** 2 + dy ** 2)
+                        added = distance * slope
+                        # add gradient to basal concentration
+                        self.lattice[mol_index][x_patch][y_patch] += added
+
+                self.lattice[mol_index][self.lattice[mol_index] <= 0.0] = 0.0
+
+        elif gradient.get('type') == 'exponential':
+            """
+            exponential gradient adds a delta (d) to the base concentration (c)
+            of the given molecule as a function of distance  (x) from center and base (b),
+            with d=c+x^d.
+
+            'gradient': {
+                'type': 'exponential',
+                'molecules': {
+                    'mol_id1':{
+                        'center': [0.0, 0.0],
+                        'base': 1+2e-4},
+                    'mol_id2': {
+                        'center': [1.0, 1.0],
+                        'base': 1+2e-4}
+                }},
+            """
+
+            for molecule_id, specs in gradient['molecules'].items():
+                mol_index = self._molecule_ids.index(molecule_id)
+                center = [specs['center'][0] * self.edge_length_x,
+                          specs['center'][1] * self.edge_length_y]
+                base = specs['base']
+
+                for x_patch in range(self.patches_per_edge_x):
+                    for y_patch in range(self.patches_per_edge_y):
+                        dx = (x_patch + 0.5) * self.edge_length_x / self.patches_per_edge_x - center[0]
+                        dy = (y_patch + 0.5) * self.edge_length_y / self.patches_per_edge_y - center[1]
+                        distance = np.sqrt(dx ** 2 + dy ** 2)
+                        added = base ** distance - 1
+
+                        # add to base concentration
+                        self.lattice[mol_index][x_patch][y_patch] += added
+
+                self.lattice[mol_index][self.lattice[mol_index] <= 0.0] = 0.0
+
+
+
+
+# testing
+def plot_field_output(data, config, out_dir='out', filename='field'):
+    n_snapshots = 6
+
+    # parameters
+    molecules = config.get('molecules', {})
+    molecule_ids = list(molecules)
+    n_fields = len(molecule_ids)
+
+    n_bins = config.get('n_bins')
+    size = config.get('size')
+    bins_x = n_bins[0]
+    bins_y = n_bins[1]
+    length_x = size[0]
+    length_y = size[1]
+
+    # data
+    times = data.get('time')
+    field_series = data.get('fields')
+
+     # plot fields
+    time_vec = times
+    plot_steps = np.round(np.linspace(0, len(time_vec) - 1, n_snapshots)).astype(int).tolist()
+
+    # make figure
+    fig = plt.figure(figsize=(20 * n_snapshots, 10*n_fields))
+    grid = plt.GridSpec(n_fields, n_snapshots, wspace=0.2, hspace=0.2)
+    plt.rcParams.update({'font.size': 36})
+
+    for mol_idx, mol_id in enumerate(molecule_ids):
+        field_data = field_series[mol_id]
+        vmin = np.amin(field_data)
+        vmax = np.amax(field_data)
+
+        for time_index, time_step in enumerate(plot_steps, 0):
+            this_field = field_data[time_index]
+
+            ax = fig.add_subplot(grid[mol_idx, time_index])  # grid is (row, column)
+            ax.set(xlim=[0, length_x], ylim=[0, length_y], aspect=1)
+            ax.set_yticklabels([])
+            ax.set_xticklabels([])
+
+            # plot field
+            plt.imshow(np.transpose(this_field),
+                       vmin=vmin,
+                       vmax=vmax,
+                       origin='lower',
+                       extent=[0, length_x, 0, length_y],
+                       interpolation='nearest',
+                       cmap='YlGn')
+
+    fig_path = os.path.join(out_dir, filename)
+    plt.subplots_adjust(wspace=0.7, hspace=0.1)
+    plt.savefig(fig_path, bbox_inches='tight')
+    plt.close(fig)
+
+def get_field_config():
+    n_bins = (10, 10)
+    return {
+        'molecules': ['glc'],
+        'initial_state': {
+            'glc': np.random.rand(n_bins[0], n_bins[1])},
+        'n_bins': n_bins,
+        'size': n_bins}
+
+def test_diffusion(config, time=10):
+    diffusion = DiffusionField(config)
+    settings = {
+        'total_time': time,
+        # 'exchange_port': 'exchange',
+        'environment_port': 'external',
+        'environment_volume': 1e-12}
+
+    compartment = process_in_compartment(diffusion)
+    return simulate_with_environment(compartment, settings)
+
+
+if __name__ == '__main__':
+    out_dir = os.path.join('out', 'tests', 'diffusion_field')
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    config = get_field_config()
+    saved_data = test_diffusion(config, 10)
+    timeseries = convert_to_timeseries(saved_data)
+    plot_field_output(timeseries, config, out_dir, 'field')

--- a/vivarium/processes/diffusion_field.py
+++ b/vivarium/processes/diffusion_field.py
@@ -28,7 +28,6 @@ def make_fields(molecule_ids, n_bins):
         fields[molecule_id] = np.empty((bins_x, bins_y), dtype=np.float64)
     return fields
 
-
 def make_gradient(gradient, n_bins, size):
     bins_x = n_bins[0]
     bins_y = n_bins[1]
@@ -88,7 +87,7 @@ def make_gradient(gradient, n_bins, size):
         """
 
         for molecule_id, specs in gradient['molecules'].items():
-            mol_index = self._molecule_ids.index(molecule_id)
+            field = np.ones((bins_x, bins_y), dtype=np.float64)
             center = [specs['center'][0] * length_x,
                       specs['center'][1] * length_y]
             slope = specs['slope']
@@ -101,9 +100,9 @@ def make_gradient(gradient, n_bins, size):
                     distance = np.sqrt(dx ** 2 + dy ** 2)
                     added = distance * slope
                     # add gradient to basal concentration
-                    self.lattice[mol_index][x_patch][y_patch] += added
-
-            self.lattice[mol_index][self.lattice[mol_index] <= 0.0] = 0.0
+                    field[x_patch][y_patch] += added
+            fields[fields <= 0.0] = 0.0
+            fields[molecule_id] = field
 
     elif gradient.get('type') == 'exponential':
         """
@@ -124,7 +123,7 @@ def make_gradient(gradient, n_bins, size):
         """
 
         for molecule_id, specs in gradient['molecules'].items():
-            mol_index = self._molecule_ids.index(molecule_id)
+            field = np.ones((bins_x, bins_y), dtype=np.float64)
             center = [specs['center'][0] * length_x,
                       specs['center'][1] * length_y]
             base = specs['base']
@@ -137,9 +136,9 @@ def make_gradient(gradient, n_bins, size):
                     added = base ** distance - 1
 
                     # add to base concentration
-                    self.lattice[mol_index][x_patch][y_patch] += added
-
-            self.lattice[mol_index][self.lattice[mol_index] <= 0.0] = 0.0
+                    field[x_patch][y_patch] += added
+            fields[fields <= 0.0] = 0.0
+            fields[molecule_id] = field
 
     return fields
 
@@ -322,10 +321,10 @@ if __name__ == '__main__':
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    # config = get_field_config()
-    # saved_data = test_diffusion(config, 10)
-    # timeseries = convert_to_timeseries(saved_data)
-    # plot_field_output(timeseries, config, out_dir, 'field')
+    config = get_field_config()
+    saved_data = test_diffusion(config, 10)
+    timeseries = convert_to_timeseries(saved_data)
+    plot_field_output(timeseries, config, out_dir, 'field')
 
     gaussian_config = get_gaussian_config()
     gaussian_data = test_diffusion(gaussian_config, 10)

--- a/vivarium/processes/diffusion_network.py
+++ b/vivarium/processes/diffusion_network.py
@@ -212,6 +212,10 @@ def get_grid_config():
         'membrane_composition': {
             'porin': 1e2},
         'sites': {
+            (1, 1): {
+                'glc': 20.0},
+            (1, 2): {
+                'glc': 20.0},
             (2, 1): {
                 'glc': 20.0},
             (2, 2): {
@@ -220,29 +224,35 @@ def get_grid_config():
                 'glc': 20.0},
             (3, 2): {
                 'glc': 20.0},
-            (6, 1): {
-                'glc': 20.0}
         }}
 
     return {
         'initial_state': initial_state,
         'molecules': ['glc'],
         'membrane_locations': [
-            ((1, 0), (2, 0)),
-            ((1, 1), (2, 1)),
-            ((1, 2), (2, 2)),
+            # left
+            ((0, 1), (1, 1)),
+            ((0, 2), (1, 2)),
+            # top
+            ((1, 3), (1, 2)),
             ((2, 3), (2, 2)),
             ((3, 3), (3, 2)),
-            ((4, 3), (4, 2)),
-            ((5, 3), (5, 2)),
-            ((6, 2), (6, 3)),
+            # ((4, 3), (4, 2)),
+            #right
+            ((4, 2), (5, 2)),
+            ((4, 1), (5, 1)),
+            ((1, 0), (1, 1)),
+            ((2, 0), (2, 1)),
+            #bottom
+            ((3, 0), (3, 1)),
+            ((4, 0), (4, 1)),
         ],
         'channels': {
-            'porin': 5e-4  # diffusion rate through porin
+            'porin': 1e-4  # diffusion rate through porin
         },
-        'n_bins': (10, 4),
-        'size': (10, 4),
-        'diffusion': 2e-1}
+        'n_bins': (6, 4),
+        'size': (6, 4),
+        'diffusion': 3e-1}
 
 def test_diffusion(config = get_two_compartment_config(), time=10):
     diffusion = DiffusionNetwork(config)
@@ -351,6 +361,6 @@ if __name__ == '__main__':
     plot_diffusion_field_output(timeseries, config, out_dir, '2_sites')
 
     config = get_grid_config()
-    saved_data = test_diffusion(config, 20)
+    saved_data = test_diffusion(config, 30)
     timeseries = convert_to_timeseries(saved_data)
     plot_diffusion_field_output(timeseries, config, out_dir, 'grid')

--- a/vivarium/processes/diffusion_network.py
+++ b/vivarium/processes/diffusion_network.py
@@ -72,9 +72,9 @@ def make_location_network(n_bins):
     return locations, adjacent_edges
 
 
+
 class DiffusionNetwork(Process):
-    '''
-    '''
+    ''''''
     def __init__(self, initial_parameters={}):
 
         # parameters

--- a/vivarium/processes/diffusion_network.py
+++ b/vivarium/processes/diffusion_network.py
@@ -95,7 +95,7 @@ class DiffusionNetwork(Process):
         locations, edges = make_location_network(n_bins)
 
         # membranes
-        membrane_locations = initial_parameters.get('membrane_locations', [])
+        membrane_edges = initial_parameters.get('membrane_edges', [])
         channels = initial_parameters.get('channels', {})
 
         # diffusion settings
@@ -109,7 +109,7 @@ class DiffusionNetwork(Process):
             'edges': edges,
             'molecule_ids': molecule_ids,
             'diffusion': diffusion/dx2,
-            'membrane_locations': membrane_locations,
+            'membrane_edges': membrane_edges,
             'channels': channels}
 
         self.diffusion_network = Network(diffusion_config)
@@ -152,7 +152,7 @@ class Network(object):
         self.edges = config.get('edges')
         self.molecule_ids = config.get('molecule_ids')
         self.diffusion = config.get('diffusion')
-        self.membrane_locations = config.get('membrane_locations')
+        self.membrane_edges = config.get('membrane_edges')
         self.channel_diffusion = config.get('channels')
 
     def diffusion_delta(self, locations, membrane, timestep):
@@ -166,7 +166,7 @@ class Network(object):
             concs1 = locations[node1]
             concs2 = locations[node2]
 
-            if edge in self.membrane_locations or (edge[1], edge[0]) in self.membrane_locations:
+            if edge in self.membrane_edges or (edge[1], edge[0]) in self.membrane_edges:
                 diffusion = 0
                 for channel_id, channel_conc in membrane.items():
                     diffusion += channel_conc * self.channel_diffusion[channel_id]
@@ -199,7 +199,7 @@ def get_two_compartment_config():
     return {
         'initial_state': initial_state,
         'molecules': ['glc'],
-        'membrane_locations': [((0,0),(1,0))],
+        'membrane_edges': [((0,0),(1,0))],
         'channels':{
             'porin': 5e-2  # diffusion rate through porin
         },
@@ -229,7 +229,7 @@ def get_grid_config():
     return {
         'initial_state': initial_state,
         'molecules': ['glc'],
-        'membrane_locations': [
+        'membrane_edges': [
             # left
             ((0, 1), (1, 1)),
             ((0, 2), (1, 2)),
@@ -272,7 +272,7 @@ def plot_diffusion_field_output(data, config, out_dir='out', filename='field'):
     molecules = config.get('molecules', {})
     molecule_ids = list(molecules)
     n_fields = len(molecule_ids)
-    membrane_locations = config.get('membrane_locations')
+    membrane_edges = config.get('membrane_edges')
 
     n_bins = config.get('n_bins')
     size = config.get('size')
@@ -323,7 +323,7 @@ def plot_diffusion_field_output(data, config, out_dir='out', filename='field'):
                        cmap='YlGn')
 
             # plot membrane
-            for membrane in membrane_locations:
+            for membrane in membrane_edges:
                 site1 = membrane[0]
                 site2 = membrane[1]
                 middle = (

--- a/vivarium/processes/diffusion_network.py
+++ b/vivarium/processes/diffusion_network.py
@@ -71,7 +71,7 @@ def make_location_network(n_bins):
     return locations, adjacent_edges
 
 
-class Diffusion(Process):
+class DiffusionNetwork(Process):
     '''
     '''
     def __init__(self, initial_parameters={}):
@@ -112,7 +112,7 @@ class Diffusion(Process):
             'membrane_locations': membrane_locations,
             'channels': channels}
 
-        self.diffusion_network = DiffusionNetwork(diffusion_config)
+        self.diffusion_network = Network(diffusion_config)
 
         # make ports from locations and membrane channels
         ports = {
@@ -124,7 +124,7 @@ class Diffusion(Process):
         parameters = {}
         parameters.update(initial_parameters)
 
-        super(Diffusion, self).__init__(ports, parameters)
+        super(DiffusionNetwork, self).__init__(ports, parameters)
 
 
     def default_settings(self):
@@ -145,7 +145,7 @@ class Diffusion(Process):
         return diffusion_delta
 
 
-class DiffusionNetwork(object):
+class Network(object):
 
     def __init__(self, config):
         self.nodes = config.get('nodes')
@@ -245,7 +245,7 @@ def get_grid_config():
         'diffusion': 2e-1}
 
 def test_diffusion(config = get_two_compartment_config(), time=10):
-    diffusion = Diffusion(config)
+    diffusion = DiffusionNetwork(config)
     settings = {
         'total_time': time,
         # 'exchange_port': 'exchange',
@@ -255,11 +255,11 @@ def test_diffusion(config = get_two_compartment_config(), time=10):
     compartment = process_in_compartment(diffusion)
     return simulate_with_environment(compartment, settings)
 
-def plot_diffusion_output(data, config, out_dir='out', filename='field'):
+def plot_diffusion_field_output(data, config, out_dir='out', filename='field'):
     n_snapshots = 6
 
     # parameters
-    molecules = config.get('molecules')
+    molecules = config.get('molecules', {})
     molecule_ids = list(molecules)
     n_fields = len(molecule_ids)
     membrane_locations = config.get('membrane_locations')
@@ -341,16 +341,16 @@ def plot_diffusion_output(data, config, out_dir='out', filename='field'):
     plt.close(fig)
 
 if __name__ == '__main__':
-    out_dir = os.path.join('out', 'tests', 'diffusion')
+    out_dir = os.path.join('out', 'tests', 'diffusion_network')
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
     config = get_two_compartment_config()
     saved_data = test_diffusion(config, 20)
     timeseries = convert_to_timeseries(saved_data)
-    plot_diffusion_output(timeseries, config, out_dir, '2_sites')
+    plot_diffusion_field_output(timeseries, config, out_dir, '2_sites')
 
     config = get_grid_config()
     saved_data = test_diffusion(config, 20)
     timeseries = convert_to_timeseries(saved_data)
-    plot_diffusion_output(timeseries, config, out_dir, 'grid')
+    plot_diffusion_field_output(timeseries, config, out_dir, 'grid')


### PR DESCRIPTION
This PR adds a ```diffusion_field``` process, which supports 2D field-based diffusion as is used by ```lattice``` -- thus taking a step towards modularizing lattice and making it into a compartment. 
This process contrasts with the existing ```diffusion_network```, which is a more general diffusion process that implements fields as networks with locations as nodes and adjacency as edges -- this allows for the addition of membranes along these edges, and can also support arbitrary topologies.

```diffusion_nework``` is now only a grid-based network through configuration, by default it just requires nodes and edges, and so can be configured to any topology.

This is the output for a diffusion network with two locations, and an edge between them that has a membrane.
![2_sites](https://user-images.githubusercontent.com/6809431/76251200-e420cc00-6203-11ea-8729-b710f0538e27.png)

This is the output for a grid-based diffusion network, which has edges along adjacent sites:
![grid](https://user-images.githubusercontent.com/6809431/76251262-ff8bd700-6203-11ea-8740-2b566ff79ab3.png)

