### PR TITLE
Agent states under one port

### DIFF
--- a/vivarium/composites/lattice_environment.py
+++ b/vivarium/composites/lattice_environment.py
@@ -62,12 +62,13 @@ def compose_lattice_environment(config):
         'diffusion': diffusion}]
 
     # topology
-    agent_ports = {agent_id: agent_id for agent_id in agent_ids}
-    diffusion_ports = {'fields': 'fields'}
-    diffusion_ports.update(agent_ports)
     topology = {
-        'multibody': agent_ports,
-        'diffusion': diffusion_ports}
+        'multibody': {
+            'agents': 'agents',
+        },
+        'diffusion': {
+            'agents': 'agents',
+            'fields': 'fields'}}
 
     # initialize the states
     # TODO -- pull out each agent_boundary, make a special initialize_state that can connect these up


### PR DESCRIPTION
This reverts some of the work from #171, back to having all agent states under one ```port``` in the environmental compartments.  After discussion with @prismofeverything, we decided to keep a ```ports``` static, and have the ```Stores``` handle all the dynamics resulting from a changing number of agents. This will likely require Stores to have many different keys, one for each agent, so that agents can share a "Boundary" Store that connects up to the environment compartment's ```'agents'``` ```port```.  