### PR TITLE
Deriver cleanup, asserts, length

### DIFF
--- a/vivarium/compartment/composition.py
+++ b/vivarium/compartment/composition.py
@@ -32,10 +32,10 @@ TEST_OUT_DIR = os.path.join('out', 'tests')
 
 
 deriver_library = {
+    'mass': DeriveMass,
     'globals': DeriveGlobals,
     'mmol_to_counts': DeriveCounts,
     'counts_to_mmol': DeriveConcs,
-    'mass': DeriveMass,
 }
 
 

--- a/vivarium/compartment/composition.py
+++ b/vivarium/compartment/composition.py
@@ -40,7 +40,7 @@ deriver_library = {
 
 
 
-def get_derivers(process_list, topology):
+def get_derivers(process_list, topology, config={}):
     '''
     get the derivers for a list of processes
 
@@ -53,25 +53,24 @@ def get_derivers(process_list, topology):
         'deriver_topology': topology}
     '''
 
-
     # get deriver configuration
-    deriver_config = {}
+    deriver_configs = config.copy()
     full_deriver_topology = {}
     for level in process_list:
         for process_id, process in level.items():
             process_settings = process.default_settings()
-            setting = process_settings.get('deriver_setting', [])
+            deriver_setting = process_settings.get('deriver_setting', [])
             try:
                 port_map = topology[process_id]
             except:
                 print('{} topology port mismatch'.format(process_id))
                 raise
 
-            for set in setting:
-                type = set['type']
-                keys = set['keys']
-                source_port = set['source_port']
-                target_port = set['derived_port']
+            for setting in deriver_setting:
+                type = setting['type']
+                keys = setting['keys']
+                source_port = setting['source_port']
+                target_port = setting['derived_port']
                 try:
                     source_compartment_port = port_map[source_port]
                     target_compartment_port = port_map[target_port]
@@ -93,14 +92,14 @@ def get_derivers(process_list, topology):
                 ports = {
                     source_port: keys,
                     target_port: keys}
-                config = {type: {'ports': ports}}
+                deriver_config = {type: {'ports': ports}}
 
-                deep_merge(deriver_config, config)
+                deep_merge(deriver_configs, deriver_config)
 
     # configure the derivers
     deriver_processes = {}
-    for type, config in deriver_config.items():
-        deriver_processes[type] = deriver_library[type](config)
+    for type, deriver_config in deriver_configs.items():
+        deriver_processes[type] = deriver_library[type](deriver_config)
 
     # add global deriver
     global_deriver = {

--- a/vivarium/compartment/composition.py
+++ b/vivarium/compartment/composition.py
@@ -89,12 +89,12 @@ def get_derivers(process_list, topology, config={}):
                 # TODO -- what if multiple different source/targets?
                 # TODO -- merge overwrites them. need list extend
                 # ports for configuration
-                ports = {
-                    source_port: keys,
-                    target_port: keys}
-                deriver_config = {type: {'ports': ports}}
+                ports_config = {type: {
+                    'source_ports': {source_port: keys},
+                    'target_ports': {target_port: keys}
+                }}
 
-                deep_merge(deriver_configs, deriver_config)
+                deep_merge(deriver_configs, ports_config)
 
     # configure the derivers
     deriver_processes = {}

--- a/vivarium/compartment/process.py
+++ b/vivarium/compartment/process.py
@@ -490,7 +490,7 @@ class Compartment(Store):
 
         updates = {}
         for name, process in derivers.items():
-            new_update = process.update_for(1)  # timestep shouldn't influence derivers
+            new_update = process.update_for(0)  # timestep shouldn't influence derivers
             updates = self.collect_updates(updates, name, new_update)
 
         for key, update in updates.items():

--- a/vivarium/processes/derive_concentrations.py
+++ b/vivarium/processes/derive_concentrations.py
@@ -13,9 +13,15 @@ class DeriveConcs(Process):
     def __init__(self, initial_parameters={}):
         self.avogadro = AVOGADRO
 
-        ports = initial_parameters.get('ports')
-        ports.update({
-            'global': ['volume', 'mmol_to_counts']})
+        source_ports = initial_parameters.get('source_ports')
+        target_ports = initial_parameters.get('target_ports')
+
+        assert len(target_ports) == 1, 'DeriveConcs too many target ports'
+        assert list(target_ports.keys())[0] == 'concentrations', 'DeriveConcs requires target port named concentrations'
+
+        ports = {'global': ['volume', 'mmol_to_counts']}
+        ports.update(source_ports)
+        ports.update(target_ports)
 
         parameters = {}
         parameters.update(initial_parameters)

--- a/vivarium/processes/derive_counts.py
+++ b/vivarium/processes/derive_counts.py
@@ -25,9 +25,15 @@ class DeriveCounts(Process):
 
         self.initial_state = initial_parameters.get('initial_state', get_default_state())
 
-        ports = initial_parameters.get('ports')
-        ports.update({
-            'global': ['volume', 'mmol_to_counts']})
+        source_ports = initial_parameters.get('source_ports')
+        target_ports = initial_parameters.get('target_ports')
+
+        assert len(target_ports) == 1, 'DeriveCounts too many target ports'
+        assert list(target_ports.keys())[0] == 'counts', 'DeriveCounts requires target port named counts'
+
+        ports = {'global': ['volume', 'mmol_to_counts']}
+        ports.update(source_ports)
+        ports.update(target_ports)
 
         parameters = {}
         parameters.update(initial_parameters)

--- a/vivarium/processes/derive_globals.py
+++ b/vivarium/processes/derive_globals.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import copy
+import math
 
 from scipy import constants
 import numpy as np
@@ -10,26 +11,49 @@ from vivarium.utils.units import units
 from vivarium.utils.dict_utils import deep_merge
 
 
-
+PI = math.pi
 AVOGADRO = constants.N_A * 1 / units.mol
+
+
+
+def get_length(volume, width):
+    radius = width / 2
+    cylinder_length = volume / (PI * radius ** 2) + (4 / 3) * PI * radius ** 3
+    length = cylinder_length + width
+
+    return length
 
 
 
 class DeriveGlobals(Process):
     """
-    Process for deriving volume, mmol_to_counts factor, and growth rate
-    from the cell mass
+    Process for deriving volume, mmol_to_counts, and shape from the cell mass
     """
+
+    defaults = {
+        'width': 0.5,  # um
+        'source_ports': {},
+    }
+
     def __init__(self, initial_parameters={}):
+
+        self.width = initial_parameters.get('width', self.defaults['width'])
+        self.source_ports = initial_parameters.get('source_ports', self.defaults['source_ports'])
+        target_ports = initial_parameters.get('target_ports')
+
+        if target_ports:
+            assert len(target_ports) == 1, 'DeriveGlobals too many target ports'
+            assert list(target_ports.keys())[0] == 'global', 'DeriveGlobals requires target port named global'
 
         ports = {
             'global': [
                 'mass',
                 'volume',
-                'growth_rate',
-                'prior_mass',
                 'mmol_to_counts',
-                'density']}
+                'density',
+                'length']}
+
+        ports.update(self.source_ports)
 
         parameters = {}
         parameters.update(initial_parameters)
@@ -42,13 +66,14 @@ class DeriveGlobals(Process):
         density = 1100 * units.g / units.L
         volume = mass/density
         mmol_to_counts = (AVOGADRO * volume).to('L/mmol')
+        length = get_length(volume.magnitude, self.width)
+
         global_state = {
-            'growth_rate': 0.0,
             'mass': mass.magnitude,
             'volume': volume.to('fL').magnitude,
             'mmol_to_counts': mmol_to_counts.magnitude,
-            'prior_mass': mass.magnitude,
-            'density': density.magnitude
+            'density': density.magnitude,
+            'length': length,
         }
 
         default_state = {
@@ -56,11 +81,11 @@ class DeriveGlobals(Process):
 
         # default emitter keys
         default_emitter_keys = {
-            'global': ['volume', 'growth_rate']}
+            'global': ['volume']}
 
         # schema
-        set_states = ['volume', 'growth_rate', 'prior_mass', 'mmol_to_counts']
-        set_divide = ['density', 'prior_mass']
+        set_states = ['volume', 'mmol_to_counts', 'length']
+        set_divide = ['density']
         schema = {
             'global': {
                 state_id : {
@@ -81,24 +106,20 @@ class DeriveGlobals(Process):
         return default_settings
 
     def next_update(self, timestep, states):
-
         # states
         density = states['global']['density'] * units.g / units.L
-        prior_mass = states['global']['prior_mass'] * units.fg
         mass = states['global']['mass'] * units.fg
 
-        # update volume and growth rate
+        # get volume from mass, and more variables from volume
         volume = mass / density
         mmol_to_counts = (AVOGADRO * volume).to('L/mmol')
-        growth_rate = (mass - prior_mass) / timestep / mass
-        deriver_update = {
-            'volume': volume.to('fL').magnitude,
-            'mmol_to_counts': mmol_to_counts.magnitude,
-            'growth_rate': growth_rate.magnitude,
-            'prior_mass': mass.magnitude}
+        length = get_length(volume.magnitude, self.width)
 
         return {
-            'global': deriver_update}
+            'global': {
+                'volume': volume.to('fL').magnitude,
+                'mmol_to_counts': mmol_to_counts.magnitude,
+                'length': length}}
 
 
 

--- a/vivarium/processes/derive_mass.py
+++ b/vivarium/processes/derive_mass.py
@@ -14,7 +14,7 @@ class DeriveMass(Process):
     def __init__(self, initial_parameters={}):
 
 
-        ports = initial_parameters['ports']
+        ports = initial_parameters['source_ports']
         ports.update({
             'global': ['mass', 'volume', 'mmol_to_counts']})
 

--- a/vivarium/processes/derive_mass.py
+++ b/vivarium/processes/derive_mass.py
@@ -13,10 +13,16 @@ class DeriveMass(Process):
     """
     def __init__(self, initial_parameters={}):
 
+        source_ports = initial_parameters['source_ports']
+        target_ports = initial_parameters.get('target_ports')
 
-        ports = initial_parameters['source_ports']
-        ports.update({
-            'global': ['mass', 'volume', 'mmol_to_counts']})
+        if target_ports:
+            assert len(target_ports) == 1, 'DeriveMass too many target ports'
+            assert list(target_ports.keys())[0] == 'global', 'DeriveMass requires target port named global'
+
+        ports = {
+            'global': ['mass', 'volume', 'mmol_to_counts']}
+        ports.update(source_ports)
 
         self.in_ports = {
             port_id: keys


### PR DESCRIPTION
This PR cleans up some of the derivers and ```get_derivers``` in ```composition```.  The individual derivers have new asserts to check that the assigned ports are corrects.  ```derive_globals``` no longer handles growth_rate -- derivers should not count on time step, and growth rate should be more of an outcome of a simulation than a state anyways. ```derive_globals``` now calculates length -- this can be used in the boundary store for the environment to use, rather than have the environment calculate length from volume.