### PR TITLE
Mother machine

### DIFF
--- a/vivarium/processes/multibody_physics.py
+++ b/vivarium/processes/multibody_physics.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import argparse
 os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = "hide"
 
 import random
@@ -155,8 +156,8 @@ class Multibody(Process):
             self.pygame_scale = DEBUG_SIZE / max_bound  # increase scale for showing on screen during debug
             pygame.init()
             self._screen = pygame.display.set_mode((
-                int(bounds[0]*self.pygame_scale),
-                int(bounds[1]*self.pygame_scale)), RESIZABLE)
+                int(self.bounds[0]*self.pygame_scale),
+                int(self.bounds[1]*self.pygame_scale)), RESIZABLE)
             self._clock = pygame.time.Clock()
             self._draw_options = pymunk.pygame_util.DrawOptions(self._screen)
 
@@ -844,18 +845,9 @@ def init_axes(fig, edge_length_x, edge_length_y, grid, row_idx, col_idx, time):
     ax.set_xticklabels([])
     return ax
 
-
-
-if __name__ == '__main__':
-    out_dir = os.path.join('out', 'tests', 'multibody')
-    if not os.path.exists(out_dir):
-        os.makedirs(out_dir)
-
+def run_mother_machine():
     # run mother machine
     bounds = [20, 20]
-    motility_sim_settings = {
-        'timestep': 0.1,
-        'total_time': 100}
     mm_config = {
         'debug': True,
         'animate': False,
@@ -869,7 +861,7 @@ if __name__ == '__main__':
     multibody = Multibody(mm_config)
     data = simulate_process(multibody)
 
-
+def run_motility(out_dir):
     # test motility
     bounds = [20, 20]
     motility_sim_settings = {
@@ -897,3 +889,20 @@ if __name__ == '__main__':
     agents = {time: time_data['agents']['agents'] for time, time_data in motility_data.items()}
     fields = {}
     plot_snapshots(agents, fields, motility_config, out_dir, 'motility_snapshots')
+
+
+
+if __name__ == '__main__':
+    out_dir = os.path.join('out', 'tests', 'multibody')
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    parser = argparse.ArgumentParser(description='multibody')
+    parser.add_argument('--mother', '-m', action='store_true', default=False)
+    parser.add_argument('--motility', '-o', action='store_true', default=False)
+    args = parser.parse_args()
+
+    if args.mother:
+        run_mother_machine()
+    elif args.motility:
+        run_motility(out_dir)

--- a/vivarium/processes/multibody_physics.py
+++ b/vivarium/processes/multibody_physics.py
@@ -610,11 +610,11 @@ def simulate_motility(config, settings):
     return compartment.emitter.get_data()
 
 def run_mother_machine():
-    bounds = [20, 20]
+    bounds = [30, 30]
     settings = {
         'growth_rate': 0.05,
         'division_volume': 1.0,
-        'total_time': 60}
+        'total_time': 120}
     config = {
         'animate': True,
         # 'debug': True,
@@ -623,7 +623,7 @@ def run_mother_machine():
         'bounds': bounds}
     body_config = {
         'bounds': bounds,
-        'n_agents': 1}
+        'n_agents': 8}
     config.update(mother_machine_body_config(body_config))
     return simulate_growth_division(config, settings)
 
@@ -660,6 +660,7 @@ def run_growth_division():
     bounds = [20, 20]
     settings = {
         'growth_rate': 0.1,
+        'growth_rate_noise': 0.01,
         'division_volume': 1,
         'total_time': 60}
     config = {
@@ -684,6 +685,7 @@ def simulate_growth_division(config, settings):
     ## run simulation
     # get simulation settings
     growth_rate = settings.get('growth_rate', 0.0006)
+    growth_rate_noise = settings.get('growth_rate_noise', 0.0)
     division_volume = settings.get('division_volume', 0.4)
     total_time = settings.get('total_time', 10)
     timestep = compartment.time_step
@@ -704,8 +706,9 @@ def simulate_growth_division(config, settings):
             mass = state['mass']
 
             # update
-            new_mass = mass + mass * growth_rate
-            new_length = length + length * growth_rate
+            growth_rate2 = growth_rate + np.random.normal(0.0, growth_rate_noise)
+            new_mass = mass + mass * growth_rate2
+            new_length = length + length * growth_rate2
             new_volume = get_volume(new_length, width)
 
             if new_volume > division_volume:

--- a/vivarium/processes/multibody_physics.py
+++ b/vivarium/processes/multibody_physics.py
@@ -301,8 +301,9 @@ class Multibody(Process):
         ]
 
         if self.mother_machine:
-            channel_height = y_bound * 0.8
-            channel_space = 20
+            channel_height = self.mother_machine.get('channel_height') * self.pygame_scale
+            channel_space = self.mother_machine.get('channel_space') * self.pygame_scale
+
             n_lines = math.floor(x_bound/channel_space)
 
             machine_lines = [
@@ -611,14 +612,18 @@ def simulate_motility(config, settings):
 
 def run_mother_machine():
     bounds = [30, 30]
+    channel_height = 0.8 * bounds[1]
     settings = {
         'growth_rate': 0.05,
         'division_volume': 1.0,
+        'channel_height': channel_height,
         'total_time': 120}
     config = {
-        'animate': True,
-        # 'debug': True,
-        'mother_machine': True,
+        # 'animate': True,
+        'debug': True,
+        'mother_machine': {
+            'channel_height': channel_height,
+            'channel_space': 1},
         'jitter_force': 0.5e0,
         'bounds': bounds}
     body_config = {
@@ -687,6 +692,7 @@ def simulate_growth_division(config, settings):
     growth_rate = settings.get('growth_rate', 0.0006)
     growth_rate_noise = settings.get('growth_rate_noise', 0.0)
     division_volume = settings.get('division_volume', 0.4)
+    channel_height = settings.get('channel_height')
     total_time = settings.get('total_time', 10)
     timestep = compartment.time_step
 
@@ -711,7 +717,9 @@ def simulate_growth_division(config, settings):
             new_length = length + length * growth_rate2
             new_volume = get_volume(new_length, width)
 
-            if new_volume > division_volume:
+            if channel_height and location[1] > channel_height:
+                remove_agents.append(agent_id)
+            elif new_volume > division_volume:
                 daughter_ids = [str(agent_id) + '0', str(agent_id) + '1']
 
                 # daughter state with updated values

--- a/vivarium/processes/multibody_physics.py
+++ b/vivarium/processes/multibody_physics.py
@@ -439,7 +439,7 @@ class Multibody(Process):
             y = y_center - dy
 
             # Create a rectangle
-            rect = patches.Rectangle((x, y), width, length, angle=angle, linewidth=2, edgecolor='w')
+            rect = patches.Rectangle((x, y), width, length, angle=angle, linewidth=1, edgecolor='b')
             self.ax.add_patch(rect)
 
         plt.xlim([0, self.bounds[0]])
@@ -619,8 +619,8 @@ def run_mother_machine():
         'channel_height': channel_height,
         'total_time': 120}
     config = {
-        # 'animate': True,
-        'debug': True,
+        'animate': True,
+        # 'debug': True,
         'mother_machine': {
             'channel_height': channel_height,
             'channel_space': 1},


### PR DESCRIPTION
This PR adds:

1. a ```mother_machine``` config option to the multibody process, 
2. a growth_division test.
3. an additional ```animate``` option, that supports interactive Matplotlib figure when multibody is runninng.

Here is a screenshot of of the mother machine config in action:
<img width="388" alt="mother_machine" src="https://user-images.githubusercontent.com/6809431/80290691-e67bae80-86fb-11ea-8f38-5895b3e1d191.png">
