### PR TITLE
get_deriver refactor and dark mass

### DIFF
--- a/vivarium/compartment/composition.py
+++ b/vivarium/compartment/composition.py
@@ -101,18 +101,20 @@ def get_derivers(process_list, topology, config={}):
     for type, deriver_config in deriver_configs.items():
         deriver_processes[type] = deriver_library[type](deriver_config)
 
-    # add global deriver
-    global_deriver = {
-        'global_deriver': DeriveGlobals({})}
-    global_deriver_topology = {
-        'global_deriver': {
-            'global': 'global'}}
-    deep_merge(full_deriver_topology, global_deriver_topology)
+    # TODO -- configure global deriver for all compartments through config
+    # # add global deriver
+    # global_deriver = {
+    #     'global_deriver': DeriveGlobals({})}
+    # global_deriver_topology = {
+    #     'global_deriver': {
+    #         'global': 'global'}}
+    # deep_merge(full_deriver_topology, global_deriver_topology)
 
+    # TODO -- put derivers in order
     # put the global deriver and additional derivers in two process layers
-    processes = [
-        global_deriver,
-        deriver_processes]
+    processes = [deriver_processes]
+        # global_deriver,
+        # deriver_processes]
 
     return {
         'deriver_processes': processes,

--- a/vivarium/compartment/composition.py
+++ b/vivarium/compartment/composition.py
@@ -773,9 +773,7 @@ def load_compartment(composite, boot_config={}):
     derivers = composite_config.get('derivers', [])
     states = composite_config['states']
     options = composite_config['options']
-    options.update({
-        'emitter': boot_config.get('emitter', 'timeseries'),
-        'time_step': boot_config.get('time_step', 1.0)})   # TODO -- let compartment handle its own timestep
+    options['emitter'] = boot_config.get('emitter', 'timeseries')
 
     return Compartment(processes, derivers, states, options)
 

--- a/vivarium/compartment/composition.py
+++ b/vivarium/compartment/composition.py
@@ -59,14 +59,8 @@ def get_derivers(process_list, topology, config={}):
     deriver_configs = process_derivers['deriver_configs']
     deriver_topology = process_derivers['deriver_topology']
 
-    # update with config
+    # update deriver_configs
     deriver_configs = deep_merge(deriver_configs, config)
-
-    # # add globals topology, since it does not have a declared topology within process
-    # if 'globals' in deriver_configs:
-    #     globals_topology = {
-    #         'globals': {'global': 'global'}}
-    #     deriver_topology = deep_merge(deriver_topology, globals_topology)
 
     # configure the deriver processes
     deriver_processes = {}
@@ -81,7 +75,7 @@ def get_derivers(process_list, topology, config={}):
         'deriver_topology': deriver_topology}
 
 def get_deriver_config_from_proceses(process_list, topology):
-    ''' get the deriver configuration from deriver_settings processes'''
+    ''' get the deriver configuration from processes' deriver_settings'''
 
     deriver_configs = {}
     full_deriver_topology = {}

--- a/vivarium/compartment/composition.py
+++ b/vivarium/compartment/composition.py
@@ -45,17 +45,47 @@ def get_derivers(process_list, topology, config={}):
     get the derivers for a list of processes
 
     requires:
-        - process_list -- (list) with configured processes
-        - topology -- (dict) with topology of the processes connected to compartment ports
+        - process_list: (list) with configured processes
+        - topology: (dict) with topology of the processes connected to compartment ports
+        - config: (dict) with deriver configurations, which are used to make deriver processes
 
     returns: (dict) with:
         {'deriver_processes': processes,
         'deriver_topology': topology}
     '''
 
-    # get deriver configuration
-    deriver_configs = config.copy()
+    # get deriver configuration from processes
+    process_derivers = get_deriver_config_from_proceses(process_list, topology)
+    deriver_configs = process_derivers['deriver_configs']
+    deriver_topology = process_derivers['deriver_topology']
+
+    # update with config
+    deriver_configs = deep_merge(deriver_configs, config)
+
+    # # add globals topology, since it does not have a declared topology within process
+    # if 'globals' in deriver_configs:
+    #     globals_topology = {
+    #         'globals': {'global': 'global'}}
+    #     deriver_topology = deep_merge(deriver_topology, globals_topology)
+
+    # configure the deriver processes
+    deriver_processes = {}
+    for deriver_type, deriver_config in deriver_configs.items():
+        deriver_processes[deriver_type] = deriver_library[deriver_type](deriver_config)
+
+    # TODO -- put derivers in order
+    processes = [deriver_processes]
+
+    return {
+        'deriver_processes': processes,
+        'deriver_topology': deriver_topology}
+
+def get_deriver_config_from_proceses(process_list, topology):
+    ''' get the deriver configuration from deriver_settings processes'''
+
+    deriver_configs = {}
     full_deriver_topology = {}
+
     for level in process_list:
         for process_id, process in level.items():
             process_settings = process.default_settings()
@@ -67,7 +97,7 @@ def get_derivers(process_list, topology, config={}):
                 raise
 
             for setting in deriver_setting:
-                type = setting['type']
+                deriver_type = setting['type']
                 keys = setting['keys']
                 source_port = setting['source_port']
                 target_port = setting['derived_port']
@@ -80,7 +110,7 @@ def get_derivers(process_list, topology, config={}):
 
                 # make deriver_topology, add to full_deriver_topology
                 deriver_topology = {
-                    type: {
+                    deriver_type: {
                         source_port: source_compartment_port,
                         target_port: target_compartment_port,
                         'global': 'global'}}
@@ -88,37 +118,18 @@ def get_derivers(process_list, topology, config={}):
 
                 # TODO -- what if multiple different source/targets?
                 # TODO -- merge overwrites them. need list extend
-                # ports for configuration
-                ports_config = {type: {
+                ports_config = {
                     'source_ports': {source_port: keys},
-                    'target_ports': {target_port: keys}
-                }}
+                    'target_ports': {target_port: keys}}
 
-                deep_merge(deriver_configs, ports_config)
-
-    # configure the derivers
-    deriver_processes = {}
-    for type, deriver_config in deriver_configs.items():
-        deriver_processes[type] = deriver_library[type](deriver_config)
-
-    # TODO -- configure global deriver for all compartments through config
-    # # add global deriver
-    # global_deriver = {
-    #     'global_deriver': DeriveGlobals({})}
-    # global_deriver_topology = {
-    #     'global_deriver': {
-    #         'global': 'global'}}
-    # deep_merge(full_deriver_topology, global_deriver_topology)
-
-    # TODO -- put derivers in order
-    # put the global deriver and additional derivers in two process layers
-    processes = [deriver_processes]
-        # global_deriver,
-        # deriver_processes]
+                # ports for configuration
+                deriver_config = {deriver_type: ports_config}
+                deep_merge(deriver_configs, deriver_config)
 
     return {
-        'deriver_processes': processes,
+        'deriver_configs': deriver_configs,
         'deriver_topology': full_deriver_topology}
+
 
 def get_schema(process_list, topology):
     schema = {}
@@ -148,6 +159,7 @@ def process_in_compartment(process, settings={}):
     process_settings = process.default_settings()
     compartment_state_port = settings.get('compartment_state_port')
     emitter = settings.get('emitter', 'timeseries')
+    deriver_config = settings.get('deriver_config', {})
 
     processes = [{'process': process}]
     topology = {
@@ -162,7 +174,7 @@ def process_in_compartment(process, settings={}):
         topology['process'][compartment_state_port] = COMPARTMENT_STATE
 
     # add derivers
-    derivers = get_derivers(processes, topology)
+    derivers = get_derivers(processes, topology, deriver_config)
     deriver_processes = derivers['deriver_processes']
     all_processes = processes + derivers['deriver_processes']
     topology.update(derivers['deriver_topology'])

--- a/vivarium/composites/glc_lct_shifter.py
+++ b/vivarium/composites/glc_lct_shifter.py
@@ -11,7 +11,7 @@ from vivarium.compartment.composition import (
 )
 
 # composite
-from vivarium.composites.txb_mtb_ge import compose_txb_mtb_ge
+from vivarium.composites.txp_mtb_ge import compose_txp_mtb_ge
 
 # process configurations
 from vivarium.processes.metabolism import get_iAF1260b_config
@@ -63,7 +63,7 @@ def compose_glc_lct_shifter(config):
 
     config.update(shifter_config)
 
-    return compose_txb_mtb_ge(config)
+    return compose_txp_mtb_ge(config)
 
 
 

--- a/vivarium/composites/txp_mtb_ge.py
+++ b/vivarium/composites/txp_mtb_ge.py
@@ -94,17 +94,25 @@ def txp_mtb_ge_compartment(config):
 
 
 
-def compose_txb_mtb_ge(config):
+def compose_txp_mtb_ge(config):
     """
     A composite with kinetic transport, metabolism, and gene expression
     """
+
+    # TODO -- pass metabolism mass in through config.
 
     compartment = txp_mtb_ge_compartment(config)
     processes = compartment['processes']
     topology = compartment['topology']
 
+    # TODO -- globals topology?
+    topology['globals'] = {'global': 'global'}
     # add derivers
-    derivers = get_derivers(processes, topology)
+    deriver_config = {
+        'globals': {},
+        'mass': {'dark_mass': 1339}}  # units.fg
+
+    derivers = get_derivers(processes, topology, deriver_config)
     deriver_processes = derivers['deriver_processes']
     all_processes = processes + derivers['deriver_processes']
     topology.update(derivers['deriver_topology'])  # add derivers to the topology
@@ -148,8 +156,8 @@ def default_metabolism_config():
 
 
 # simulate
-def test_txb_mtb_ge(time=10):
-    compartment = load_compartment(compose_txb_mtb_ge)
+def test_txp_mtb_ge(time=10):
+    compartment = load_compartment(compose_txp_mtb_ge)
     options = compartment.configuration
     settings = {
         'environment_port': options['environment_port'],
@@ -161,11 +169,11 @@ def test_txb_mtb_ge(time=10):
 
 
 if __name__ == '__main__':
-    out_dir = os.path.join('out', 'tests', 'txb_mtb_ge_composite')
+    out_dir = os.path.join('out', 'tests', 'txp_mtb_ge_composite')
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    timeseries = test_txb_mtb_ge(100) # 2520 sec (42 min) is the expected doubling time in minimal media
+    timeseries = test_txp_mtb_ge(10) # 2520 sec (42 min) is the expected doubling time in minimal media
     plot_settings = {
         'max_rows': 20,
         'remove_zeros': True,

--- a/vivarium/composites/txp_mtb_ge.py
+++ b/vivarium/composites/txp_mtb_ge.py
@@ -99,18 +99,12 @@ def compose_txp_mtb_ge(config):
     A composite with kinetic transport, metabolism, and gene expression
     """
 
-    # TODO -- pass metabolism mass in through config.
-
     compartment = txp_mtb_ge_compartment(config)
     processes = compartment['processes']
     topology = compartment['topology']
 
-    # TODO -- globals topology?
-    # TODO -- pass in deriver layers
-    topology['globals'] = {'global': 'global'}
     # add derivers
     deriver_config = {
-        'globals': {},
         'mass': {'dark_mass': 1339}}  # units.fg
 
     derivers = get_derivers(processes, topology, deriver_config)

--- a/vivarium/composites/txp_mtb_ge.py
+++ b/vivarium/composites/txp_mtb_ge.py
@@ -106,6 +106,7 @@ def compose_txp_mtb_ge(config):
     topology = compartment['topology']
 
     # TODO -- globals topology?
+    # TODO -- pass in deriver layers
     topology['globals'] = {'global': 'global'}
     # add derivers
     deriver_config = {

--- a/vivarium/environment/lattice_compartment.py
+++ b/vivarium/environment/lattice_compartment.py
@@ -5,7 +5,7 @@ import uuid
 from vivarium.compartment.process import Compartment, initialize_state, get_minimum_timestep, Process, Store
 from vivarium.compartment.emitter import get_emitter
 from vivarium.actor.inner import Simulation
-from vivarium.compartment.composition import get_derivers, load_compartment
+from vivarium.compartment.composition import get_derivers
 
 
 # TODO -- remove these functions once all key manipulation is gone

--- a/vivarium/processes/cellular_potts.py
+++ b/vivarium/processes/cellular_potts.py
@@ -261,7 +261,7 @@ def get_cpm_minimum_config():
         'target_area': 10,
         'animate': True}
 
-def test_CPM(cpm_config = get_cpm_minimum_config(), time=5):
+def run_CPM(cpm_config = get_cpm_minimum_config(), time=5):
     # load process
     expression = CellularPotts(cpm_config)
 
@@ -281,5 +281,5 @@ if __name__ == '__main__':
         os.makedirs(out_dir)
 
     cpm_config = get_cpm_config()
-    saved_data = test_CPM(cpm_config, 30)
+    saved_data = run_CPM(cpm_config, 30)
 

--- a/vivarium/processes/convenience_kinetics.py
+++ b/vivarium/processes/convenience_kinetics.py
@@ -75,11 +75,19 @@ class ConvenienceKinetics(Process):
                     'updater': 'set'}
                 for flux_id in self.kinetic_rate_laws.reaction_ids}}
 
+        # derivers
+        deriver_setting = [{
+            'type': 'globals',
+            'source_port': 'global',
+            'derived_port': 'global',
+            'keys': []}]
+
         default_settings = {
             'process_id': 'convenience_kinetics',
             'state': default_state,
             'emitter_keys': default_emitter_keys,
             'schema': schema,
+            'deriver_setting': deriver_setting,
             'time_step': 1.0}
 
         return default_settings

--- a/vivarium/processes/degradation.py
+++ b/vivarium/processes/degradation.py
@@ -87,9 +87,17 @@ class RnaDegradation(Process):
             'molecules': self.molecule_order,
             'global': []}
 
+        # derivers
+        deriver_setting = [{
+            'type': 'globals',
+            'source_port': 'global',
+            'derived_port': 'global',
+            'keys': []}]
+
         return {
             'state': default_state,
             'emitter_keys': default_emitter_keys,
+            'deriver_setting': deriver_setting,
             'parameters': self.parameters}
 
     def next_update(self, timestep, states):

--- a/vivarium/processes/derive_globals.py
+++ b/vivarium/processes/derive_globals.py
@@ -32,15 +32,17 @@ class DeriveGlobals(Process):
 
     defaults = {
         'width': 0.5,  # um
-        'source_ports': {},
     }
 
     def __init__(self, initial_parameters={}):
 
         self.width = initial_parameters.get('width', self.defaults['width'])
-        self.source_ports = initial_parameters.get('source_ports', self.defaults['source_ports'])
+        source_ports = initial_parameters.get('source_ports')
         target_ports = initial_parameters.get('target_ports')
 
+        if source_ports:
+            assert len(source_ports) == 1, 'DeriveGlobals too many source ports'
+            assert list(source_ports.keys())[0] == 'global', 'DeriveGlobals requires source port named global'
         if target_ports:
             assert len(target_ports) == 1, 'DeriveGlobals too many target ports'
             assert list(target_ports.keys())[0] == 'global', 'DeriveGlobals requires target port named global'
@@ -52,8 +54,6 @@ class DeriveGlobals(Process):
                 'mmol_to_counts',
                 'density',
                 'length']}
-
-        ports.update(self.source_ports)
 
         parameters = {}
         parameters.update(initial_parameters)

--- a/vivarium/processes/derive_mass.py
+++ b/vivarium/processes/derive_mass.py
@@ -18,9 +18,9 @@ class DeriveMass(Process):
 
     def __init__(self, initial_parameters={}):
 
-        self.dark_mass = initial_parameters.get('dark_mass', self.defaults['dark_mass'])
+        self.dark_mass = initial_parameters.get(
+            'dark_mass', self.defaults['dark_mass'])
         # TODO -- add dark mass to schema?
-        import ipdb; ipdb.set_trace()
 
         source_ports = initial_parameters['source_ports']
         target_ports = initial_parameters['target_ports']
@@ -72,6 +72,8 @@ class DeriveMass(Process):
                 mol = count / AVOGADRO
                 added_mass = mw * mol
                 mass += added_mass.to('fg')
+
+        mass += self.dark_mass  # TODO -- add dark mass to schema
 
         return {
             'global': {'mass': mass.magnitude}}

--- a/vivarium/processes/derive_mass.py
+++ b/vivarium/processes/derive_mass.py
@@ -73,7 +73,7 @@ class DeriveMass(Process):
                 added_mass = mw * mol
                 mass += added_mass.to('fg')
 
-        mass += self.dark_mass  # TODO -- add dark mass to schema
+        mass += self.dark_mass * units.fg # TODO -- add dark mass to schema
 
         return {
             'global': {'mass': mass.magnitude}}

--- a/vivarium/processes/derive_mass.py
+++ b/vivarium/processes/derive_mass.py
@@ -13,8 +13,12 @@ class DeriveMass(Process):
     """
     def __init__(self, initial_parameters={}):
 
+        dark_mass = initial_parameters.get('dark_mass')
+        # TODO -- add dark mass to schema?
+        # import ipdb; ipdb.set_trace()
+
         source_ports = initial_parameters['source_ports']
-        target_ports = initial_parameters.get('target_ports')
+        target_ports = initial_parameters['target_ports']
 
         if target_ports:
             assert len(target_ports) == 1, 'DeriveMass too many target ports'

--- a/vivarium/processes/derive_mass.py
+++ b/vivarium/processes/derive_mass.py
@@ -13,44 +13,56 @@ class DeriveMass(Process):
     """
 
     defaults = {
-        'dark_mass': 0,
+        'dark_mass': 0,  # fg of dark mass
     }
 
     def __init__(self, initial_parameters={}):
 
-        self.dark_mass = initial_parameters.get(
-            'dark_mass', self.defaults['dark_mass'])
-        # TODO -- add dark mass to schema?
-
-        source_ports = initial_parameters['source_ports']
+        self.source_ports = initial_parameters['source_ports']
         target_ports = initial_parameters['target_ports']
-
         if target_ports:
             assert len(target_ports) == 1, 'DeriveMass too many target ports'
             assert list(target_ports.keys())[0] == 'global', 'DeriveMass requires target port named global'
 
-        ports = {
-            'global': ['mass', 'volume', 'mmol_to_counts']}
-        ports.update(source_ports)
+        self.dark_mass = initial_parameters.get(
+            'dark_mass', self.defaults['dark_mass'])
 
-        self.in_ports = {
-            port_id: keys
-            for port_id, keys in ports.items()
-            if port_id not in ['global']}
+        if self.dark_mass > 0:
+            self.source_ports['global'] = ['dark_mass']
+
+        # make the ports
+        ports = self.source_ports.copy()
+
+        # add global variables to global port
+        global_variables = ['mass', 'volume', 'mmol_to_counts']
+        if 'global' in ports:
+            variable_set = set(ports['global'])
+            variable_set.update(global_variables)
+            ports['global'] = list(variable_set)
+        else:
+            ports['global'] = global_variables
 
         super(DeriveMass, self).__init__(ports, initial_parameters)
 
     def default_settings(self):
-        default_state = {}
+        default_state = {
+            'global': {'dark_mass': (self.dark_mass * AVOGADRO).magnitude}
+        }
 
         # emitter keys
-        default_emitter_keys = {'global': ['mass']}
+        default_emitter_keys = {
+            'global': ['mass', 'dark_mass']}
 
         # schema
         schema = {
             'global': {
                 'mass': {
-                    'updater': 'set'}}}
+                    'updater': 'set'},
+                'dark_mass': {
+                    'mass': 1  # 1 g/mol of dark mass
+                }
+            }
+        }
 
         return {
             'state': default_state,
@@ -58,22 +70,17 @@ class DeriveMass(Process):
             'schema': schema}
 
     def next_update(self, timestep, states):
-        mass_schema = self.schema_properties(self.in_ports, 'mass')
+        mass_schema = self.schema_properties(self.source_ports, 'mass')
 
-        states_with_mass = {
-            port: molecules
-            for port, molecules in states.items()
-            if port in self.in_ports}
-
+        # get mass from all molecules in source_ports
         mass = 0
-        for port, molecules in states_with_mass.items():
-            for mol_id, count in molecules.items():
+        for port, molecules in self.source_ports.items():
+            for mol_id in molecules:
+                count = states[port][mol_id]
                 mw = mass_schema[port].get(mol_id, 0.0) * (units.g / units.mol)
                 mol = count / AVOGADRO
                 added_mass = mw * mol
                 mass += added_mass.to('fg')
-
-        mass += self.dark_mass * units.fg # TODO -- add dark mass to schema
 
         return {
             'global': {'mass': mass.magnitude}}

--- a/vivarium/processes/derive_mass.py
+++ b/vivarium/processes/derive_mass.py
@@ -11,11 +11,16 @@ class DeriveMass(Process):
     that have a mass schema in their stores .
 
     """
+
+    defaults = {
+        'dark_mass': 0,
+    }
+
     def __init__(self, initial_parameters={}):
 
-        dark_mass = initial_parameters.get('dark_mass')
+        self.dark_mass = initial_parameters.get('dark_mass', self.defaults['dark_mass'])
         # TODO -- add dark mass to schema?
-        # import ipdb; ipdb.set_trace()
+        import ipdb; ipdb.set_trace()
 
         source_ports = initial_parameters['source_ports']
         target_ports = initial_parameters['target_ports']


### PR DESCRIPTION
This PR does two things:

1. ```get_derivers``` is refactored. 
 - I separated out a function ```get_deriver_config_from_proceses``` that takes a process list and makes a deriver config and topology. 
 - ```get_derivers``` calls this function, and updates the config with passed-in values, and then makes the derivers. This lets users configure derivers without needing to declare them in process.  
 - The global deriver (```derive_globals```) is no longer automatically inserted. It has to be called by a process' ```deriver_settings``` if required, or passed in as a config to ```get_derivers```. Two processes required updated ```deriver_settings``` -- ```convenience_kinetics``` and ```degradation```.

2. The mass deriver, ```derive_mass``` can be initialized with "dark mass".  This is mass that is not accounted for in the actual modeled molecules, but is still needed for the cell as a whole. For example, a chemotaxis agent might have only flagella and chemoreceptors as modeled states, but will still need to be the size of a whole cell. Since mass is determined at every deriver call, dark mass is just a state in the global store with a mass schema of 1 g/mol. 