### PR TITLE
Variable flagella

### DIFF
--- a/vivarium/compartment/composition.py
+++ b/vivarium/compartment/composition.py
@@ -469,27 +469,27 @@ def plot_simulation_output(timeseries, settings={}, out_dir='out', filename='sim
             ax = fig.add_subplot(grid[row_idx, col_idx])  # grid is (row, column)
 
             # check if series is a list of ints or floats
-            # TODO -- plot non-numeric states as well (in particular dicts)
             if not all(isinstance(state, (int, float)) for state in series):
-                break
-
-            # plot line at zero if series crosses the zero line
-            if any(x == 0.0 for x in series) or (any(x < 0.0 for x in series) and any(x > 0.0 for x in series)):
-                zero_line = [0 for t in time_vec]
-                ax.plot(time_vec, zero_line, 'k--')
-
-            if (port, state_id) in show_state:
-                ax.plot(time_vec, series, 'indigo', linewidth=2)
+                ax.title.set_text(str(port) + ': ' + str(state_id))
+                ax.title.set_fontsize(16)
             else:
-                ax.plot(time_vec, series)
+                # plot line at zero if series crosses the zero line
+                if any(x == 0.0 for x in series) or (any(x < 0.0 for x in series) and any(x > 0.0 for x in series)):
+                    zero_line = [0 for t in time_vec]
+                    ax.plot(time_vec, zero_line, 'k--')
 
-            # overlay
-            if state_id in top_timeseries.keys():
-                ax.plot(time_vec, top_timeseries[state_id], 'm', label=top_port)
-                ax.legend()
+                if (port, state_id) in show_state:
+                    ax.plot(time_vec, series, 'indigo', linewidth=2)
+                else:
+                    ax.plot(time_vec, series)
 
-            ax.title.set_text(str(port) + ': ' + str(state_id))
-            ax.title.set_fontsize(16)
+                # overlay
+                if state_id in top_timeseries.keys():
+                    ax.plot(time_vec, top_timeseries[state_id], 'm', label=top_port)
+                    ax.legend()
+
+                ax.title.set_text(str(port) + ': ' + str(state_id))
+                ax.title.set_fontsize(16)
 
             if row_idx == columns[col_idx]-1:
                 # if last row of column

--- a/vivarium/compartment/composition.py
+++ b/vivarium/compartment/composition.py
@@ -469,8 +469,8 @@ def plot_simulation_output(timeseries, settings={}, out_dir='out', filename='sim
             ax = fig.add_subplot(grid[row_idx, col_idx])  # grid is (row, column)
 
             # check if series is a list of ints or floats
-            if not all(isinstance(state, (int, float)) for state in series):
-                ax.title.set_text(str(port) + ': ' + str(state_id))
+            if not all(isinstance(state, (int, float, np.int64, np.int32)) for state in series):
+                ax.title.set_text(str(port) + ': ' + str(state_id) + ' (non numeric)')
                 ax.title.set_fontsize(16)
             else:
                 # plot line at zero if series crosses the zero line

--- a/vivarium/composites/flagella_expression.py
+++ b/vivarium/composites/flagella_expression.py
@@ -238,9 +238,10 @@ def scan_flagella_expression_parameters():
 if __name__ == '__main__':
     commands = ['plot', 'scan']
     parser = argparse.ArgumentParser(description='flagella expression')
-    parser.add_argument('command', choices=commands)
+    parser.add_argument('--scan', '-s', action='store_true', default=False,)
     args = parser.parse_args()
-    if args.command == 'scan':
+
+    if args.scan:
         scan_flagella_expression_parameters()
     else:
         plot_flagella_expression()

--- a/vivarium/composites/flagella_expression.py
+++ b/vivarium/composites/flagella_expression.py
@@ -245,10 +245,7 @@ def scan_flagella_expression_parameters():
         'metrics': metrics,
         'options': {'time': 5}}
 
-
-    print('number of paramters: {}'.format(len(scan_params)))  # TODO -- get this down to 10
-    import ipdb; ipdb.set_trace()
-
+    print('number of parameters: {}'.format(len(scan_params)))  # TODO -- get this down to 10
     results = parameter_scan(scan_config)
 
     return results

--- a/vivarium/composites/flagella_expression.py
+++ b/vivarium/composites/flagella_expression.py
@@ -88,8 +88,8 @@ def get_flagella_expression_config(config):
                 'Fnr': 10,
                 'endoRNAse': 1,
                 'flagellum': 8,
-                UNBOUND_RIBOSOME_KEY: 100,  # e. coli has ~ 20000 ribosomes
-                UNBOUND_RNAP_KEY: 100}}}
+                UNBOUND_RIBOSOME_KEY: 200,  # e. coli has ~ 20000 ribosomes
+                UNBOUND_RNAP_KEY: 200}}}
 
     return config
 

--- a/vivarium/composites/flagella_expression.py
+++ b/vivarium/composites/flagella_expression.py
@@ -28,9 +28,9 @@ def get_flagella_expression_config(config):
 
     molecules = {}
     for nucleotide in nucleotides.values():
-        molecules[nucleotide] = 500000
+        molecules[nucleotide] = 5000000
     for amino_acid in amino_acids.values():
-        molecules[amino_acid] = 100000
+        molecules[amino_acid] = 1000000
 
     config = {
 
@@ -50,7 +50,6 @@ def get_flagella_expression_config(config):
             'templates': flagella_data.transcript_templates,
             'concentration_keys': ['CRP', 'flhDC', 'fliA'],
             'transcript_affinities': flagella_data.transcript_affinities,
-
             'elongation_rate': 22,
             'polymerase_occlusion': 50},
 
@@ -81,8 +80,8 @@ def get_flagella_expression_config(config):
                 'CRP': 10,
                 'Fnr': 10,
                 'endoRNAse': 1,
-                UNBOUND_RIBOSOME_KEY: 10,
-                UNBOUND_RNAP_KEY: 10}}}
+                UNBOUND_RIBOSOME_KEY: 100,  # e. coli has ~ 20000 ribosomes
+                UNBOUND_RNAP_KEY: 100}}}
 
     return config
 
@@ -203,9 +202,9 @@ def plot_flagella_expression():
 
     # make a basic sim output
     plot_settings = {
-        'max_rows': 25,
+        'max_rows': 30,
         'remove_zeros': False,
-        'skip_ports': ['chromosome', 'ribosomes']}
+        'skip_ports': ['chromosome']}
 
     plot_simulation_output(
         timeseries,

--- a/vivarium/composites/flagella_expression.py
+++ b/vivarium/composites/flagella_expression.py
@@ -12,7 +12,10 @@ from vivarium.states.chromosome import Chromosome, rna_bases, sequence_monomers
 from vivarium.processes.transcription import UNBOUND_RNAP_KEY
 from vivarium.processes.translation import UNBOUND_RIBOSOME_KEY
 from vivarium.composites.gene_expression import compose_gene_expression, plot_gene_expression_output
-from vivarium.parameters.parameters import parameter_scan
+from vivarium.parameters.parameters import (
+    parameter_scan,
+    get_parameters_logspace
+)
 
 def get_flagella_expression_config(config):
     flagella_data = FlagellaChromosome(config)
@@ -203,21 +206,17 @@ def scan_flagella_expression_parameters():
     flagella_data = FlagellaChromosome()
     scan_params = {}
 
-    steps = 3
-    affinities_range = exponential_range(steps, 3, 1e-3)
-    thresholds_range = exponential_range(steps, 2.5, 1e-7)
-
-    # add promoter affinities
-    for promoter in flagella_data.chromosome_config['promoters'].keys():
-        scan_params[('promoter_affinities', promoter)] = affinities_range
+    # # add promoter affinities
+    # for promoter in flagella_data.chromosome_config['promoters'].keys():
+    #     scan_params[('promoter_affinities', promoter)] = get_parameters_logspace(1e-3, 1e0, 4)
 
     # add transcript affinities
     for site in flagella_data.transcript_affinities.keys():
-        scan_params[('transcript_affinities', site)] = affinities_range
+        scan_params[('transcript_affinities', site)] = get_parameters_logspace(1e-3, 1e0, 4)
 
-    # add transcription factor thresholds
-    for threshold in flagella_data.factor_thresholds.keys():
-        scan_params[('thresholds', threshold)] = thresholds_range
+    # # add transcription factor thresholds
+    # for threshold in flagella_data.factor_thresholds.keys():
+    #     scan_params[('thresholds', threshold)] = get_parameters_logspace(1e-7, 1e-4, 4)
 
         metrics = [
         ('proteins', monomer)
@@ -230,6 +229,11 @@ def scan_flagella_expression_parameters():
         'scan_parameters': scan_params,
         'metrics': metrics,
         'options': {'time': 5}}
+
+
+    print('number of paramters: {}'.format(len(scan_params)))  # TODO -- get this down to 10
+    import ipdb; ipdb.set_trace()
+
     results = parameter_scan(scan_config)
 
     return results

--- a/vivarium/composites/flagella_expression.py
+++ b/vivarium/composites/flagella_expression.py
@@ -171,7 +171,7 @@ def plot_flagella_expression():
 
     # run simulation
     settings = {
-        'total_time': 2400,
+        'total_time': 600,  # 10 minutes should be enough time for a full flagellum to be expressed
         'verbose': True}
     timeseries = simulate_compartment(flagella_expression_compartment, settings)
 

--- a/vivarium/composites/flagella_expression.py
+++ b/vivarium/composites/flagella_expression.py
@@ -80,6 +80,7 @@ def get_flagella_expression_config(config):
                 'CRP': 10,
                 'Fnr': 10,
                 'endoRNAse': 1,
+                'flagellum': 8,
                 UNBOUND_RIBOSOME_KEY: 100,  # e. coli has ~ 20000 ribosomes
                 UNBOUND_RNAP_KEY: 100}}}
 

--- a/vivarium/composites/flagella_expression.py
+++ b/vivarium/composites/flagella_expression.py
@@ -4,7 +4,11 @@ import argparse
 import matplotlib.pyplot as plt
 import numpy as np
 
-from vivarium.compartment.composition import load_compartment, simulate_compartment
+from vivarium.compartment.composition import (
+    load_compartment,
+    simulate_compartment,
+    plot_simulation_output
+)
 from vivarium.data.nucleotides import nucleotides
 from vivarium.data.amino_acids import amino_acids
 from vivarium.data.chromosomes.flagella_chromosome import FlagellaChromosome
@@ -196,6 +200,18 @@ def plot_flagella_expression():
         timeseries,
         plot_config2,
         out_dir)
+
+    # make a basic sim output
+    plot_settings = {
+        'max_rows': 25,
+        'remove_zeros': False,
+        'skip_ports': ['chromosome', 'ribosomes']}
+
+    plot_simulation_output(
+        timeseries,
+        plot_settings,
+        out_dir)
+
 
 def exponential_range(steps, base, factor):
     return [

--- a/vivarium/composites/flagella_expression.py
+++ b/vivarium/composites/flagella_expression.py
@@ -232,9 +232,9 @@ def scan_flagella_expression_parameters():
     flagella_data = FlagellaChromosome()
     scan_params = {}
 
-    # # add promoter affinities
-    # for promoter in flagella_data.chromosome_config['promoters'].keys():
-    #     scan_params[('promoter_affinities', promoter)] = get_parameters_logspace(1e-3, 1e0, 4)
+    # add promoter affinities
+    for promoter in flagella_data.chromosome_config['promoters'].keys():
+        scan_params[('promoter_affinities', promoter)] = get_parameters_logspace(1e-3, 1e0, 4)
 
     # add transcript affinities
     for site in flagella_data.transcript_affinities.keys():
@@ -244,7 +244,7 @@ def scan_flagella_expression_parameters():
     # for threshold in flagella_data.factor_thresholds.keys():
     #     scan_params[('thresholds', threshold)] = get_parameters_logspace(1e-7, 1e-4, 4)
 
-        metrics = [
+    metrics = [
         ('proteins', monomer)
         for monomer in flagella_data.complexation_monomer_ids] + [
         ('proteins', complex)
@@ -257,6 +257,11 @@ def scan_flagella_expression_parameters():
         'options': {'time': 5}}
 
     print('number of parameters: {}'.format(len(scan_params)))  # TODO -- get this down to 10
+
+
+    import ipdb; ipdb.set_trace()
+
+
     results = parameter_scan(scan_config)
 
     return results

--- a/vivarium/composites/flagella_expression.py
+++ b/vivarium/composites/flagella_expression.py
@@ -236,7 +236,6 @@ def scan_flagella_expression_parameters():
 
 
 if __name__ == '__main__':
-    commands = ['plot', 'scan']
     parser = argparse.ArgumentParser(description='flagella expression')
     parser.add_argument('--scan', '-s', action='store_true', default=False,)
     args = parser.parse_args()

--- a/vivarium/composites/flagella_expression.py
+++ b/vivarium/composites/flagella_expression.py
@@ -18,10 +18,12 @@ from vivarium.processes.translation import UNBOUND_RIBOSOME_KEY
 from vivarium.composites.gene_expression import (
     compose_gene_expression,
     plot_gene_expression_output,
-    gene_network_plot)
+    gene_network_plot
+)
 from vivarium.parameters.parameters import (
     parameter_scan,
-    get_parameters_logspace
+    get_parameters_logspace,
+    plot_scan_results
 )
 
 
@@ -232,13 +234,12 @@ def scan_flagella_expression_parameters():
     flagella_data = FlagellaChromosome()
     scan_params = {}
 
-    # add promoter affinities
-    for promoter in flagella_data.chromosome_config['promoters'].keys():
-        scan_params[('promoter_affinities', promoter)] = get_parameters_logspace(1e-3, 1e0, 4)
+    # # add promoter affinities
+    # for promoter in flagella_data.chromosome_config['promoters'].keys():
+    #     scan_params[('promoter_affinities', promoter)] = get_parameters_logspace(1e-3, 1e0, 4)
 
-    # add transcript affinities
-    for site in flagella_data.transcript_affinities.keys():
-        scan_params[('transcript_affinities', site)] = get_parameters_logspace(1e-3, 1e0, 4)
+    # scan minimum transcript affinity -- other affinities are a scaled factor of this value
+    scan_params[('min_tr_affinity', flagella_data.min_tr_affinity)] = get_parameters_logspace(1e-2, 1e2, 6)
 
     # # add transcription factor thresholds
     # for threshold in flagella_data.factor_thresholds.keys():
@@ -254,13 +255,9 @@ def scan_flagella_expression_parameters():
         'composite': generate_flagella_compartment,
         'scan_parameters': scan_params,
         'metrics': metrics,
-        'options': {'time': 5}}
+        'options': {'time': 480}}
 
     print('number of parameters: {}'.format(len(scan_params)))  # TODO -- get this down to 10
-
-
-    import ipdb; ipdb.set_trace()
-
 
     results = parameter_scan(scan_config)
 
@@ -278,7 +275,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.scan:
-        scan_flagella_expression_parameters()
         results = scan_flagella_expression_parameters()
+        plot_scan_results(results, out_dir)
     else:
         plot_flagella_expression(out_dir)

--- a/vivarium/data/chromosomes/flagella_chromosome.py
+++ b/vivarium/data/chromosomes/flagella_chromosome.py
@@ -379,7 +379,9 @@ class FlagellaChromosome(object):
             'fliM': 34,
             'fliG': 26,
             'fliH': 12,
-            'fliI': 6 }
+            'fliI': 6,
+            'fliD': 5,
+            'flgE': 120}
         self.transcript_affinities = {}
         for (operon, product) in self.transcripts:
             self.transcript_affinities[(operon, product)] = self.min_tr_affinity * tr_affinity_scaling.get(product,1)

--- a/vivarium/data/chromosomes/flagella_chromosome.py
+++ b/vivarium/data/chromosomes/flagella_chromosome.py
@@ -372,7 +372,7 @@ class FlagellaChromosome(object):
             for key, sequence in self.protein_sequences.items()}
 
         self.transcript_affinities = {
-            operon: 0.01
+            operon: 1e-2
             for operon in self.transcripts}
 
         self.transcript_affinities.update(

--- a/vivarium/data/chromosomes/flagella_chromosome.py
+++ b/vivarium/data/chromosomes/flagella_chromosome.py
@@ -53,6 +53,7 @@ class FlagellaChromosome(object):
                 'fliE': ['fliE'],
                 'fliF': ['fliF', 'fliG', 'fliH', 'fliI', 'fliJ', 'fliK'],
                 'flgA': ['flgA', 'flgM', 'flgN'],
+                'flgM': ['flgM', 'flgN'],
                 'flgE': ['flgE'],
                 'flgB': ['flgB', 'flgC', 'flgD', 'flgE', 'flgF', 'flgG', 'flgH', 'flgI', 'flgJ'],
                 'flhB': ['flhB', 'flhA', 'flhE'],
@@ -61,8 +62,7 @@ class FlagellaChromosome(object):
                 'flgK': ['flgK', 'flgL'],
                 'fliC': ['fliC'],
                 'tar': ['tar', 'tap', 'cheR', 'cheB', 'cheY', 'cheZ'],
-                'motA': ['motA', 'motB', 'cheA', 'cheW'],
-                'flgM': ['flgM', 'flgN']},
+                'motA': ['motA', 'motB', 'cheA', 'cheW']},
             'promoters': {
                 'flhDp': {
                     'id': 'flhDp',

--- a/vivarium/data/chromosomes/flagella_chromosome.py
+++ b/vivarium/data/chromosomes/flagella_chromosome.py
@@ -371,12 +371,21 @@ class FlagellaChromosome(object):
                 [key[1]])
             for key, sequence in self.protein_sequences.items()}
 
-        self.transcript_affinities = {
-            operon: 1e-2
-            for operon in self.transcripts}
-
+        # transcript affinities are the affinities transcripts to bind a ribosome and translate to protein
+        # transcript affinities are scaled relative to the requirements to build a single full flagellum.
+        self.min_tr_affinity = 1e-1
+        tr_affinity_scaling = {
+            'fliL': 2,
+            'fliM': 34,
+            'fliG': 26,
+            'fliH': 12,
+            'fliI': 6 }
+        self.transcript_affinities = {}
+        for (operon, product) in self.transcripts:
+            self.transcript_affinities[(operon, product)] = self.min_tr_affinity * tr_affinity_scaling.get(product,1)
         self.transcript_affinities.update(
             parameters.get('transcript_affinities', {}))
+
 
         self.transcription_factors = [
             'flhDC', 'fliA', 'CsgD', 'CRP', 'GadE', 'H-NS', 'CpxR', 'Fnr']

--- a/vivarium/processes/Mears2014_flagella_activity.py
+++ b/vivarium/processes/Mears2014_flagella_activity.py
@@ -4,6 +4,7 @@ import os
 import random
 import math
 import uuid
+import argparse
 
 import numpy as np
 from numpy import linspace
@@ -505,22 +506,7 @@ def plot_motor_PMF(output, out_dir='out'):
     plt.subplots_adjust(wspace=0.7, hspace=0.3)
     plt.savefig(fig_path + '.png', bbox_inches='tight')
 
-
-if __name__ == '__main__':
-    out_dir = os.path.join('out', 'tests', 'Mears2014_flagella_activity')
-    if not os.path.exists(out_dir):
-        os.makedirs(out_dir)
-
-    zero_flagella = {'flagella': 0}
-    timeline = [(10, {})]
-    output1 = test_activity(zero_flagella, timeline)
-    plot_activity(output1, out_dir, 'motor_control_zero_flagella')
-
-    five_flagella = {'flagella': 5}
-    timeline = [(10, {})]
-    output2 = test_activity(five_flagella, timeline)
-    plot_activity(output2, out_dir, 'motor_control')
-
+def run_variable_flagella(out_dir):
     # variable flagella
     init_params = {'flagella': 5}
     timeline = [
@@ -533,7 +519,33 @@ if __name__ == '__main__':
                 'flagella': 4}}),
         (10, {})]
     output3 = test_activity(init_params, timeline)
-    plot_activity(output3, out_dir, 'motor_control_variable')
+    plot_activity(output3, out_dir, 'variable_flagella')
 
     output3 = test_motor_PMF()
     plot_motor_PMF(output3, out_dir)
+
+if __name__ == '__main__':
+    out_dir = os.path.join('out', 'tests', 'Mears2014_flagella_activity')
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    parser = argparse.ArgumentParser(description='flagella expression')
+    parser.add_argument('--variable', '-v', action='store_true', default=False,)
+    args = parser.parse_args()
+
+    if args.variable:
+        run_variable_flagella(out_dir)
+    else:
+        zero_flagella = {'flagella': 0}
+        timeline = [(10, {})]
+        output1 = test_activity(zero_flagella, timeline)
+        plot_activity(output1, out_dir, 'motor_control_zero_flagella')
+
+        five_flagella = {'flagella': 5}
+        timeline = [(10, {})]
+        output2 = test_activity(five_flagella, timeline)
+        plot_activity(output2, out_dir, 'motor_control')
+
+        run_variable_flagella(out_dir)
+
+

--- a/vivarium/processes/Mears2014_flagella_activity.py
+++ b/vivarium/processes/Mears2014_flagella_activity.py
@@ -353,12 +353,13 @@ def plot_activity(output, out_dir='out', filename='motor_control'):
     flagella_activity = output['flagella_activity']['flagella']
     time_vec = output['time']
 
-    # get flagella ids
-    flagella_ids = set()
+    # get flagella ids by order appearance
+    flagella_ids = []
     for state in flagella_activity:
         flg_ids = list(state.keys())
-        flagella_ids.update(flg_ids)
-    flagella_ids = list(flagella_ids)
+        for flg_id in flg_ids:
+            if flg_id not in flagella_ids:
+                flagella_ids.append(flg_id)
 
     # make flagella activity grid
     activity_grid = np.zeros((len(flagella_ids), len(time_vec)))
@@ -482,7 +483,7 @@ def plot_activity(output, out_dir='out', filename='motor_control'):
     plt.subplots_adjust(wspace=0.7, hspace=0.3)
     plt.savefig(fig_path + '.png', bbox_inches='tight')
 
-def plot_motor_PMF(output, out_dir='out'):
+def plot_motor_PMF(output, out_dir='out', figname='motor_PMF'):
     motile_state = output['motile_state']
     motile_force = output['motile_force']
     motile_torque = output['motile_torque']
@@ -502,7 +503,7 @@ def plot_motor_PMF(output, out_dir='out'):
     ax1.set_ylabel('force')
 
     # save figure
-    fig_path = os.path.join(out_dir, 'motor_PMF')
+    fig_path = os.path.join(out_dir, figname)
     plt.subplots_adjust(wspace=0.7, hspace=0.3)
     plt.savefig(fig_path + '.png', bbox_inches='tight')
 
@@ -511,18 +512,15 @@ def run_variable_flagella(out_dir):
     init_params = {'flagella': 5}
     timeline = [
         (0, {}),
-        (2, {
+        (60, {
             'flagella_counts': {
                 'flagella': 6}}),
-        (4, {
+        (200, {
             'flagella_counts': {
-                'flagella': 4}}),
-        (10, {})]
+                'flagella': 7}}),
+        (240, {})]
     output3 = test_activity(init_params, timeline)
     plot_activity(output3, out_dir, 'variable_flagella')
-
-    output3 = test_motor_PMF()
-    plot_motor_PMF(output3, out_dir)
 
 if __name__ == '__main__':
     out_dir = os.path.join('out', 'tests', 'Mears2014_flagella_activity')

--- a/vivarium/processes/Mears2014_flagella_activity.py
+++ b/vivarium/processes/Mears2014_flagella_activity.py
@@ -387,21 +387,21 @@ def plot_activity(output, out_dir='out', filename='motor_control'):
 
     # set up colormaps
     # cell motile state
-    cmap1 = colors.ListedColormap(['blue', 'lightgray', 'red'])
+    cmap1 = colors.ListedColormap(['steelblue', 'lightgray', 'darkorange'])
     bounds1 = [-1, -1/3, 1/3, 1]
     norm1 = colors.BoundaryNorm(bounds1, cmap1.N)
     motile_legend_elements = [
-        Patch(facecolor='blue', edgecolor='k', label='Run'),
-        Patch(facecolor='red', edgecolor='k', label='Tumble'),
+        Patch(facecolor='steelblue', edgecolor='k', label='Run'),
+        Patch(facecolor='darkorange', edgecolor='k', label='Tumble'),
         Patch(facecolor='lightgray', edgecolor='k', label='N/A')]
 
     # rotational state
-    cmap2 = colors.ListedColormap(['lightgray', 'blue', 'red'])
+    cmap2 = colors.ListedColormap(['lightgray', 'steelblue', 'darkorange'])
     bounds2 = [0, 0.5, 1.5, 2]
     norm2 = colors.BoundaryNorm(bounds2, cmap2.N)
     rotational_legend_elements = [
-        Patch(facecolor='blue', edgecolor='k', label='CCW'),
-        Patch(facecolor='red', edgecolor='k', label='CW'),
+        Patch(facecolor='steelblue', edgecolor='k', label='CCW'),
+        Patch(facecolor='darkorange', edgecolor='k', label='CW'),
         Patch(facecolor='lightgray', edgecolor='k', label='N/A')]
 
     # plot results


### PR DESCRIPTION
This PR includes several tweaks for the analysis and visualization of flagella.
1. Most importantly, the ```flagella_expression``` composite's initial ribosome, RNAP, and base pair counts are bumped up one order of magnitude to get ~8 flagella expressed per cell cycle (1st fig below).
2. Some tweaks to the listed gene order in the ```flagella_chromosome``` orders the just-in-time expression plot.
3. Tweaks to ```composition's``` ```plot_simulation_output``` handle non-numeric states better. It does not plot them, but accounts for them when setting up the different plot columns.
4. ```Mears2014_flagella_activity``` process has an analysis that shows flagella activity upon adding new flagella (2nd fig below).

![flagella_proteins](https://user-images.githubusercontent.com/6809431/80324608-772eb900-87e6-11ea-993c-d4759643995f.png)

![variable_flagella](https://user-images.githubusercontent.com/6809431/80324700-eefce380-87e6-11ea-8f70-374493ee484b.png)

