### PR TITLE
Rehab experiments

### DIFF
--- a/vivarium/environment/boot.py
+++ b/vivarium/environment/boot.py
@@ -84,6 +84,7 @@ def wrap_init_composite(make_composite):
         # set up the the composite
         composite_config = make_composite(boot_config)
         processes = composite_config['processes']
+        derivers = composite_config['derivers']
         states = composite_config['states']
         options = composite_config['options']
         topology = options['topology']
@@ -93,7 +94,7 @@ def wrap_init_composite(make_composite):
         options.update({'emitter': emitter})
 
         # create the compartment
-        return LatticeCompartment(processes, states, options)
+        return LatticeCompartment(processes, derivers, states, options)
 
     return initialize
 

--- a/vivarium/environment/control.py
+++ b/vivarium/environment/control.py
@@ -77,7 +77,7 @@ class ShepherdControl(ActorControl):
 
         # define experimental environment and agents
         experiment_id = 'growth_division'
-        environment_type = 'lattice'
+        environment_type = 'ecoli_core_glc'
         agents = {
             'growth_division': 1}
 


### PR DESCRIPTION
This updates the agent initialization function in ```environment.boot``` to include derivers.  This should have been included in #183. Note to self -- tests would have helped catch this earlier!