### PR TITLE
Raise Degradation Default Settings to Show Change

### DIFF
--- a/vivarium/processes/degradation.py
+++ b/vivarium/processes/degradation.py
@@ -69,13 +69,13 @@ class RnaDegradation(Process):
     def default_settings(self):
         default_state = {
             'transcripts': {
-                transcript: 10
+                transcript: 1e3
                 for transcript in self.transcript_order},
             'proteins': {
-                protein: 1
+                protein: 1e2
                 for protein in self.protein_order},
             'molecules': {
-                nucleotide: 100
+                nucleotide: 1e4
                 for nucleotide in self.molecule_order}}
 
         default_emitter_keys = {


### PR DESCRIPTION
The degradation process's default settings were too small for any
changes to be observed when the test was run. This commit raises those
counts so the test shows changes. This leads to output plots like this:

![simulation](https://user-images.githubusercontent.com/19878639/77258540-a4210680-6c51-11ea-97c3-4b9abcecf41c.png)
