### PR TITLE
bring metabolism back into chemotaxis master

### DIFF
--- a/vivarium/composites/chemotaxis_master
+++ b/vivarium/composites/chemotaxis_master
@@ -90,7 +90,7 @@ def compose_chemotaxis_master(config):
         'translation': translation,
         'degradation': degradation,
         'complexation': complexation,
-        # 'metabolism': metabolism
+        'metabolism': metabolism
         },
 
         {
@@ -112,13 +112,13 @@ def compose_chemotaxis_master(config):
             'fluxes': 'flux_bounds',
             'global': 'global'},
 
-        # 'metabolism': {
-        #     'internal': 'internal',
-        #     'external': 'environment',
-        #     'reactions': 'reactions',
-        #     'exchange': 'exchange',
-        #     'flux_bounds': 'flux_bounds',
-        #     'global': 'global'},
+        'metabolism': {
+            'internal': 'internal',
+            'external': 'environment',
+            'reactions': 'reactions',
+            'exchange': 'exchange',
+            'flux_bounds': 'flux_bounds',
+            'global': 'global'},
 
         'transcription': {
             'chromosome': 'chromosome',
@@ -220,7 +220,7 @@ if __name__ == '__main__':
 
     timeseries = simulate_with_environment(compartment, settings)
 
-    # get growth
+    # print growth
     volume_ts = timeseries['global']['volume']
     print('growth: {}'.format(volume_ts[-1]/volume_ts[0]))
 


### PR DESCRIPTION
Now that we have separate timescales for processes, metabolism can be added to ```chemotaxis_master```.  It worked beautifully, with metabolism running 1 time per second, and flagella every 0.01 seconds. 

Here is ```chemotaxis_master's``` new topology:
![topology](https://user-images.githubusercontent.com/6809431/79075858-2ed1b000-7caa-11ea-9c32-eb3f4ca19ad1.png)
