### PR TITLE
complete timeseries emitter conversion

### DIFF
--- a/vivarium/compartment/composition.py
+++ b/vivarium/compartment/composition.py
@@ -254,29 +254,6 @@ def simulate_with_environment(compartment, settings={}):
     else:
         return compartment.emitter.get_timeseries()
 
-def convert_to_timeseries(sim_output):
-    '''
-    input:
-        - saved_states (dict) with {timestep: state_dict}
-    returns:
-        - timeseries (dict) with timeseries in lists {'time': [], 'port1': {'state': []}}
-    TODO --  currently assumes state is 1 dictionary deep. make a more general state embedding
-    '''
-
-    time_vec = list(sim_output.keys())
-    initial_state = sim_output[time_vec[0]]
-    timeseries = {port: {state: []
-        for state, initial in states.items()}
-        for port, states in initial_state.items()}
-    timeseries['time'] = time_vec
-
-    for time, all_states in sim_output.items():
-        for port, states in all_states.items():
-            for state_id, state in states.items():
-                timeseries[port][state_id].append(state)
-
-    return timeseries
-
 
 def set_axes(ax, show_xaxis=False):
     ax.ticklabel_format(style='sci', axis='y', scilimits=(-5,5))

--- a/vivarium/composites/lattice_environment.py
+++ b/vivarium/composites/lattice_environment.py
@@ -6,10 +6,7 @@ from vivarium.compartment.process import (
     initialize_state,
     load_compartment,
 )
-from vivarium.compartment.composition import (
-    simulate_compartment,
-    convert_to_timeseries
-)
+from vivarium.compartment.composition import simulate_compartment
 
 # processes
 from vivarium.processes.multibody_physics import (
@@ -108,8 +105,7 @@ if __name__ == '__main__':
         os.makedirs(out_dir)
 
     config = get_lattice_config()
-    saved_data = test_lattice_environment(config, 10)
-    timeseries = convert_to_timeseries(saved_data)
+    timeseries = test_lattice_environment(config, 10)
     plot_field_output(timeseries, config, out_dir, 'lattice_field')
     plot_snapshots(timeseries, config, out_dir, 'lattice_bodies')
     

--- a/vivarium/processes/diffusion_field.py
+++ b/vivarium/processes/diffusion_field.py
@@ -8,9 +8,7 @@ from scipy.ndimage import convolve
 import matplotlib.pyplot as plt
 
 from vivarium.compartment.process import Process
-from vivarium.compartment.composition import (
-    simulate_process,
-    convert_to_timeseries)
+from vivarium.compartment.composition import simulate_process
 
 
 # laplacian kernel for diffusion
@@ -195,11 +193,16 @@ class DiffusionField(Process):
             'agents': {agent_id : {'updater': 'merge'}
                    for agent_id in self.ports['agents']}}
 
+        default_emitter_keys = {
+            port_id: keys for port_id, keys in self.ports.items()}
+
         return {
             'schema': schema,
+            'emitter_keys': default_emitter_keys,
             'state': {
                  'fields': self.initial_state,
-                 'agents': self.initial_agents}}
+                 'agents': self.initial_agents}
+        }
 
     def next_update(self, timestep, states):
         fields = states['fields'].copy()
@@ -414,16 +417,13 @@ if __name__ == '__main__':
         os.makedirs(out_dir)
 
     config = get_random_field_config()
-    saved_data = test_diffusion_field(config, 10)
-    timeseries = convert_to_timeseries(saved_data)
+    timeseries = test_diffusion_field(config, 10)
     plot_field_output(timeseries, config, out_dir, 'random_field')
 
     gaussian_config = get_gaussian_config()
-    gaussian_data = test_diffusion_field(gaussian_config, 10)
-    gaussian_timeseries = convert_to_timeseries(gaussian_data)
+    gaussian_timeseries = test_diffusion_field(gaussian_config, 10)
     plot_field_output(gaussian_timeseries, gaussian_config, out_dir, 'gaussian_field')
 
     secretion_config = get_secretion_agent_config()
-    secretion_data = test_diffusion_field(secretion_config, 10)
-    secretion_timeseries = convert_to_timeseries(secretion_data)
+    secretion_timeseries = test_diffusion_field(secretion_config, 10)
     plot_field_output(secretion_timeseries, secretion_config, out_dir, 'secretion')

--- a/vivarium/processes/multibody_physics.py
+++ b/vivarium/processes/multibody_physics.py
@@ -5,8 +5,7 @@ os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = "hide"
 
 import random
 import math
-import copy
-import uuid
+
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -17,12 +16,9 @@ import pymunk
 # vivarium imports
 from vivarium.compartment.process import (
     Process,
-    Store,
     COMPARTMENT_STATE)
 from vivarium.compartment.composition import (
-    simulate_process,
-    process_in_compartment,
-    convert_to_timeseries)
+    simulate_process)
 
 
 # constants
@@ -137,9 +133,14 @@ class Multibody(Process):
         schema = {'agents': {agent_id: {'updater': 'merge'}
                 for agent_id, agent in agents.items()}}
 
+        default_emitter_keys = {
+            port_id: keys for port_id, keys in self.ports.items()}
+
         return {
             'state': state,
-            'schema': schema,}
+            'schema': schema,
+            'emitter_keys': default_emitter_keys,
+        }
 
     def next_update(self, timestep, states):
         agents = states['agents']
@@ -455,7 +456,6 @@ if __name__ == '__main__':
         os.makedirs(out_dir)
 
     config = random_body_config(get_n_dummy_agents(10))
-    saved_data = test_multibody(config, 20)
-    timeseries = convert_to_timeseries(saved_data)
+    timeseries = test_multibody(config, 20)
     plot_snapshots(timeseries, config, out_dir, 'bodies')
 


### PR DESCRIPTION
This completes the transition begun in #167. ```convert_to_timeseries``` is now removed from ```composition.py```, so there is no redundant code left. All compartment simulations are using the ```TimeseriesEmitter``` for their timeseries.