### PR TITLE
more multibody/ mother machine

### DIFF
--- a/vivarium/processes/multibody_physics.py
+++ b/vivarium/processes/multibody_physics.py
@@ -500,19 +500,28 @@ def random_body_config(config):
 def mother_machine_body_config(config):
     n_agents = config['n_agents']
     bounds = config.get('bounds', DEFAULT_BOUNDS)
+    channel_space = config.get('channel_space', 1)
+
+    # possible locations, shuffled for index-in
+    n_spaces = math.floor(bounds[0]/channel_space)
+    assert n_agents < n_spaces, 'more agents than mother machine spaces'
+
+    possible_locations = [
+        [x*channel_space - channel_space/2, 0.01]
+        for x in range(1, n_spaces)]
+    random.shuffle(possible_locations)
+
     agents = get_n_dummy_agents(n_agents)
     agent_config = {
         agent_id: {
-            'location': [
-                np.random.uniform(0, bounds[0]),
-                0.01],
+            'location': possible_locations[index],
             'angle': PI/2,
             'volume': 1,
             'length': 1.0,
             'width': 0.5,
             'mass': 1,
             'forces': [0, 0]}
-        for agent_idx, agent_id in enumerate(agents.keys())}
+        for index, agent_id in enumerate(agents.keys())}
 
     return {
         'agents': agent_config,
@@ -613,6 +622,8 @@ def simulate_motility(config, settings):
 def run_mother_machine():
     bounds = [30, 30]
     channel_height = 0.8 * bounds[1]
+    channel_space = 0.8
+
     settings = {
         'growth_rate': 0.05,
         'division_volume': 1.0,
@@ -623,11 +634,13 @@ def run_mother_machine():
         # 'debug': True,
         'mother_machine': {
             'channel_height': channel_height,
-            'channel_space': 1},
+            'channel_space': channel_space},
         'jitter_force': 0.5e0,
         'bounds': bounds}
     body_config = {
         'bounds': bounds,
+        'channel_height': channel_height,
+        'channel_space': channel_space,
         'n_agents': 8}
     config.update(mother_machine_body_config(body_config))
     return simulate_growth_division(config, settings)

--- a/vivarium/processes/multibody_physics.py
+++ b/vivarium/processes/multibody_physics.py
@@ -151,7 +151,8 @@ class Multibody(Process):
         # debug screen with pygame
         self.pygame_viz = initial_parameters.get('debug', self.defaults['debug'])
         max_bound = max(self.bounds)
-        self.pygame_scale = DEBUG_SIZE / max_bound  # TODO -- remove this
+        self.pygame_scale = 1
+        # self.pygame_scale = DEBUG_SIZE / max_bound  # TODO -- remove this
         if self.pygame_viz:
             pygame.init()
             self._screen = pygame.display.set_mode((
@@ -367,6 +368,12 @@ class Multibody(Process):
         position = body.position
         angle = body.angle
 
+
+
+        print('angle: {}'.format(angle))
+
+
+
         # make shape, moment of inertia, and add a body
         half_length = length/2
         half_width = width/2
@@ -390,8 +397,8 @@ class Multibody(Process):
         new_shape.friction = shape.friction
 
         # swap bodies
-        self.space.add(new_body, new_shape)
         self.space.remove(body, shape)
+        self.space.add(new_body, new_shape)
 
         # update body
         self.agent_bodies[body_id] = (new_body, new_shape)
@@ -399,6 +406,7 @@ class Multibody(Process):
     def get_body_position(self, agent_id):
         body, shape = self.agent_bodies[agent_id]
         position = body.position
+        angle = body.angle
         rescaled_position = [
             position[0] / self.pygame_scale,
             position[1] / self.pygame_scale]
@@ -411,9 +419,13 @@ class Multibody(Process):
             self.bounds[idx] if pos>self.bounds[idx] else pos
             for idx, pos in enumerate(rescaled_position)]
 
+
+        print('get angle: {}'.format(angle))
+        # import ipdb; ipdb.set_trace()
+
         return {
             'location': rescaled_position,
-            'angle': body.angle,
+            'angle': angle,
         }
 
 
@@ -622,7 +634,7 @@ def simulate_motility(config, settings):
 def run_mother_machine():
     bounds = [30, 30]
     channel_height = 0.8 * bounds[1]
-    channel_space = 0.8
+    channel_space = 2  #0.8
 
     settings = {
         'growth_rate': 0.05,
@@ -641,7 +653,7 @@ def run_mother_machine():
         'bounds': bounds,
         'channel_height': channel_height,
         'channel_space': channel_space,
-        'n_agents': 8}
+        'n_agents': 1}
     config.update(mother_machine_body_config(body_config))
     return simulate_growth_division(config, settings)
 


### PR DESCRIPTION
This fixes a bug I was having only when debugging with pygame. The jitter force was not scaling correctly, the fix was easy -- I had to use the ```pygame_scaling``` factor for forces as well.  

While at it, I made the mother_machine more configurable, with adjustable channel widths/height.