### PR TITLE
agent port with agent key

### DIFF
--- a/vivarium/compartment/process.py
+++ b/vivarium/compartment/process.py
@@ -39,7 +39,15 @@ def update_set(key, state_dict, current_value, new_value):
     return new_value, {}
 
 def update_merge(key, state_dict, current_value, new_value):
-    return deep_merge(dict(current_value), new_value), {}
+    # merge dicts, with new_value replacing any shared keys with current_value
+    update = current_value.copy()
+    for k, v in current_value.items():
+        new = new_value.get(k)
+        if isinstance(new, dict):
+            update[k] = deep_merge(dict(v), new)
+        else:
+            update[k] = new
+    return update, {}
 
 updater_library = {
     'accumulate': update_accumulate,

--- a/vivarium/composites/lattice_environment.py
+++ b/vivarium/composites/lattice_environment.py
@@ -100,10 +100,26 @@ def get_lattice_config():
 
 def test_lattice_environment(config=get_lattice_config(), time=10):
     lattice_environment = load_compartment(compose_lattice_environment, config)
-    settings = {'total_time': time}
+    settings = {
+        'return_raw_data': True,
+        'total_time': time}
     return simulate_compartment(lattice_environment, settings)
 
 
+# TODO -- this is copied from TimeSeriesEmitter -- make a shared function
+def get_timeseries(data):
+    time_vec = list(data.keys())
+    initial_state = data[time_vec[0]]
+    timeseries = {port: {state: []
+                         for state, initial in states.items()}
+                  for port, states in initial_state.items()}
+    timeseries['time'] = time_vec
+
+    for time, all_states in data.items():
+        for port, states in all_states.items():
+            for state_id, state in states.items():
+                timeseries[port][state_id].append(state)
+    return timeseries
 
 if __name__ == '__main__':
     out_dir = os.path.join('out', 'tests', 'lattice_environment_composite')
@@ -111,7 +127,9 @@ if __name__ == '__main__':
         os.makedirs(out_dir)
 
     config = get_lattice_config()
-    timeseries = test_lattice_environment(config, 10)
+    data = test_lattice_environment(config, 10)
+    timeseries = get_timeseries(data)
+
     plot_field_output(timeseries, config, out_dir, 'lattice_field')
-    plot_snapshots(timeseries, config, out_dir, 'lattice_bodies')
+    plot_snapshots(data, config, out_dir, 'lattice_bodies')
     

--- a/vivarium/processes/multibody_physics.py
+++ b/vivarium/processes/multibody_physics.py
@@ -118,7 +118,7 @@ class Multibody(Process):
             self.add_body_from_center(agent_id, specs)
 
         # all initial agents get a key under a single port
-        ports = {'agents': list(self.agents.keys())}
+        ports = {'agents': ['agents']}
 
         parameters = {}
         parameters.update(initial_parameters)
@@ -128,10 +128,9 @@ class Multibody(Process):
     def default_settings(self):
         agents = {agent_id: self.get_body_specs(agent_id)
                 for agent_id in self.agents.keys()}
-        state = {'agents': agents}
+        state = {'agents': {'agents': agents}}
 
-        schema = {'agents': {agent_id: {'updater': 'merge'}
-                for agent_id, agent in agents.items()}}
+        schema = {'agents': {'agents': {'updater': 'merge'}}}
 
         default_emitter_keys = {
             port_id: keys for port_id, keys in self.ports.items()}
@@ -143,7 +142,7 @@ class Multibody(Process):
         }
 
     def next_update(self, timestep, states):
-        agents = states['agents']
+        agents = states['agents']['agents']
 
         # check if an agent has been removed
         removed_agents = [
@@ -166,7 +165,7 @@ class Multibody(Process):
             agent_id: self.get_body_specs(agent_id)
             for agent_id in self.agents.keys()}
 
-        return {'agents': new_agents}
+        return {'agents': {'agents': new_agents}}
 
     def run(self, timestep):
         assert self.physics_dt < timestep
@@ -377,7 +376,6 @@ def plot_agents(ax, agents, agent_colors={}):
     - agents: a dict with {agent_id: agent_data} and
         agent_data a dict with keys location, angle, length, width
     - agent_colors: dict with {agent_id: hsv color}
--
     '''
     for agent_id, agent_data in agents.items():
         color = agent_colors.get(agent_id, [DEFAULT_HUE]+DEFAULT_SV)
@@ -388,12 +386,16 @@ def plot_snapshots(data, config, out_dir='out', filename='multibody'):
     bounds = config.get('bounds', DEFAULT_BOUNDS)
 
     # time steps that will be used
-    time_vec = data['time']
+    time_vec = list(data.keys())
     time_indices = np.round(np.linspace(0, len(time_vec) - 1, n_snapshots)).astype(int)
     snapshot_times = [time_vec[i] for i in time_indices]
 
     # get agents
-    agents = data['agents']
+    agents = set()
+    for time, time_data in data.items():
+        current_agents = list(time_data['agents']['agents'].keys())
+        agents.update(current_agents)
+    agents = list(agents)
 
     agent_colors = {}
     for agent_id in agents:
@@ -412,17 +414,7 @@ def plot_snapshots(data, config, out_dir='out', filename='multibody'):
     for col_idx, (time_idx, time) in enumerate(zip(time_indices, snapshot_times), 1):
         row_idx = 0
         ax = init_axes(fig, bounds[0], bounds[1], grid, row_idx, col_idx, time)
-
-        # get agents_now and plot them
-        agents_now = {}
-        for agent_id, series in agents.items():
-            if series[time_idx]['location'] is not None:
-                agent_data = {
-                    'location': series[time_idx]['location'],
-                    'angle': series[time_idx]['angle'],
-                    'length': series[time_idx]['length'],
-                    'width': series[time_idx]['width']}
-                agents_now[agent_id] = agent_data
+        agents_now = data[time]['agents']['agents']
         plot_agents(ax, agents_now, agent_colors)
 
     fig_path = os.path.join(out_dir, filename)
@@ -444,10 +436,10 @@ def test_multibody(config=random_body_config(), time=1):
     multibody = Multibody(config)
     settings = {
         'total_time': time,
+        'return_raw_data': True,
         'environment_port': 'external',
         'environment_volume': 1e-2}
     return simulate_process(multibody, settings)
-
 
 
 if __name__ == '__main__':
@@ -456,6 +448,5 @@ if __name__ == '__main__':
         os.makedirs(out_dir)
 
     config = random_body_config(get_n_dummy_agents(10))
-    timeseries = test_multibody(config, 20)
-    plot_snapshots(timeseries, config, out_dir, 'bodies')
-
+    data = test_multibody(config, 20)
+    plot_snapshots(data, config, out_dir, 'bodies')


### PR DESCRIPTION
I'm again redoing the agent port for the environmental compartments. There is now only one key in the agent ports: ```['agents']```. Under this key is a dict with all agent ids matched to their boundary states. This way, the keys don't need to be updated as agents are added/removed from boundary stores.