### PR TITLE
multibody physics process

### DIFF
--- a/vivarium/processes/diffusion_field.py
+++ b/vivarium/processes/diffusion_field.py
@@ -12,7 +12,6 @@ from vivarium.compartment.composition import (
     convert_to_timeseries)
 
 
-
 # laplacian kernel for diffusion
 LAPLACIAN_2D = np.array([[0.0, 1.0, 0.0], [1.0, -4.0, 1.0], [0.0, 1.0, 0.0]])
 

--- a/vivarium/processes/diffusion_field.py
+++ b/vivarium/processes/diffusion_field.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import os
 
 import numpy as np
+from scipy import constants
 from scipy.ndimage import convolve
 import matplotlib.pyplot as plt
 
@@ -14,7 +15,7 @@ from vivarium.compartment.composition import (
 
 # laplacian kernel for diffusion
 LAPLACIAN_2D = np.array([[0.0, 1.0, 0.0], [1.0, -4.0, 1.0], [0.0, 1.0, 0.0]])
-
+AVOGADRO = constants.N_A
 DIFFUSION_CONSTANT = 5e-1
 DEFAULT_DEPTH = 3000.0  # um
 
@@ -28,7 +29,7 @@ def make_gradient(gradient, n_bins, size):
     length_x = size[0]
     length_y = size[1]
     fields = {}
-    
+
     if gradient.get('type') == 'gaussian':
         """
         gaussian gradient multiplies the base concentration of the given molecule
@@ -143,20 +144,20 @@ class DiffusionField(Process):
     def __init__(self, initial_parameters={}):
 
         # initial state
-        molecule_ids = initial_parameters.get('molecules', ['glc'])
+        self.molecule_ids = initial_parameters.get('molecules', ['glc'])
         self.initial_state = initial_parameters.get('initial_state', {})
 
         # parameters
-        n_bins = initial_parameters.get('n_bins', [10,10])
-        size = initial_parameters.get('size', [10, 10])
-        depth = initial_parameters.get('depth', DEFAULT_DEPTH)  # um
+        self.n_bins = initial_parameters.get('n_bins', [10,10])
+        self.size = initial_parameters.get('size', [10, 10])
+        depth = initial_parameters.get('depth', DEFAULT_DEPTH)
 
         # diffusion
         diffusion = initial_parameters.get('diffusion', DIFFUSION_CONSTANT)
-        bins_x = n_bins[0]
-        bins_y = n_bins[1]
-        length_x = size[0]
-        length_y = size[1]
+        bins_x = self.n_bins[0]
+        bins_y = self.n_bins[1]
+        length_x = self.size[0]
+        length_y = self.size[1]
         dx = length_x / bins_x
         dy = length_y / bins_y
         dx2 = dx * dy
@@ -166,17 +167,22 @@ class DiffusionField(Process):
 
         # volume, to convert between counts and concentration
         total_volume = (depth * length_x * length_y) * 1e-15 # (L)
-        bin_volume = total_volume / (length_x * length_y)
+        self.bin_volume = total_volume / (length_x * length_y)
 
         # initialize gradient fields
         gradient = initial_parameters.get('gradient', {})
         if gradient:
-            gradient_fields = make_gradient(gradient, n_bins, size)
+            gradient_fields = make_gradient(gradient, self.n_bins, self.size)
             self.initial_state.update(gradient_fields)
+
+        # bodies
+        # todo -- support adaptive ports for bodies
+        self.initial_bodies = initial_parameters.get('bodies', {})
 
         # make ports
         ports = {
-            'fields': molecule_ids}
+            'fields': self.molecule_ids,
+            'bodies': list(self.initial_bodies.keys())}
 
         parameters = {}
         parameters.update(initial_parameters)
@@ -186,13 +192,52 @@ class DiffusionField(Process):
     def default_settings(self):
         return {
             'state': {
-                'fields': self.initial_state}}
+                'fields': self.initial_state,
+                'bodies': self.initial_bodies}}
 
     def next_update(self, timestep, states):
-        fields = states['fields']
+        fields = states['fields'].copy()
+        bodies = states['bodies']
+
+        # uptake/secretion from bodies
+        delta_exchanges = self.apply_exchanges(bodies)
+        for field_id, delta in delta_exchanges.items():
+            fields[field_id] += delta
+
+        # diffuse field
         delta_fields = self.diffuse(fields, timestep)
+
         return {
             'fields': delta_fields}
+
+    def count_to_concentration(self, count):
+        return count / (self.bin_volume * AVOGADRO)
+
+    def apply_single_exchange(self, delta_fields, specs):
+        location = specs['location']
+        exchange = specs['exchange']
+
+        patch = np.array([
+            location[0] * self.n_bins[0] / self.size[0],
+            location[1] * self.n_bins[1] / self.size[1]])
+        patch_site = tuple(np.floor(patch).astype(int))
+
+        for mol_id, count in exchange.items():
+            concentration = self.count_to_concentration(count)
+            delta_fields[mol_id][patch_site[0], patch_site[1]] += concentration
+
+    def apply_exchanges(self, bodies):
+
+        # initialize delta_fields with zero array
+        delta_fields = {
+            mol_id: np.zeros((self.n_bins[0], self.n_bins[1]), dtype=np.float64)
+            for mol_id in self.molecule_ids}
+
+        # apply exchanges to delta_fields
+        for body_id, specs in bodies.items():
+            self.apply_single_exchange(delta_fields, specs)
+
+        return delta_fields
 
     # diffusion functions
     def diffusion_delta(self, field, timestep):
@@ -275,8 +320,7 @@ def plot_field_output(data, config, out_dir='out', filename='field'):
     plt.savefig(fig_path, bbox_inches='tight')
     plt.close(fig)
 
-def get_field_config():
-    n_bins = (10, 10)
+def get_random_field_config(n_bins=(10, 10)):
     return {
         'molecules': ['glc'],
         'initial_state': {
@@ -284,8 +328,7 @@ def get_field_config():
         'n_bins': n_bins,
         'size': n_bins}
 
-def get_gaussian_config():
-    n_bins = (10, 10)
+def get_gaussian_config(n_bins=(10, 10)):
     return {
         'molecules': ['glc'],
         'n_bins': n_bins,
@@ -295,19 +338,32 @@ def get_gaussian_config():
             'molecules': {
                 'glc': {
                     'center': [0.5, 0.5],
-                    'deviation': 1},
-            }},
-    }
+                    'deviation': 1}}}}
 
+def get_secretion_body_config(n_bins=(10, 10)):
+    size = n_bins
+    molecules = ['glc']
 
-def test_diffusion(config, time=10):
+    body = {
+        'location': [size[0]/4, size[1]/4],
+        'exchange': {
+            mol_id: 1e2 for mol_id in molecules}}
+
+    return {
+        'molecules': molecules,
+        'initial_state': {
+            'glc': np.ones((n_bins[0], n_bins[1]))},
+        'n_bins': n_bins,
+        'size': size,
+        'bodies': {'1': body}}
+
+def test_diffusion_field(config, time=10):
     diffusion = DiffusionField(config)
     settings = {
         'total_time': time,
         # 'exchange_port': 'exchange',
         'environment_port': 'external',
         'environment_volume': 1e-12}
-
     return simulate_process(diffusion, settings)
 
 
@@ -316,12 +372,17 @@ if __name__ == '__main__':
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    config = get_field_config()
-    saved_data = test_diffusion(config, 10)
+    config = get_random_field_config()
+    saved_data = test_diffusion_field(config, 10)
     timeseries = convert_to_timeseries(saved_data)
-    plot_field_output(timeseries, config, out_dir, 'field')
+    plot_field_output(timeseries, config, out_dir, 'random_field')
 
     gaussian_config = get_gaussian_config()
-    gaussian_data = test_diffusion(gaussian_config, 10)
+    gaussian_data = test_diffusion_field(gaussian_config, 10)
     gaussian_timeseries = convert_to_timeseries(gaussian_data)
     plot_field_output(gaussian_timeseries, gaussian_config, out_dir, 'gaussian_field')
+
+    secretion_config = get_secretion_body_config()
+    secretion_data = test_diffusion_field(secretion_config, 10)
+    secretion_timeseries = convert_to_timeseries(secretion_data)
+    plot_field_output(secretion_timeseries, secretion_config, out_dir, 'secretion')

--- a/vivarium/processes/diffusion_network.py
+++ b/vivarium/processes/diffusion_network.py
@@ -182,10 +182,9 @@ class Network(object):
                 diffusion = self.diffusion
 
             for mol_id in self.molecule_ids:
-                delta1 = diffusion * timestep * (concs2[mol_id] - concs1[mol_id])
-                delta2 = -delta1
-                diffusion_delta[node1][mol_id] += delta1
-                diffusion_delta[node2][mol_id] += delta2
+                delta = diffusion * timestep * (concs2[mol_id] - concs1[mol_id])
+                diffusion_delta[node1][mol_id] += delta
+                diffusion_delta[node2][mol_id] -= delta
 
         return diffusion_delta
 

--- a/vivarium/processes/diffusion_network.py
+++ b/vivarium/processes/diffusion_network.py
@@ -7,8 +7,7 @@ import numpy as np
 
 from vivarium.compartment.process import Process
 from vivarium.compartment.composition import (
-    process_in_compartment,
-    simulate_with_environment,
+    simulate_process_with_environment,
     convert_to_timeseries,
     plot_simulation_output)
 
@@ -276,8 +275,7 @@ def test_diffusion_network(config = get_two_compartment_config(), time=10):
         'environment_port': 'external',
         'environment_volume': 1e-2}
 
-    compartment = process_in_compartment(diffusion)
-    return simulate_with_environment(compartment, settings)
+    return simulate_process_with_environment(diffusion, settings)
 
 def plot_diffusion_field_output(data, config, out_dir='out', filename='field'):
     n_snapshots = 6

--- a/vivarium/processes/diffusion_network.py
+++ b/vivarium/processes/diffusion_network.py
@@ -111,15 +111,12 @@ class DiffusionNetwork(Process):
             edges = network.get('edges')
             membrane_edges = network.get('membrane_edges', [])
 
-        diffusion_config = {
-            'nodes': locations,
-            'edges': edges,
-            'molecule_ids': molecule_ids,
-            'diffusion': diffusion,
-            'membrane_edges': membrane_edges,
-            'channels': channels}
-
-        self.diffusion_network = Network(diffusion_config)
+        self.nodes = locations
+        self.edges = edges
+        self.molecule_ids = molecule_ids
+        self.diffusion = diffusion
+        self.membrane_edges = membrane_edges
+        self.channel_diffusion = channels
 
         # make ports from locations and membrane channels
         ports = {
@@ -147,20 +144,9 @@ class DiffusionNetwork(Process):
             for state_id, concs in states.items() if state_id is not 'membrane_composition'}
         membrane = states['membrane_composition']
 
-        diffusion_delta = self.diffusion_network.diffusion_delta(concentrations, membrane, timestep)
+        diffusion_delta = self.diffusion_delta(concentrations, membrane, timestep)
 
         return diffusion_delta
-
-
-class Network(object):
-
-    def __init__(self, config):
-        self.nodes = config.get('nodes')
-        self.edges = config.get('edges')
-        self.molecule_ids = config.get('molecule_ids')
-        self.diffusion = config.get('diffusion')
-        self.membrane_edges = config.get('membrane_edges')
-        self.channel_diffusion = config.get('channels')
 
     def diffusion_delta(self, locations, membrane, timestep):
         diffusion_delta = {

--- a/vivarium/processes/multibody_physics.py
+++ b/vivarium/processes/multibody_physics.py
@@ -1,0 +1,366 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+
+os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = "hide"
+import pygame
+from pygame.locals import *
+from pygame.color import *
+
+# python imports
+import random
+import math
+import numpy as np
+
+# pymunk imports
+import pymunkoptions
+pymunkoptions.options["debug"] = False
+import pymunk
+import pymunk.pygame_util
+
+# vivarium imports
+from vivarium.compartment.process import Process
+from vivarium.compartment.composition import (
+    simulate_process,
+    convert_to_timeseries)
+
+
+PI = math.pi
+ELASTICITY = 0.95
+DAMPING = 0.05  # simulates viscous forces to reduce velocity at low Reynolds number (1 = no damping, 0 = full damping)
+ANGULAR_DAMPING = 0.7  # less damping for angular velocity seems to improve behavior
+FRICTION = 0.9  # TODO -- does this do anything?
+PHYSICS_TS = 0.005
+FORCE_SCALING = 15  # scales from pN
+JITTER_FORCE = 1e-3  # pN
+
+
+
+def get_force_with_angle(force, angle):
+    x = force * math.cos(angle)
+    y = force * math.sin(angle)
+    return [x, y]
+
+def front_from_corner(width, length, corner_position, angle):
+    half_width = width/2
+    dx = length * math.cos(angle) + half_width * math.cos(angle + PI/2)  # PI/2 gives a half-rotation for the width component
+    dy = length * math.sin(angle) + half_width * math.sin(angle + PI/2)
+    front_position = [corner_position[0] + dx, corner_position[1] + dy]
+    return np.array([front_position[0], front_position[1], angle])
+
+def corner_from_center(width, length, center_position, angle):
+    half_length = length/2
+    half_width = width/2
+    dx = half_length * math.cos(angle) + half_width * math.cos(angle + PI/2)
+    dy = half_length * math.sin(angle) + half_width * math.sin(angle + PI/2)
+    corner_position = [center_position[0] - dx, center_position[1] - dy]
+
+    return np.array([corner_position[0], corner_position[1], angle])
+
+def random_body_position(body):
+    ''' pick a random point along the boundary'''
+    width, length = body.dimensions
+    if random.randint(0, 1) == 0:
+        # force along ends
+        if random.randint(0, 1) == 0:
+            # force on the left end
+            location = (random.uniform(0, width), 0)
+        else:
+            # force on the right end
+            location = (random.uniform(0, width), length)
+    else:
+        # force along length
+        if random.randint(0, 1) == 0:
+            # force on the bottom end
+            location = (0, random.uniform(0, length))
+        else:
+            # force on the top end
+            location = (width, random.uniform(0, length))
+
+    return location
+
+
+
+class Multibody(Process):
+    ''''''
+    def __init__(self, initial_parameters={}):
+
+        self.elasticity = ELASTICITY
+        self.friction = FRICTION
+        self.damping = DAMPING
+        self.angular_damping = ANGULAR_DAMPING
+        self.force_scaling = FORCE_SCALING
+        self.jitter_force = initial_parameters.get('jitter_force', JITTER_FORCE)
+
+        # Space
+        self.space = pymunk.Space()
+
+        # Physics
+        self.physics_dt = PHYSICS_TS
+
+        # Static barriers
+        # TODO -- mother machine configuration
+        bounds = initial_parameters.get('bounds', [10, 10])
+        self.add_barriers(bounds)
+
+        # initialize bodies
+        self.bodies = {}
+        bodies = initial_parameters.get('bodies')
+        for body_id, specs in bodies.items():
+            self.add_body_from_center(body_id, specs)
+
+        # make ports
+        body_specs = {
+            body_id: self.get_body_specs(body_id)
+                for body_id in self.bodies.keys()}
+
+        # TODO -- need option to add/remove ports throughout simulation
+        ports = {body_id: list(specs.keys()) for body_id, specs in body_specs.items()}
+
+        parameters = {}
+        parameters.update(initial_parameters)
+
+        super(Multibody, self).__init__(ports, parameters)
+
+    def default_settings(self):
+        bodies = {
+            body_id: self.get_body_specs(body_id)
+                for body_id in self.bodies.keys()}
+        return {'state': bodies}
+
+    def next_update(self, timestep, states):
+        agents = states
+
+        # TODO -- check if any body has been removed?
+        for agent_id, specs in agents.items():
+            if agent_id in self.bodies:
+                self.update_body(agent_id, specs)
+            else:
+                # add body
+                self.add_body_from_center(agent_id, specs)
+
+
+        self.run(timestep)
+
+        # get new body variables
+        body_specs = {
+            body_id: self.get_body_specs(body_id)
+                for body_id in self.bodies.keys()}
+
+
+        return body_specs
+
+    def run(self, timestep):
+        assert self.physics_dt < timestep
+
+        time = 0
+        while time < timestep:
+            time += self.physics_dt
+
+            # apply forces
+            for body in self.space.bodies:
+                self.apply_jitter_force(body)
+                self.apply_motile_force(body)
+                self.apply_viscous_force(body)
+
+            self.space.step(self.physics_dt)
+
+    def apply_motile_force(self, body):
+        width, length = body.dimensions
+
+        # motile forces
+        motile_location = (width / 2, 0)  # apply force at back end of body
+        motile_force = [0.0, 0.0]
+        if hasattr(body, 'motile_force'):
+            thrust, torque = body.motile_force
+            motile_force = [thrust, 0.0]
+
+            # add directly to angular velocity
+            body.angular_velocity += torque
+
+            ## force-based torque
+            # if torque != 0.0:
+            #     motile_force = get_force_with_angle(thrust, torque)
+
+        scaled_motile_force = [thrust * self.force_scaling for thrust in motile_force]
+        body.apply_force_at_local_point(scaled_motile_force, motile_location)
+
+    def apply_jitter_force(self, body):
+        # jitter forces
+        jitter_location = random_body_position(body)
+        jitter_force = [
+            random.normalvariate(0, self.jitter_force),
+            random.normalvariate(0, self.jitter_force)]
+        scaled_jitter_force = [force * self.force_scaling for force in jitter_force]
+        body.apply_force_at_local_point(scaled_jitter_force, jitter_location)
+
+    def apply_viscous_force(self, body):
+        # dampen the velocity
+        body.velocity = body.velocity * self.damping + (body.force / body.mass) * self.physics_dt
+        body.angular_velocity = body.angular_velocity * self.angular_damping + body.torque / body.moment * self.physics_dt
+
+    def add_barriers(self, bounds):
+        """ Create static barriers """
+        x_bound = bounds[0]
+        y_bound = bounds[1]
+
+        static_body = self.space.static_body
+        static_lines = [
+            pymunk.Segment(static_body, (0.0, 0.0), (x_bound, 0.0), 0.0),
+            pymunk.Segment(static_body, (x_bound, 0.0), (x_bound, y_bound), 0.0),
+            pymunk.Segment(static_body, (x_bound, y_bound), (0.0, y_bound), 0.0),
+            pymunk.Segment(static_body, (0.0, y_bound), (0.0, 0.0), 0.0),
+        ]
+        for line in static_lines:
+            line.elasticity = 0.0  # no bounce
+            line.friction = 0.9
+        self.space.add(static_lines)
+
+    def add_body_from_center(self, body_id, body):
+        '''
+        add a cell to the physics engine by specifying a dictionary with values:
+            - body_id (str): the cell's id
+            - width (float)
+            - length (float)
+            - mass (float)
+            - center_position (float)
+            - angle (float)
+            - angular_velocity (float) -- this value is optional, if it is not given, it is set to 0.
+        '''
+
+        # body_id = body['body_id']
+        width = body['width']
+        length = body['length']
+        mass = body['mass']
+        center_position = body['location']
+        angle = body['angle']
+        angular_velocity = body.get('angular_velocity', 0.0)
+
+        half_length = length / 2
+        half_width = width / 2
+
+        shape = pymunk.Poly(None, (
+            (-half_length, -half_width),
+            (half_length, -half_width),
+            (half_length, half_width),
+            (-half_length, half_width)))
+
+        inertia = pymunk.moment_for_poly(mass, shape.get_vertices())
+        body = pymunk.Body(mass, inertia)
+        shape.body = body
+
+        body.position = (center_position[0], center_position[1])
+        body.angle = angle
+        body.dimensions = (width, length)
+        body.angular_velocity = angular_velocity
+
+        shape.elasticity = self.elasticity
+        shape.friction = self.friction
+
+        # add body and shape to space
+        self.space.add(body, shape)
+
+        # add body
+        self.bodies[body_id] = (body, shape)
+
+    def update_body(self, body_id, specs):
+
+        length = specs.get('length')
+        width = specs.get('width')
+        mass = specs.get('mass')
+
+        body, shape = self.bodies[body_id]
+        position = body.position
+        angle = body.angle
+
+        # make shape, moment of inertia, and add a body
+        half_length = length/2
+        half_width = width/2
+        new_shape = pymunk.Poly(None, (
+            (-half_length, -half_width),
+            (half_length, -half_width),
+            (half_length, half_width),
+            (-half_length, half_width)))
+
+        inertia = pymunk.moment_for_poly(mass, new_shape.get_vertices())
+        new_body = pymunk.Body(mass, inertia)
+        new_shape.body = new_body
+
+        new_body.position = position
+        new_body.angle = angle
+        new_body.angular_velocity = body.angular_velocity
+        new_body.dimensions = (width, length)
+
+        new_shape.elasticity = shape.elasticity
+        new_shape.friction = shape.friction
+
+        # swap bodies
+        self.space.add(new_body, new_shape)
+        self.space.remove(body, shape)
+
+        # update body
+        self.bodies[body_id] = (new_body, new_shape)
+
+    def get_body_specs(self, body_id):
+        body, shape = self.bodies[body_id]
+        width, length = body.dimensions
+        position = body.position
+        # angle = body.angle
+        # mass = body.mass
+
+
+
+
+        # TODO -- velocity? angular velocity?
+        return {
+            'location': [position[0], position[1]],
+            'angle': body.angle,
+            # 'volume': body.volume,
+            'length': length,
+            'width': width,
+            'mass': body.mass,
+            # 'forces': forces,
+        }
+
+
+
+
+# test functions
+def one_body():
+    bodies = {
+        '1': {
+            'location': [0.5, 0.5],
+            'angle': np.random.uniform(0, 2 * PI),
+            'volume': 1,
+            'length': 1.0,
+            'width': 0.5,
+            'mass': 1,
+            'forces': [0, 0]
+        },
+    }
+
+    return {
+        'bodies': bodies,
+        'bounds': [10, 10],
+    }
+
+
+def test_multibody(config=one_body(), time=1):
+    multibody = Multibody(config)
+    settings = {
+        'total_time': time,
+        # 'exchange_port': 'exchange',
+        'environment_port': 'external',
+        'environment_volume': 1e-2}
+    return simulate_process(multibody, settings)
+
+
+if __name__ == '__main__':
+    out_dir = os.path.join('out', 'tests', 'multibody')
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    config = one_body()
+    saved_data = test_multibody(config, 20)
+    timeseries = convert_to_timeseries(saved_data)
+    # plot_simulation_output(timeseries, {}, out_dir, '2_sites')

--- a/vivarium/processes/multibody_physics.py
+++ b/vivarium/processes/multibody_physics.py
@@ -338,24 +338,25 @@ class Multibody(Process):
 
 
 
-
 # test functions
-def one_body_config():
+def n_body_config(n_bodies=10, bounds=[10, 10]):
     bodies = {
-        '1': {
-            'location': [0.5, 0.5],
+        body_id: {
+            'location': [
+                np.random.uniform(0, bounds[0]),
+                np.random.uniform(0, bounds[1])],
             'angle': np.random.uniform(0, 2 * PI),
             'volume': 1,
             'length': 1.0,
             'width': 0.5,
             'mass': 1,
-            'forces': [0, 0]
-        },
+            'forces': [0, 0]}
+        for body_id in range(n_bodies)
     }
 
     return {
         'bodies': bodies,
-        'bounds': [10, 10],
+        'bounds': bounds,
         'jitter_force': 1e1,
     }
 
@@ -456,7 +457,7 @@ if __name__ == '__main__':
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    config = one_body_config()
+    config = n_body_config(10)
     saved_data = test_multibody(config, 20)
     timeseries = convert_to_timeseries(saved_data)
-    plot_snapshots(timeseries, config, out_dir, 'one_body')
+    plot_snapshots(timeseries, config, out_dir, 'bodies')


### PR DESCRIPTION
This PR continues the modularization of ```lattice's``` processes with a multibody physics process, ```multibody_physics```. There is still a lot of work left to do on this, but with this PR bodies can be initiated in the space, and run with pymunk. Each body gets its own port, with keys for location, angle, volume, mass, and motile forces -- to add and remove bodies will requires us to add and remove ports.

There is a basic test function and plotting that creates this output:
![bodies](https://user-images.githubusercontent.com/6809431/76353218-92447880-62cd-11ea-8a6e-ec311d4a388a.png)

```diffusion_field``` is also updated to support exchange bodies.  This uses a dictionary of body_ids paired with locations and exchange.  With each update, the exchanges are added at the given locations, and then diffusion runs. This can be seen with the constant secretion of a molecule in this test:
![secretion](https://user-images.githubusercontent.com/6809431/76364383-3f28f080-62e2-11ea-8c8a-bca011db5e97.png)

TODO -- ```multibody_physics```, composed with ```diffusion_field```, should give us the basics of an environmental compartment.  Each body in this environment can be connected to its own compartment through an ```environment``` store, which will be connected to the environment's agent ports -- this is how they exchange via an inner/outer relation.  I am thinking ```external``` and ```environment``` should be renamed ```boundary``` because they are really about the interface between the agent and environment rather than the environment itself.
