### PR TITLE
begin chemotaxis master, add topology plot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ cffi==1.13.2
 cobra==0.17.1
 confluent-kafka==0.11.5
 matplotlib==2.2.2
+networkx==2.4
 numpy==1.15.3
 parsimonious==0.8.1
 Pint==0.9

--- a/vivarium/compartment/composition.py
+++ b/vivarium/compartment/composition.py
@@ -73,7 +73,7 @@ def get_derivers(process_list, topology):
                     source_compartment_port = port_map[source_port]
                     target_compartment_port = port_map[target_port]
                 except:
-                    print('{} source/target port mismatch'.format(process_id))
+                    print('source/target port mismatch for process "{}"'.format(process_id))
                     raise
 
                 deriver_topology = {

--- a/vivarium/compartment/composition.py
+++ b/vivarium/compartment/composition.py
@@ -259,6 +259,11 @@ def simulate_with_environment(compartment, settings={}):
 
 # plotting functions
 def plot_compartment_topology(compartment, settings, out_dir='out', filename='topology'):
+    """
+    Make a plot of the topology
+     - compartment: a compartment
+     - settings (dict): 'network_layout' can be 'bipartite' or 'process_layers'
+    """
     store_rgb = [x/255 for x in [239,131,148]]
     process_rgb = [x / 255 for x in [249, 204, 86]]
     node_size = 2500
@@ -268,15 +273,16 @@ def plot_compartment_topology(compartment, settings, out_dir='out', filename='to
     topology = compartment.topology
     process_layers = compartment.processes
 
-    # get layout
+    # get figure settings
     network_layout = settings.get('network_layout', 'bipartite')
+    show_ports = settings.get('show_ports', True)
 
 
     # make graph from topology
     G = nx.Graph()
     process_nodes = []
     store_nodes = []
-    edges = []
+    edges = {}
     for process_id, connections in topology.items():
         process_nodes.append(process_id)
         G.add_node(process_id)
@@ -288,7 +294,8 @@ def plot_compartment_topology(compartment, settings, out_dir='out', filename='to
                 G.add_node(store_id)
 
             edge = (process_id, store_id)
-            edges.append(edge)
+            edges[edge]= port
+
             G.add_edge(process_id, store_id)
 
     # are there overlapping names?
@@ -343,21 +350,28 @@ def plot_compartment_topology(compartment, settings, out_dir='out', filename='to
                            node_shape='s')
 
     # edges
-    colors = list(range(1,len(edges)))
+    colors = list(range(1,len(edges)+1))
     nx.draw_networkx_edges(G, pos,
                            edge_color=colors,
                            width=1.5)
 
-    #labels
+    # labels
     nx.draw_networkx_labels(G, pos,
                             font_size=8,
                             )
+    if show_ports:
+        nx.draw_networkx_edge_labels(G, pos,
+                                 edge_labels=edges,
+                                 font_size=6,
+                                 label_pos=0.85)
 
     # save figure
     fig_path = os.path.join(out_dir, filename)
     plt.figure(3, figsize=(12, 12))
     plt.axis('off')
     plt.savefig(fig_path, bbox_inches='tight')
+
+    plt.close()
 
 
 def set_axes(ax, show_xaxis=False):

--- a/vivarium/composites/PMF_chemotaxis.py
+++ b/vivarium/composites/PMF_chemotaxis.py
@@ -73,10 +73,10 @@ def compose_pmf_chemotaxis(config):
             'internal': 'cytoplasm',
             'external': 'environment'},
         'flagella': {
-            'counts': 'cell_counts',
+            'flagella_counts': 'cell_counts',
             'internal': 'cytoplasm',
             'membrane': 'membrane',
-            'flagella': 'flagella',
+            'flagella_activity': 'flagella',
             'external': 'environment'},
         'PMF': {
             'external': 'environment',

--- a/vivarium/composites/chemotaxis_master
+++ b/vivarium/composites/chemotaxis_master
@@ -10,6 +10,7 @@ from vivarium.compartment.composition import (
     simulate_with_environment,
     plot_simulation_output)
 from vivarium.composites.gene_expression import plot_gene_expression_output
+from vivarium.composites.flagella_expression import get_flg_expression_config
 
 # processes
 from vivarium.processes.division import (
@@ -53,13 +54,14 @@ def compose_chemotaxis_master(config):
     metabolism_config.update({'constrained_reaction_ids': target_fluxes})
     metabolism = Metabolism(metabolism_config)
 
-    # expression
-    transcription = Transcription(config.get('transcription', {}))
-    translation = Translation(config.get('translation', {}))
-    degradation = RnaDegradation(config.get('degradation', {}))
-    complexation = Complexation(config.get('complexation', {}))
+    # flagella expression
+    flg_expression_config = get_flg_expression_config()
+    transcription = Transcription(flg_expression_config['transcription'])
+    translation = Translation(flg_expression_config['translation'])
+    degradation = RnaDegradation(flg_expression_config['degradation'])
+    complexation = Complexation(flg_expression_config['complexation'])
 
-    # chemotaxis
+    # chemotaxis -- flagella activity, receptor activity, and PMF
     receptor_parameters = {'ligand': 'GLC'}
     receptor_parameters.update(config)
     receptor = ReceptorCluster(config.get('receptor', receptor_parameters))
@@ -74,49 +76,60 @@ def compose_chemotaxis_master(config):
 
     # Place processes in layers
     processes = [
-        {'PMF': PMF},
+        {
+        'PMF': PMF
+        },
 
-        {'receptor': receptor,
-         'transport': transport,
-         'transcription': transcription,
-         'translation': translation,
-         'degradation': degradation,
-         'complexation': complexation},
+        {
+        'receptor': receptor,
+        'transport': transport,
+        },
 
-        {'flagella': flagella,
-         'metabolism': metabolism},
+        {
+        'transcription': transcription,
+        'translation': translation,
+        'degradation': degradation,
+        'complexation': complexation,
+        # 'metabolism': metabolism
+        },
 
-        {'division': division}
+        {
+        'flagella': flagella
+        },
+
+        {
+        'division': division
+        }
     ]
 
     # Make the topology
     # for each process, map process ports to store ids
     topology = {
         'transport': {
-            'internal': 'cell',
+            'internal': 'internal',
             'external': 'environment',
             'exchange': 'null',  # metabolism's exchange is used
             'fluxes': 'flux_bounds',
             'global': 'global'},
 
-        'metabolism': {
-            'internal': 'cell',
-            'external': 'environment',
-            'reactions': 'reactions',
-            'exchange': 'exchange',
-            'flux_bounds': 'flux_bounds',
-            'global': 'global'},
+        # 'metabolism': {
+        #     'internal': 'internal',
+        #     'external': 'environment',
+        #     'reactions': 'reactions',
+        #     'exchange': 'exchange',
+        #     'flux_bounds': 'flux_bounds',
+        #     'global': 'global'},
 
         'transcription': {
             'chromosome': 'chromosome',
-            'molecules': 'molecules',
+            'molecules': 'internal',
             'proteins': 'proteins',
             'transcripts': 'transcripts',
             'factors': 'concentrations'},
 
         'translation': {
             'ribosomes': 'ribosomes',
-            'molecules': 'molecules',
+            'molecules': 'internal',
             'transcripts': 'transcripts',
             'proteins': 'proteins',
             'concentrations': 'concentrations'},
@@ -124,7 +137,7 @@ def compose_chemotaxis_master(config):
         'degradation': {
             'transcripts': 'transcripts',
             'proteins': 'proteins',
-            'molecules': 'molecules',
+            'molecules': 'internal',
             'global': 'global'},
 
         'complexation': {
@@ -133,35 +146,41 @@ def compose_chemotaxis_master(config):
 
         'receptor': {
             'external': 'environment',
-            'internal': 'cytoplasm'},
+            'internal': 'internal'},
 
         'flagella': {
-            'counts': 'cell_counts',
-            'internal': 'cytoplasm',
+            'internal': 'internal',
             'membrane': 'membrane',
-            'flagella': 'flagella',
+            'flagella_counts': 'proteins',
+            'flagella_activity': 'flagella',
             'external': 'environment'},
 
         'PMF': {
             'external': 'environment',
             'membrane': 'membrane',
-            'internal': 'cytoplasm'},
+            'internal': 'internal'},
 
         'division': {
-            'global': 'global'}}
+            'global': 'global'}
+    }
 
     # add derivers
     derivers = get_derivers(processes, topology)
     processes.extend(derivers['deriver_processes'])  # add deriver processes
     topology.update(derivers['deriver_topology'])  # add deriver topology
 
-    # initialize the states
-    states = initialize_state(processes, topology, config.get('initial_state', {}))
+    ## Initialize the states
+
+    # flagella initialized at 8
+    initial_state = {
+        'internal': {'flagella': 8}
+    }
+    states = initialize_state(processes, topology, config.get('initial_state', initial_state))
 
     options = {
         'name': config.get('name', 'chemotaxis_master'),
         'environment_port': 'environment',
-        'exchange_port': 'exchange',
+        # 'exchange_port': 'exchange',
         'topology': topology,
         'initial_time': config.get('initial_time', 0.0),
         'divide_condition': divide_condition}
@@ -180,36 +199,37 @@ if __name__ == '__main__':
         os.makedirs(out_dir)
 
     compartment = load_compartment(compose_chemotaxis_master)
-
-    # settings for simulation and plot
     options = compartment.configuration
 
-    # define timeline
-    timeline = [(20, {})] # 2520 sec (42 min) is the expected doubling time in minimal media
-
+    # simulate
+    timeline = [(120, {})] # 2520 sec (42 min) is the expected doubling time in minimal media
     settings = {
-        'environment_port': options['environment_port'],
-        'exchange_port': options['exchange_port'],
+        'environment_port': options.get('environment_port'),
+        'exchange_port': options.get('exchange_port'),
         'environment_volume': 1e-13,  # L
-        'timeline': timeline,
-    }
+        'timeline': timeline}
 
+    timeseries = simulate_with_environment(compartment, settings)
+
+    # get growth
+    volume_ts = timeseries['global']['volume']
+    print('growth: {}'.format(volume_ts[-1]/volume_ts[0]))
+
+    # plots
     plot_settings = {
-        'max_rows': 20,
+        'max_rows': 60,
         'remove_zeros': True,
         'overlay': {'reactions': 'flux_bounds'},
         'skip_ports': ['prior_state', 'null']}
+    plot_simulation_output(timeseries, plot_settings, out_dir)
 
-    expression_plot_settings = {
-        'name': 'gene_expression',
+    gene_exp_plot_config = {
+        'name': 'flagella_expression',
         'ports': {
             'transcripts': 'transcripts',
-            'molecules': 'cell',
-            'proteins': 'proteins'}}
-
-    # saved_state = simulate_compartment(compartment, settings)
-    timeseries = simulate_with_environment(compartment, settings)
-    volume_ts = timeseries['global']['volume']
-    print('growth: {}'.format(volume_ts[-1]/volume_ts[0]))
-    plot_gene_expression_output(timeseries, expression_plot_settings, out_dir)
-    plot_simulation_output(timeseries, plot_settings, out_dir)
+            'proteins': 'proteins',
+            'molecules': 'molecules'}}
+    plot_gene_expression_output(
+        timeseries,
+        gene_exp_plot_config,
+        out_dir)

--- a/vivarium/composites/chemotaxis_master
+++ b/vivarium/composites/chemotaxis_master
@@ -204,7 +204,12 @@ if __name__ == '__main__':
     options = compartment.configuration
 
     # save the topology network
-    plot_compartment_topology(compartment, out_dir)
+    topology_plot_settings = {
+        'network_layout': 'process_layers'}
+    plot_compartment_topology(
+        compartment,
+        topology_plot_settings,
+        out_dir)
 
     # simulate
     timeline = [(120, {})] # 2520 sec (42 min) is the expected doubling time in minimal media
@@ -238,3 +243,4 @@ if __name__ == '__main__':
         timeseries,
         gene_exp_plot_config,
         out_dir)
+    

--- a/vivarium/composites/chemotaxis_master
+++ b/vivarium/composites/chemotaxis_master
@@ -1,0 +1,215 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+
+from vivarium.compartment.process import (
+    initialize_state,
+    load_compartment)
+from vivarium.compartment.composition import (
+    get_derivers,
+    simulate_with_environment,
+    plot_simulation_output)
+from vivarium.composites.gene_expression import plot_gene_expression_output
+
+# processes
+from vivarium.processes.division import (
+    Division,
+    divide_condition
+)
+from vivarium.processes.metabolism import (
+    Metabolism,
+    get_iAF1260b_config
+)
+from vivarium.processes.convenience_kinetics import (
+    ConvenienceKinetics,
+    get_glc_lct_config
+)
+from vivarium.processes.transcription import Transcription
+from vivarium.processes.translation import Translation
+from vivarium.processes.degradation import RnaDegradation
+from vivarium.processes.complexation import Complexation
+from vivarium.processes.Endres2006_chemoreceptor import ReceptorCluster
+from vivarium.processes.Mears2014_flagella_activity import FlagellaActivity
+from vivarium.processes.membrane_potential import MembranePotential
+
+
+# the composite function
+def compose_chemotaxis_master(config):
+    """
+    A composite with kinetic transport, metabolism, and gene expression
+    """
+
+    ## Declare the processes.
+    # Transport
+    # load the kinetic parameters
+    transport_config = config.get('transport', get_glc_lct_config())
+    transport = ConvenienceKinetics(transport_config)
+    target_fluxes = transport.kinetic_rate_laws.reaction_ids
+
+    # Metabolism
+    # get target fluxes from transport
+    # load regulation function
+    metabolism_config = config.get('metabolism', get_iAF1260b_config())
+    metabolism_config.update({'constrained_reaction_ids': target_fluxes})
+    metabolism = Metabolism(metabolism_config)
+
+    # expression
+    transcription = Transcription(config.get('transcription', {}))
+    translation = Translation(config.get('translation', {}))
+    degradation = RnaDegradation(config.get('degradation', {}))
+    complexation = Complexation(config.get('complexation', {}))
+
+    # chemotaxis
+    receptor_parameters = {'ligand': 'GLC'}
+    receptor_parameters.update(config)
+    receptor = ReceptorCluster(config.get('receptor', receptor_parameters))
+    flagella = FlagellaActivity(config.get('flagella', {}))
+    PMF = MembranePotential(config.get('PMF', {}))
+
+    # Division
+    # get initial volume from metabolism
+    division_config = config.get('division', {})
+    division_config.update({'initial_state': metabolism.initial_state})
+    division = Division(division_config)
+
+    # Place processes in layers
+    processes = [
+        {'PMF': PMF},
+
+        {'receptor': receptor,
+         'transport': transport,
+         'transcription': transcription,
+         'translation': translation,
+         'degradation': degradation,
+         'complexation': complexation},
+
+        {'flagella': flagella,
+         'metabolism': metabolism},
+
+        {'division': division}
+    ]
+
+    # Make the topology
+    # for each process, map process ports to store ids
+    topology = {
+        'transport': {
+            'internal': 'cell',
+            'external': 'environment',
+            'exchange': 'null',  # metabolism's exchange is used
+            'fluxes': 'flux_bounds',
+            'global': 'global'},
+
+        'metabolism': {
+            'internal': 'cell',
+            'external': 'environment',
+            'reactions': 'reactions',
+            'exchange': 'exchange',
+            'flux_bounds': 'flux_bounds',
+            'global': 'global'},
+
+        'transcription': {
+            'chromosome': 'chromosome',
+            'molecules': 'molecules',
+            'proteins': 'proteins',
+            'transcripts': 'transcripts',
+            'factors': 'concentrations'},
+
+        'translation': {
+            'ribosomes': 'ribosomes',
+            'molecules': 'molecules',
+            'transcripts': 'transcripts',
+            'proteins': 'proteins',
+            'concentrations': 'concentrations'},
+
+        'degradation': {
+            'transcripts': 'transcripts',
+            'proteins': 'proteins',
+            'molecules': 'molecules',
+            'global': 'global'},
+
+        'complexation': {
+            'monomers': 'proteins',
+            'complexes': 'proteins'},
+
+        'receptor': {
+            'external': 'environment',
+            'internal': 'cytoplasm'},
+
+        'flagella': {
+            'counts': 'cell_counts',
+            'internal': 'cytoplasm',
+            'membrane': 'membrane',
+            'flagella': 'flagella',
+            'external': 'environment'},
+
+        'PMF': {
+            'external': 'environment',
+            'membrane': 'membrane',
+            'internal': 'cytoplasm'},
+
+        'division': {
+            'global': 'global'}}
+
+    # add derivers
+    derivers = get_derivers(processes, topology)
+    processes.extend(derivers['deriver_processes'])  # add deriver processes
+    topology.update(derivers['deriver_topology'])  # add deriver topology
+
+    # initialize the states
+    states = initialize_state(processes, topology, config.get('initial_state', {}))
+
+    options = {
+        'name': config.get('name', 'chemotaxis_master'),
+        'environment_port': 'environment',
+        'exchange_port': 'exchange',
+        'topology': topology,
+        'initial_time': config.get('initial_time', 0.0),
+        'divide_condition': divide_condition}
+
+    return {
+        'processes': processes,
+        'states': states,
+        'options': options}
+
+
+
+
+if __name__ == '__main__':
+    out_dir = os.path.join('out', 'tests', 'chemotaxis_master')
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    compartment = load_compartment(compose_chemotaxis_master)
+
+    # settings for simulation and plot
+    options = compartment.configuration
+
+    # define timeline
+    timeline = [(20, {})] # 2520 sec (42 min) is the expected doubling time in minimal media
+
+    settings = {
+        'environment_port': options['environment_port'],
+        'exchange_port': options['exchange_port'],
+        'environment_volume': 1e-13,  # L
+        'timeline': timeline,
+    }
+
+    plot_settings = {
+        'max_rows': 20,
+        'remove_zeros': True,
+        'overlay': {'reactions': 'flux_bounds'},
+        'skip_ports': ['prior_state', 'null']}
+
+    expression_plot_settings = {
+        'name': 'gene_expression',
+        'ports': {
+            'transcripts': 'transcripts',
+            'molecules': 'cell',
+            'proteins': 'proteins'}}
+
+    # saved_state = simulate_compartment(compartment, settings)
+    timeseries = simulate_with_environment(compartment, settings)
+    volume_ts = timeseries['global']['volume']
+    print('growth: {}'.format(volume_ts[-1]/volume_ts[0]))
+    plot_gene_expression_output(timeseries, expression_plot_settings, out_dir)
+    plot_simulation_output(timeseries, plot_settings, out_dir)

--- a/vivarium/composites/chemotaxis_master
+++ b/vivarium/composites/chemotaxis_master
@@ -8,7 +8,8 @@ from vivarium.compartment.process import (
 from vivarium.compartment.composition import (
     get_derivers,
     simulate_with_environment,
-    plot_simulation_output)
+    plot_simulation_output,
+    plot_compartment_topology)
 from vivarium.composites.gene_expression import plot_gene_expression_output
 from vivarium.composites.flagella_expression import get_flg_expression_config
 
@@ -152,7 +153,7 @@ def compose_chemotaxis_master(config):
             'internal': 'internal',
             'membrane': 'membrane',
             'flagella_counts': 'proteins',
-            'flagella_activity': 'flagella',
+            'flagella_activity': 'flagella_activity',
             'external': 'environment'},
 
         'PMF': {
@@ -170,12 +171,13 @@ def compose_chemotaxis_master(config):
     topology.update(derivers['deriver_topology'])  # add deriver topology
 
     ## Initialize the states
-
-    # flagella initialized at 8
+    # flagella initialized
     initial_state = {
-        'internal': {'flagella': 8}
-    }
-    states = initialize_state(processes, topology, config.get('initial_state', initial_state))
+        'internal': {'flagella': 8}}
+    states = initialize_state(
+        processes,
+        topology,
+        config.get('initial_state', initial_state))
 
     options = {
         'name': config.get('name', 'chemotaxis_master'),
@@ -200,6 +202,9 @@ if __name__ == '__main__':
 
     compartment = load_compartment(compose_chemotaxis_master)
     options = compartment.configuration
+
+    # save the topology network
+    plot_compartment_topology(compartment, out_dir)
 
     # simulate
     timeline = [(120, {})] # 2520 sec (42 min) is the expected doubling time in minimal media

--- a/vivarium/composites/chemotaxis_master
+++ b/vivarium/composites/chemotaxis_master
@@ -204,11 +204,15 @@ if __name__ == '__main__':
     options = compartment.configuration
 
     # save the topology network
-    topology_plot_settings = {
-        'network_layout': 'process_layers'}
     plot_compartment_topology(
         compartment,
-        topology_plot_settings,
+        {'network_layout': 'bipartite'},
+        out_dir)
+
+    plot_compartment_topology(
+        compartment,
+        {'network_layout': 'process_layers',
+         'show_ports': False},
         out_dir)
 
     # simulate
@@ -243,4 +247,3 @@ if __name__ == '__main__':
         timeseries,
         gene_exp_plot_config,
         out_dir)
-    

--- a/vivarium/composites/flagella_expression.py
+++ b/vivarium/composites/flagella_expression.py
@@ -20,11 +20,9 @@ def degradation_sequences(sequence, promoters):
             promoter.last_terminator().position))
         for promoter_key, promoter in promoters.items()}
 
-def generate_flagella_compartment(config):
+def get_flg_expression_config():
     plasmid = Chromosome(flagella_chromosome.config)
     sequences = plasmid.product_sequences()
-
-    print(sequences)
 
     molecules = {}
     for nucleotide in nucleotides.values():
@@ -55,7 +53,7 @@ def generate_flagella_compartment(config):
             'polymerase_occlusion': 50},
 
         'degradation': {
-            
+
             'sequences': sequences,
             'catalysis_rates': {
                 'endoRNAse': 0.01},
@@ -83,6 +81,12 @@ def generate_flagella_compartment(config):
                 'endoRNAse': 1,
                 UNBOUND_RIBOSOME_KEY: 10,
                 UNBOUND_RNAP_KEY: 10}}}
+
+    return flagella_expression_config
+
+
+def generate_flagella_compartment(config):
+    flagella_expression_config = get_flg_expression_config()
 
     return compose_gene_expression(flagella_expression_config)
 

--- a/vivarium/composites/flagella_expression.py
+++ b/vivarium/composites/flagella_expression.py
@@ -12,14 +12,6 @@ from vivarium.processes.transcription import UNBOUND_RNAP_KEY
 from vivarium.processes.translation import UNBOUND_RIBOSOME_KEY
 from vivarium.composites.gene_expression import compose_gene_expression, plot_gene_expression_output
 
-def degradation_sequences(sequence, promoters):
-    return {
-        promoter.last_terminator().product[0]: rna_bases(sequence_monomers(
-            sequence,
-            promoter.position,
-            promoter.last_terminator().position))
-        for promoter_key, promoter in promoters.items()}
-
 def get_flg_expression_config():
     plasmid = Chromosome(flagella_chromosome.config)
     sequences = plasmid.product_sequences()

--- a/vivarium/composites/variable_flagella.py
+++ b/vivarium/composites/variable_flagella.py
@@ -34,7 +34,7 @@ def compose_variable_flagella(config):
     # flagella
     flagella_config = copy.deepcopy(config)
     flagella_range = [0, 1, 5]  #list(range(0, 4))
-    flagella_config.update({'n_flagella': random.choice(flagella_range)})
+    flagella_config.update({'flagella': random.choice(flagella_range)})
     flagella = FlagellaActivity(flagella_config)
 
     # proton motive force
@@ -59,10 +59,10 @@ def compose_variable_flagella(config):
             'external': 'environment'},
         'flagella': {
             'internal': 'cell',
-            'counts': 'counts',
             'external': 'environment',
             'membrane': 'membrane',
-            'flagella': 'flagella'},
+            'flagella_counts': 'counts',
+            'flagella_activity': 'flagella'},
         'PMF': {
             'internal': 'cell',
             'external': 'environment',
@@ -115,6 +115,5 @@ if __name__ == '__main__':
         'max_rows': 20,
         'skip_ports': ['prior_state']}
 
-    # saved_state = simulate_compartment(compartment, settings)
     timeseries = simulate_with_environment(compartment, settings)
     plot_simulation_output(timeseries, plot_settings, out_dir)

--- a/vivarium/processes/Mears2014_flagella_activity.py
+++ b/vivarium/processes/Mears2014_flagella_activity.py
@@ -96,13 +96,13 @@ class FlagellaActivity(Process):
                 'motile_state',
                 'motile_force',
                 'motile_torque'],
-            'counts': [
+            'flagella_counts': [
                 'flagella'],
             'membrane': [
                 'PMF',
                 'protons_flux_accumulated'],
-            'flagella': [
-                'flagella_activity'],
+            'flagella_activity': [
+                'flagella'],
             'external': []}
 
         parameters = DEFAULT_PARAMETERS
@@ -121,18 +121,18 @@ class FlagellaActivity(Process):
             'membrane': {
                 'PMF': DEFAULT_PMF,
                 'PROTONS': 0},
-            'counts': {'flagella': self.n_flagella},
-            'flagella': {
-                'flagella_activity': {
+            'flagella_counts': {
+                'flagella': self.n_flagella},
+            'flagella_activity': {
+                'flagella': {
                     flagella_id: random.choice([-1, 1]) for flagella_id in self.flagella_ids}},
             'internal': internal}
 
         # default emitter keys
         default_emitter_keys = {
             'internal': ['motile_force', 'motile_torque', 'motile_state', 'CheY', 'CheY_P', 'cw_bias'],
-            'flagella': ['flagella_activity'],
-            # 'external': [],
-        }
+            'flagella_counts': ['flagella'],
+            'flagella_activity': ['flagella']}
 
         # default updaters
         internal_set_states = [
@@ -152,7 +152,7 @@ class FlagellaActivity(Process):
         schema = {
             'internal': internal_schema,
             'membrane': {'PROTONS': {'updater': 'accumulate'}},
-            'flagella': {'flagella_activity': {
+            'flagella_activity': {'flagella': {
                 'updater': 'set',
                 'divide': 'split_dict'}}}
 
@@ -168,8 +168,8 @@ class FlagellaActivity(Process):
     def next_update(self, timestep, states):
 
         internal = states['internal']
-        n_flagella = states['counts']['flagella']
-        flagella = states['flagella']['flagella_activity']
+        n_flagella = states['flagella_counts']['flagella']
+        flagella = states['flagella_activity']['flagella']
         PMF = states['membrane']['PMF']
 
         # adjust number of flagella
@@ -234,8 +234,8 @@ class FlagellaActivity(Process):
             torque = 0
 
         return {
-            'flagella': {
-                'flagella_activity': flagella_update},
+            'flagella_activity': {
+                'flagella': flagella_update},
             'internal' : {
                 'CheY': CheY,
                 'CheY_P': CheY_P,
@@ -340,7 +340,7 @@ def plot_activity(output, out_dir='out', filename='motor_control'):
     cw_bias_vec = output['internal']['cw_bias']
     motile_state_vec = output['internal']['motile_state']
     motile_force_vec = output['internal']['motile_force']
-    flagella_activity = output['flagella']['flagella_activity']
+    flagella_activity = output['flagella_activity']['flagella']
     time_vec = output['time']
 
     # get flagella ids
@@ -503,12 +503,12 @@ if __name__ == '__main__':
         os.makedirs(out_dir)
 
     zero_flagella = {'flagella': 0}
-    timeline = [(2, {})]
+    timeline = [(10, {})]
     output1 = test_activity(zero_flagella, timeline)
     plot_activity(output1, out_dir, 'motor_control_zero_flagella')
 
     five_flagella = {'flagella': 5}
-    timeline = [(2, {})]
+    timeline = [(10, {})]
     output2 = test_activity(five_flagella, timeline)
     plot_activity(output2, out_dir, 'motor_control')
 
@@ -517,12 +517,12 @@ if __name__ == '__main__':
     timeline = [
         (0, {}),
         (2, {
-            'counts': {
+            'flagella_counts': {
                 'flagella': 6}}),
         (4, {
-            'counts': {
+            'flagella_counts': {
                 'flagella': 4}}),
-        (6, {})]
+        (10, {})]
     output3 = test_activity(init_params, timeline)
     plot_activity(output3, out_dir, 'motor_control_variable')
 


### PR DESCRIPTION
This PR begins the chemotaxis master composite, ```chemotaxis_master```, which will be used for the final story of the vivarium paper and for the chemotaxis paper.

The most exciting addition is the new ```plot_compartment_topology``` plotting function in ```composition.py```. This adds ```networkx``` to our requirements -- a popular library for network analysis that we can probably use elsewhere. ```plot_compartment_topology```  takes in a compartment and saves a network figure of its topology. This is useful for quickly assessing complex topology structure.

![topology](https://user-images.githubusercontent.com/6809431/78400442-93568600-75ab-11ea-9928-6118e759fc84.png)

chemotaxis master is the only composite currently using it, but it can be added to all composites with:
```plot_compartment_topology(compartment, out_dir)```

