### PR TITLE
Separate compartment from get_composite

### DIFF
--- a/vivarium/composites/growth_division.py
+++ b/vivarium/composites/growth_division.py
@@ -23,7 +23,7 @@ from vivarium.processes.convenience_kinetics import (
 
 
 
-def compose_growth_division(config):
+def growth_division(config):
 
     # declare the processes
     transport = ConvenienceKinetics(get_glc_lct_config())
@@ -54,7 +54,17 @@ def compose_growth_division(config):
         'expression': {
             'internal': 'cell',
             'external': 'environment',
-            'concentrations': 'cell_concs'}}
+            'concentrations': 'cell_concentrations'}}
+
+    return {
+        'processes': processes,
+        'topology': topology}
+
+
+def compose_growth_division(config):
+    agent = growth_division(config)
+    processes = agent['processes']
+    topology= agent['topology']
 
     # add derivers
     derivers = get_derivers(processes, topology)

--- a/vivarium/composites/lattice_environment.py
+++ b/vivarium/composites/lattice_environment.py
@@ -22,38 +22,13 @@ from vivarium.processes.diffusion_field import (
 )
 
 
-def compose_lattice_environment(config):
-    """"""
-    bounds = config.get('bounds', [10, 10])
-    size = config.get('size', [10, 10])
-    molecules = config.get('molecules', ['glc'])
 
-    # get the agents
-    agents_config = config.get('agents', {})
-    agent_ids = list(agents_config.keys())
+def get_environment(config):
+    # declare the processes.
+    multibody = Multibody(config.get('multibody', {}))
+    diffusion = DiffusionField(config.get('diffusion_field', {}))
 
-    ## Declare the processes.
-    # multibody physics
-    multibody_config = random_body_config(agents_config, bounds)
-    multibody = Multibody(multibody_config)
-
-    # diffusion field
-    agents = {
-        agent_id: {
-        'location': boundary['location'],
-        'exchange': {
-            mol_id: 1e2 for mol_id in molecules}}  # TODO -- don't hardcode exchange
-            for agent_id, boundary in multibody_config['agents'].items()}
-
-    exchange_config = {
-        'molecules': molecules,
-        'n_bins': bounds,
-        'size': size,
-        'agents': agents}
-    diffusion_config = exchange_agent_config(exchange_config)
-    diffusion = DiffusionField(diffusion_config)
-
-    # Place processes in layers
+    # place processes in layers
     processes = [
         {'multibody': multibody,
         'diffusion': diffusion}]
@@ -61,17 +36,61 @@ def compose_lattice_environment(config):
     # topology
     topology = {
         'multibody': {
-            'agents': 'agents',
+            'agents': 'boundary',
         },
         'diffusion': {
-            'agents': 'agents',
+            'agents': 'boundary',
             'fields': 'fields'}}
+
+    return {
+        'processes': processes,
+        'topology': topology}
+
+
+
+def compose_lattice_environment(config):
+    """"""
+    bounds = config.get('bounds', [10, 10])
+    size = config.get('size', [10, 10])
+    molecules = config.get('molecules', ['glc'])
+
+    # configure the agents
+    agents_config = config.get('agents', {})
+    agent_ids = list(agents_config.keys())
+
+    # config for the multibody process
+    multibody_config = random_body_config(agents_config, bounds)
+
+    # config for the diffusion proces
+    agents = {
+        agent_id: {
+        'location': boundary['location'],
+        'exchange': {
+            mol_id: 1e2 for mol_id in molecules}}  # TODO -- don't hardcode exchange
+            for agent_id, boundary in multibody_config['agents'].items()}
+    exchange_config = {
+        'molecules': molecules,
+        'n_bins': bounds,
+        'size': size,
+        'agents': agents
+    }
+    diffusion_config = exchange_agent_config(exchange_config)
+
+    # environment gets both process configs
+    environment_config = {
+        'multibody': multibody_config,
+        'diffusion_field': diffusion_config
+    }
+
+    # get the environment compartment
+    environment_compartment = get_environment(environment_config)
+    processes = environment_compartment['processes']
+    topology = environment_compartment['topology']
 
     # add derivers
     deriver_processes = []
 
     # initialize the states
-    # TODO -- pull out each agent_boundary, make a special initialize_state that can connect these up
     states = initialize_state(
         processes,
         topology,
@@ -130,6 +149,6 @@ if __name__ == '__main__':
     data = test_lattice_environment(config, 10)
 
     # make snapshot plot
-    agents = {time: time_data['agents']['agents'] for time, time_data in data.items()}
+    agents = {time: time_data['boundary']['agents'] for time, time_data in data.items()}
     fields = {time: time_data['fields'] for time, time_data in data.items()}
     plot_snapshots(agents, fields, config, out_dir, 'snapshots')


### PR DESCRIPTION
This refactor breaks up the ```get_composite``` function for ```growth_division``` and ```lattice_environment``` into two steps: 1) ```get_compartment``` gets the ```processes``` and ```topology```, ```get_composite``` takes those, creates derivers and stores for them, and compartment options. Separating out the process/topology from the rest will be useful when hooking up environment compartments with agent compartments.