### PR TITLE
make snapshot plot with fields

### DIFF
--- a/vivarium/compartment/process.py
+++ b/vivarium/compartment/process.py
@@ -344,6 +344,12 @@ def initialize_state(process_layers, topology, initial_state):
 
     return initialized_state
 
+def flatten_process_layers(process_layers):
+    processes = {}
+    for layer in process_layers:
+        processes.update(layer)
+    return processes
+
 class Compartment(Store):
     ''' Track a set of processes and states and the connections between them. '''
 
@@ -445,10 +451,7 @@ class Compartment(Store):
 
     def run_derivers(self):
 
-        # flatten all deriver layers into a single deriver dict
-        derivers = {}
-        for stack in self.state['derivers']:
-            derivers.update(stack)
+        derivers = flatten_process_layers(self.state['derivers'])
 
         updates = {}
         for name, process in derivers.items():
@@ -480,9 +483,7 @@ class Compartment(Store):
         time = 0
 
         # flatten all process layers into a single process dict
-        processes = {}
-        for stack in self.state['processes']:
-            processes.update(stack)
+        processes = flatten_process_layers(self.state['processes'])
 
         # keep track of which processes have simulated until when
         front = {

--- a/vivarium/composites/lattice_environment.py
+++ b/vivarium/composites/lattice_environment.py
@@ -128,8 +128,8 @@ if __name__ == '__main__':
 
     config = get_lattice_config()
     data = test_lattice_environment(config, 10)
-    timeseries = get_timeseries(data)
 
-    plot_field_output(timeseries, config, out_dir, 'lattice_field')
-    plot_snapshots(data, config, out_dir, 'lattice_bodies')
-    
+    # make snapshot plot
+    agents = {time: time_data['agents']['agents'] for time, time_data in data.items()}
+    fields = {time: time_data['fields'] for time, time_data in data.items()}
+    plot_snapshots(agents, fields, config, out_dir, 'snapshots')


### PR DESCRIPTION
This updates the snapshots plot in ```multi body_physics``` to include fields. 

I realize there is a ```snapshots``` plot in ```analyses``` that does pretty much the same thing, but that one is done through the database querying. In general, there are many plot functions accumulating in individual processes that are almost like analyses, but they are much easier to use and more useful! We might need to be a rethink of how these can be used and perhaps merged with analyses.

![snapshots](https://user-images.githubusercontent.com/6809431/79018680-43d30580-7b29-11ea-9046-183bd90599a2.png)
