### PR TITLE
Chemotaxis master

### DIFF
--- a/vivarium/compartments/chemotaxis_master.py
+++ b/vivarium/compartments/chemotaxis_master.py
@@ -167,7 +167,7 @@ class ChemotaxisMaster(Compartment):
                 'global': boundary_path}}
 
 def run_chemotaxis_master(out_dir):
-    total_time = 100
+    total_time = 5
     compartment = ChemotaxisMaster({})
 
     # save the topology network

--- a/vivarium/compartments/transport_metabolism.py
+++ b/vivarium/compartments/transport_metabolism.py
@@ -29,7 +29,7 @@ from vivarium.processes.ode_expression import (
     get_lacy_config)
 
 
-NAME = 'txp_mtb_ge'
+NAME = 'transport_metabolism'
 
 def default_metabolism_config():
     config = get_iAF1260b_config()
@@ -58,9 +58,9 @@ def default_expression_config():
 
     return config
 
-class TransportMetabolismExpression(Compartment):
+class TransportMetabolism(Compartment):
     """
-    TransportMetabolismExpression Compartment
+    Transport/Metabolism Compartment, with ODE expression
     """
 
     defaults = {
@@ -163,7 +163,7 @@ def test_txp_mtb_ge(total_time=10):
         'exchange_path': ('exchange',),
         'global_path': ('global',),
         'agents_path': ('agents',)}
-    compartment = TransportMetabolismExpression(compartment_config)
+    compartment = TransportMetabolism(compartment_config)
 
     # simulate
     settings = {
@@ -361,7 +361,7 @@ if __name__ == '__main__':
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    # run scan with python vivarium/compartments/txp_mtb_ge.py --scan
+    # run scan with python vivarium/compartments/transport_metabolism.py --scan
     parser = argparse.ArgumentParser(description='transport metabolism composite')
     parser.add_argument('--scan', '-s', action='store_true', default=False, )
     parser.add_argument('--run', '-r', action='store_true', default=False, )

--- a/vivarium/compartments/txp_mtb_ge.py
+++ b/vivarium/compartments/txp_mtb_ge.py
@@ -64,9 +64,8 @@ class TransportMetabolismExpression(Compartment):
     """
 
     defaults = {
-        'global_path': ('..', 'global'),
+        'boundary_path': ('boundary',),
         'agents_path': ('..', '..', 'agents',),
-        'external_path': ('..', 'external'),
         'daughter_path': tuple(),
         'transport': get_glc_lct_config(),
         'metabolism': default_metabolism_config(),
@@ -74,9 +73,10 @@ class TransportMetabolismExpression(Compartment):
         'division': {}}
 
     def __init__(self, config):
-        self.global_path = config.get('global_path', self.defaults['global_path'])
+        self.config = config
+
+        self.boundary_path = config.get('boundary_path', self.defaults['boundary_path'])
         self.agents_path = config.get('agents_path', self.defaults['agents_path'])
-        self.external_path = config.get('external_path', self.defaults['external_path'])
         self.daughter_path = config.get('daughter_path', self.defaults['daughter_path'])
 
         self.transport_config = config.get('transport', self.defaults['transport'])
@@ -126,35 +126,31 @@ class TransportMetabolismExpression(Compartment):
         }
 
     def generate_topology(self, config):
-        external_path = config.get('external_path', self.external_path)
-        global_path = config.get('global_path', self.global_path)
-        agents_path = config.get('agents_path', self.agents_path)
-
         return {
             'transport': {
                 'internal': ('cytoplasm',),
-                'external': external_path,
+                'external': self.boundary_path,
                 'exchange': ('null',),  # metabolism's exchange is used
                 'fluxes': ('flux_bounds',),
-                'global': global_path,
+                'global': self.boundary_path,
             },
             'metabolism': {
                 'internal': ('cytoplasm',),
-                'external': external_path,
+                'external': self.boundary_path,
                 'reactions': ('reactions',),
                 'exchange': ('exchange',),
                 'flux_bounds': ('flux_bounds',),
-                'global': global_path,
+                'global': self.boundary_path,
             },
             'expression': {
                 'counts': ('cytoplasm_counts',),
                 'internal': ('cytoplasm',),
-                'external': external_path,
-                'global': global_path,
+                'external': self.boundary_path,
+                'global': self.boundary_path,
             },
             'division': {
-                'global': global_path,
-                'cells': agents_path,
+                'global': self.boundary_path,
+                'cells': self.agents_path,
             }
         }
 
@@ -178,7 +174,7 @@ def test_txp_mtb_ge(total_time=10):
 def simulate_txp_mtb_ge(config={}, out_dir='out'):
     # run simulation
     timeseries = test_txp_mtb_ge(20)  # 2520 sec (42 min) is the expected doubling time in minimal media
-    volume_ts = timeseries['global']['volume']
+    volume_ts = timeseries['boundary']['volume']
     try:
         print('growth: {}'.format(volume_ts[-1] / volume_ts[0]))
     except:
@@ -188,7 +184,8 @@ def simulate_txp_mtb_ge(config={}, out_dir='out'):
     # diauxic plot
     settings = {
         'internal_port': 'cytoplasm',
-        'external_port': 'external',
+        'external_port': 'boundary',
+        'global_port': 'boundary',
         'exchange_port': 'exchange',
         'environment_volume': 1e-13,  # L
         # 'timeline': timeline

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -686,8 +686,17 @@ class Compartment(object):
         return {}
 
     def generate(self, config=None, path=tuple()):
+        '''
+        Generate processes and topology for the compartment
+        :param config: (dict) updates values in the configuration declared in the constructor
+        :param path: (tuple) with ('path', 'to', 'level') associates the processes and topology at this level
+        :return: (dict) with entries for 'processes' and 'topology'
+        '''
+
+        # config updates values in self.config
         if config is None:
             config = {}
+        config = deep_merge(dict(config), self.config)
 
         processes = self.generate_processes(config)
         topology = self.generate_topology(config)

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -708,7 +708,6 @@ class Compartment(object):
             for process_id, process in processes.items()}
 
 
-# Experiment
 def generate_state(processes, topology, initial_state):
     state = Store({})
     state.generate_paths(processes, topology, initial_state)

--- a/vivarium/experiments/chemotaxis_master.py
+++ b/vivarium/experiments/chemotaxis_master.py
@@ -19,10 +19,7 @@ from vivarium.compartments.lattice import (
     Lattice,
     get_lattice_config
 )
-from vivarium.compartments.chemotaxis_minimal import (
-    ChemotaxisMinimal,
-    get_chemotaxis_config
-)
+from vivarium.compartments.chemotaxis_master import ChemotaxisMaster
 
 # processes
 from vivarium.processes.multibody_physics import (
@@ -46,7 +43,7 @@ def make_chemotaxis_experiment(config={}):
     processes = network['processes']
     topology = network['topology']
 
-    chemotaxis = ChemotaxisMinimal(config.get('chemotaxis', {}))
+    chemotaxis = ChemotaxisMaster(config.get('chemotaxis', {}))
     agents = make_agents(agent_ids, chemotaxis, config.get('chemotaxis', {}))
     processes['agents'] = agents['processes']
     topology['agents'] = agents['topology']
@@ -160,7 +157,7 @@ def run_chemotaxis_experiment(time=5, out_dir='out'):
 
 
 if __name__ == '__main__':
-    out_dir = os.path.join(EXPERIMENT_OUT_DIR, 'chemotaxis_minimal')
+    out_dir = os.path.join(EXPERIMENT_OUT_DIR, 'chemotaxis_master.py')
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 

--- a/vivarium/processes/Endres2006_chemoreceptor.py
+++ b/vivarium/processes/Endres2006_chemoreceptor.py
@@ -74,7 +74,9 @@ class ReceptorCluster(Process):
         'parameters': DEFAULT_PARAMETERS
     }
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if not initial_parameters:
+            initial_parameters = {}
 
         self.ligand_id = initial_parameters.get('ligand_id', self.defaults['ligand_id'])
         self.initial_ligand = initial_parameters.get('initial_ligand', self.defaults['initial_ligand'])

--- a/vivarium/processes/Kremling2007_transport.py
+++ b/vivarium/processes/Kremling2007_transport.py
@@ -95,7 +95,10 @@ class Transport(Process):
     }
 
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
+
         self.dt = 0.01  # timestep for ode integration (seconds)
         self.target_fluxes = initial_parameters.get('target_fluxes', self.defaults['target_fluxes'])
 

--- a/vivarium/processes/Mears2014_flagella_activity.py
+++ b/vivarium/processes/Mears2014_flagella_activity.py
@@ -84,7 +84,9 @@ class FlagellaActivity(Process):
         'time_step': 0.01,  # 0.001
     }
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if not initial_parameters:
+            initial_parameters = {}
 
         self.n_flagella = initial_parameters.get('flagella', self.defaults['flagella'])
         self.flagellum_thrust = initial_parameters.get('flagellum_thrust', self.defaults['flagellum_thrust'])

--- a/vivarium/processes/Vladimirov2008_motor.py
+++ b/vivarium/processes/Vladimirov2008_motor.py
@@ -58,8 +58,10 @@ class MotorActivity(Process):
             }}
     }
 
-    def __init__(self, initial_parameters={}):
-
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
+            
         ports = {
             'internal': [
                 'chemoreceptor_activity',

--- a/vivarium/processes/Vladimirov2008_motor.py
+++ b/vivarium/processes/Vladimirov2008_motor.py
@@ -61,7 +61,7 @@ class MotorActivity(Process):
     def __init__(self, initial_parameters=None):
         if initial_parameters is None:
             initial_parameters = {}
-            
+
         ports = {
             'internal': [
                 'chemoreceptor_activity',

--- a/vivarium/processes/cellular_potts.py
+++ b/vivarium/processes/cellular_potts.py
@@ -24,7 +24,9 @@ class CellularPotts(Process):
         'target_area': 10
     }
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
 
         grid_size = initial_parameters.get('grid_size', self.defaults['grid_size'])
         n_initial = initial_parameters.get('n_agents', self.defaults['n_agents'])

--- a/vivarium/processes/convenience_kinetics.py
+++ b/vivarium/processes/convenience_kinetics.py
@@ -53,6 +53,164 @@ NAME = 'convenience_kinetics'
 
 
 class ConvenienceKinetics(Process):
+    '''Michaelis-Menten-style enzyme kinetics model
+
+     Arguments:
+         initial_parameters: Configures the :term:`process` with the
+             following configuration options:
+
+             * **reactions** (:py:class:`dict`): Specifies the
+               stoichiometry, reversibility, and catalysts of each
+               reaction to model. For a non-reversible reaction
+               :math:`A + B \\rightleftarrows 2C` catalized by an
+               enzyme :math:`E`, we have the following reaction
+               specification:
+
+               .. code-block:: python
+
+                 {
+                     # reaction1 is a reaction ID
+                     'reaction1': {
+                         'stoichiometry': {
+                             # 1 mol A is consumd per mol reaction
+                             ('internal', 'A'): -1,
+                             ('internal', 'B'): -1,
+                             # 2 mol C are produced per mol reaction
+                             ('internal', 'C'): 2,
+                         },
+                         'is reversible': False,
+                         'catalyzed by': [
+                             ('internal', 'E'),
+                         ],
+                     }
+                 }
+
+               Note that for simplicity, we assumed all the molecules
+               and enzymes were in the ``internal`` port, but this is
+               not necessary.
+             * **kinetic_parameters** (:py:class:`dict`): Specifies
+               the kinetics of the reaction by providing
+               :math:`k_{cat}` and :math:`K_M` parameters for each
+               enzyme. For example, let's say that for the reaction
+               described above, :math:`k{cat} = 1`, :math:`K_A = 2`,
+               and :math:`K_B = 3`. Then the reaction kinetics would
+               be specified by:
+
+               .. code-block:: python
+
+                 {
+                     'reaction1': {
+                         ('internal', 'E'): {
+                             'kcat_f': 1,  # kcat for forward reaction
+                             ('internal', 'A'): 2,
+                             ('internal', 'B'): 3,
+                         },
+                     },
+                 }
+
+               If the reaction were reversible, we could have
+               specified ``kcat_r`` as the :math:`k_{cat}` of the
+               reverse reaction.
+             * **initial_state** (:py:class:`dict`): Provides the
+               initial quantities of the molecules and enzymes. The
+               initial reaction flux must also be specified. For
+               example, to start with :math:`[E] = 1.2 mM` and
+               :math:`[A] = [B] = [C] = 0 mM` with an initial
+               reaction flux of `0`, we would have:
+
+               .. code-block:: python
+
+                 {
+                     'internal': {
+                         'A': 0.0,
+                         'B': 0.0,
+                         'C': 0.0,
+                         'E': 1.2,
+                     },
+                     'fluxes': {
+                         'reaction1': 0.0,
+                     }
+                 }
+
+               .. note:: Unlike the previous configuration options,
+                   the initial state dictionary is not divided up by
+                   reaction.
+
+               If no initial state is specified,
+               :py:const:`EMPTY_STATES` is used.
+             * **ports** (:py:class:`dict`): Each item in the
+               dictionary has a :term:`port` name as its key and a
+               list of the :term:`variables` in that port as its
+               value. Each port should be specified only once. For
+               example, the reaction we have been using as an example
+               would have:
+
+               .. code-block:: python
+
+                 {
+                     'internal': ['A', 'B', 'C', 'E'],
+                 }
+
+               If no ports are specified, :py:const:`EMPTY_ROLES` is
+               used.
+
+     The ports of the process are the ports configured by the
+     user, with the following modifications:
+
+     * A ``fluxes`` port is added with variable names equal to
+       the IDs of the configured reactions.
+     * An ``exchange`` port is added with the same variables as the
+       ``external`` port.
+     * A ``global`` port is added with a variable named
+       ``mmol_to_counts``, which is set by a :term:`deriver`.
+
+     Example configuring a process to model the kinetics and reaction
+     described above.
+
+     >>> configuration = {
+     ...     'reactions': {
+     ...         # reaction1 is the reaction ID
+     ...         'reaction1': {
+     ...             'stoichiometry': {
+     ...                 # 1 mol A is consumd per mol reaction
+     ...                 ('internal', 'A'): -1,
+     ...                 ('internal', 'B'): -1,
+     ...                 # 2 mol C are produced per mol reaction
+     ...                 ('internal', 'C'): 2,
+     ...             },
+     ...             'is reversible': False,
+     ...             'catalyzed by': [
+     ...                 ('internal', 'E'),
+     ...             ],
+     ...         }
+     ...     },
+     ...     'kinetic_parameters': {
+     ...         'reaction1': {
+     ...             ('internal', 'E'): {
+     ...                 'kcat_f': 1,  # kcat for forward reaction
+     ...                 ('internal', 'A'): 2,
+     ...                 ('internal', 'B'): 3,
+     ...             },
+     ...         },
+     ...     },
+     ...     'initial_state': {
+     ...         'internal': {
+     ...             'A': 0.0,
+     ...             'B': 0.0,
+     ...             'C': 0.0,
+     ...             'E': 1.2,
+     ...         },
+     ...         'fluxes': {
+     ...             'reaction1': 0.0,
+     ...         }
+     ...     },
+     ...     'ports': {
+     ...         'internal': ['A', 'B', 'C', 'E'],
+     ...         'external': [],
+     ...     },
+     ... }
+     >>> kinetic_process = ConvenienceKinetics(configuration)
+     '''
 
     defaults = {
         'reactions': {},
@@ -65,165 +223,10 @@ class ConvenienceKinetics(Process):
             'external': []},
         'global_deriver_key': 'global_deriver'}
 
-    def __init__(self, initial_parameters={}):
-        '''Michaelis-Menten-style enzyme kinetics model
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
 
-        Arguments:
-            initial_parameters: Configures the :term:`process` with the
-                following configuration options:
-
-                * **reactions** (:py:class:`dict`): Specifies the
-                  stoichiometry, reversibility, and catalysts of each
-                  reaction to model. For a non-reversible reaction
-                  :math:`A + B \\rightleftarrows 2C` catalized by an
-                  enzyme :math:`E`, we have the following reaction
-                  specification:
-
-                  .. code-block:: python
-
-                    {
-                        # reaction1 is a reaction ID
-                        'reaction1': {
-                            'stoichiometry': {
-                                # 1 mol A is consumd per mol reaction
-                                ('internal', 'A'): -1,
-                                ('internal', 'B'): -1,
-                                # 2 mol C are produced per mol reaction
-                                ('internal', 'C'): 2,
-                            },
-                            'is reversible': False,
-                            'catalyzed by': [
-                                ('internal', 'E'),
-                            ],
-                        }
-                    }
-
-                  Note that for simplicity, we assumed all the molecules
-                  and enzymes were in the ``internal`` port, but this is
-                  not necessary.
-                * **kinetic_parameters** (:py:class:`dict`): Specifies
-                  the kinetics of the reaction by providing
-                  :math:`k_{cat}` and :math:`K_M` parameters for each
-                  enzyme. For example, let's say that for the reaction
-                  described above, :math:`k{cat} = 1`, :math:`K_A = 2`,
-                  and :math:`K_B = 3`. Then the reaction kinetics would
-                  be specified by:
-
-                  .. code-block:: python
-
-                    {
-                        'reaction1': {
-                            ('internal', 'E'): {
-                                'kcat_f': 1,  # kcat for forward reaction
-                                ('internal', 'A'): 2,
-                                ('internal', 'B'): 3,
-                            },
-                        },
-                    }
-
-                  If the reaction were reversible, we could have
-                  specified ``kcat_r`` as the :math:`k_{cat}` of the
-                  reverse reaction.
-                * **initial_state** (:py:class:`dict`): Provides the
-                  initial quantities of the molecules and enzymes. The
-                  initial reaction flux must also be specified. For
-                  example, to start with :math:`[E] = 1.2 mM` and
-                  :math:`[A] = [B] = [C] = 0 mM` with an initial
-                  reaction flux of `0`, we would have:
-
-                  .. code-block:: python
-
-                    {
-                        'internal': {
-                            'A': 0.0,
-                            'B': 0.0,
-                            'C': 0.0,
-                            'E': 1.2,
-                        },
-                        'fluxes': {
-                            'reaction1': 0.0,
-                        }
-                    }
-
-                  .. note:: Unlike the previous configuration options,
-                      the initial state dictionary is not divided up by
-                      reaction.
-
-                  If no initial state is specified,
-                  :py:const:`EMPTY_STATES` is used.
-                * **ports** (:py:class:`dict`): Each item in the
-                  dictionary has a :term:`port` name as its key and a
-                  list of the :term:`variables` in that port as its
-                  value. Each port should be specified only once. For
-                  example, the reaction we have been using as an example
-                  would have:
-
-                  .. code-block:: python
-
-                    {
-                        'internal': ['A', 'B', 'C', 'E'],
-                    }
-
-                  If no ports are specified, :py:const:`EMPTY_ROLES` is
-                  used.
-
-        The ports of the process are the ports configured by the
-        user, with the following modifications:
-
-        * A ``fluxes`` port is added with variable names equal to
-          the IDs of the configured reactions.
-        * An ``exchange`` port is added with the same variables as the
-          ``external`` port.
-        * A ``global`` port is added with a variable named
-          ``mmol_to_counts``, which is set by a :term:`deriver`.
-
-        Example configuring a process to model the kinetics and reaction
-        described above.
-
-        >>> configuration = {
-        ...     'reactions': {
-        ...         # reaction1 is the reaction ID
-        ...         'reaction1': {
-        ...             'stoichiometry': {
-        ...                 # 1 mol A is consumd per mol reaction
-        ...                 ('internal', 'A'): -1,
-        ...                 ('internal', 'B'): -1,
-        ...                 # 2 mol C are produced per mol reaction
-        ...                 ('internal', 'C'): 2,
-        ...             },
-        ...             'is reversible': False,
-        ...             'catalyzed by': [
-        ...                 ('internal', 'E'),
-        ...             ],
-        ...         }
-        ...     },
-        ...     'kinetic_parameters': {
-        ...         'reaction1': {
-        ...             ('internal', 'E'): {
-        ...                 'kcat_f': 1,  # kcat for forward reaction
-        ...                 ('internal', 'A'): 2,
-        ...                 ('internal', 'B'): 3,
-        ...             },
-        ...         },
-        ...     },
-        ...     'initial_state': {
-        ...         'internal': {
-        ...             'A': 0.0,
-        ...             'B': 0.0,
-        ...             'C': 0.0,
-        ...             'E': 1.2,
-        ...         },
-        ...         'fluxes': {
-        ...             'reaction1': 0.0,
-        ...         }
-        ...     },
-        ...     'ports': {
-        ...         'internal': ['A', 'B', 'C', 'E'],
-        ...         'external': [],
-        ...     },
-        ... }
-        >>> kinetic_process = ConvenienceKinetics(configuration)
-        '''
         self.nAvogadro = constants.N_A * 1 / units.mol
 
         # retrieve initial parameters

--- a/vivarium/processes/derive_concentrations.py
+++ b/vivarium/processes/derive_concentrations.py
@@ -14,7 +14,10 @@ class DeriveConcentrations(Deriver):
     defaults = {
         'concentration_keys': []}
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
+
         self.avogadro = AVOGADRO
         self.concentration_keys = self.or_default(
             initial_parameters, 'concentration_keys')

--- a/vivarium/processes/derive_counts.py
+++ b/vivarium/processes/derive_counts.py
@@ -24,7 +24,9 @@ class DeriveCounts(Deriver):
     defaults = {
         'concentration_keys': []}
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
 
         self.initial_state = initial_parameters.get('initial_state', get_default_state())
 

--- a/vivarium/processes/derive_globals.py
+++ b/vivarium/processes/derive_globals.py
@@ -59,7 +59,9 @@ class DeriveGlobals(Deriver):
         'initial_mass': 1339 * units.fg,  # wet mass in fg
     }
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
 
         self.width = initial_parameters.get('width', self.defaults['width'])
         self.initial_mass = initial_parameters.get('initial_mass', self.defaults['initial_mass'])

--- a/vivarium/processes/diffusion_field.py
+++ b/vivarium/processes/diffusion_field.py
@@ -166,7 +166,9 @@ class DiffusionField(Process):
         'boundary_port': BOUNDARY_PORT,
     }
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
 
         # initial state
         self.molecule_ids = initial_parameters.get('molecules', self.defaults['molecules'])

--- a/vivarium/processes/diffusion_network.py
+++ b/vivarium/processes/diffusion_network.py
@@ -86,7 +86,9 @@ class DiffusionNetwork(Process):
         'network': {},
     }
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
 
         # parameters
         molecule_ids = initial_parameters.get('molecules', self.defaults['molecules'])

--- a/vivarium/processes/division_volume.py
+++ b/vivarium/processes/division_volume.py
@@ -12,7 +12,10 @@ class DivisionVolume(Process):
         'division_volume': 2.4 * units.fL,  # fL
     }
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if not initial_parameters:
+            initial_parameters = {}
+
         self.division = 0
         division_volume = initial_parameters.get('division_volume', self.defaults['division_volume'])
 

--- a/vivarium/processes/growth.py
+++ b/vivarium/processes/growth.py
@@ -61,7 +61,10 @@ class Growth(Process):
         'global_deriver_key': 'global_deriver',
     }
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
+
         ports = {
             'global': [
                 'mass',

--- a/vivarium/processes/growth_protein.py
+++ b/vivarium/processes/growth_protein.py
@@ -23,7 +23,10 @@ class GrowthProtein(Process):
         'mass_deriver_key': 'mass_deriver',
     }
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
+
         ports = {
             'internal': [
                 'protein'],

--- a/vivarium/processes/homogeneous_environment.py
+++ b/vivarium/processes/homogeneous_environment.py
@@ -19,7 +19,9 @@ class HomogeneousEnvironment(Deriver):
         'exchange_port': 'exchange',
     }
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
 
         volume = initial_parameters.get('volume', self.defaults['volume']) * units.L
         self.mmol_to_counts = (AVOGADRO.to('1/mmol') * volume).to('L/mmol').magnitude

--- a/vivarium/processes/membrane_potential.py
+++ b/vivarium/processes/membrane_potential.py
@@ -76,17 +76,18 @@ class MembranePotential(Process):
             }
     }
 
-
-    def __init__(self, config={}):
+    def __init__(self, initial_parameters=None):
+        if not initial_parameters:
+            initial_parameters = {}
 
         # set states
-        self.initial_states = config.get('states', self.defaults['states'])
-        self.permeability = config.get('permeability', self.defaults['permeability'])
-        self.charge = config.get('charge', self.defaults['charge'])
+        self.initial_states = initial_parameters.get('states', self.defaults['states'])
+        self.permeability = initial_parameters.get('permeability', self.defaults['permeability'])
+        self.charge = initial_parameters.get('charge', self.defaults['charge'])
 
         # set parameters
         parameters = self.defaults['constants']
-        parameters.update(config.get('parameters', self.defaults['parameters']))
+        parameters.update(initial_parameters.get('parameters', self.defaults['parameters']))
 
         # get list of internal and external states
         internal_states = list(self.initial_states['internal'].keys())

--- a/vivarium/processes/meta_division.py
+++ b/vivarium/processes/meta_division.py
@@ -31,7 +31,10 @@ class MetaDivision(Deriver):
         'daughter_path': ('cell',),
         'id_function': CountForever(start=33).generate}
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
+
         self.division = 0
 
         # must provide a compartment to generate new daughters

--- a/vivarium/processes/metabolism.py
+++ b/vivarium/processes/metabolism.py
@@ -107,6 +107,7 @@ class Metabolism(Process):
     """
     defaults = {
         'constrained_reaction_ids': [],
+        'model_path': 'models/iAF1260b.json',
         'default_upper_bound': 1000.0,
         'regulation': {},
         'initial_state': {},
@@ -123,6 +124,8 @@ class Metabolism(Process):
         time_step = initial_parameters.get('time_step', self.defaults['time_step'])
 
         # initialize FBA
+        if 'model_path' not in initial_parameters and 'stoichiometry' not in initial_parameters:
+            initial_parameters['model_path'] = self.defaults['model_path']
         self.fba = CobraFBA(initial_parameters)
         self.reaction_ids = self.fba.reaction_ids()
         self.exchange_threshold = self.defaults['exchange_threshold']

--- a/vivarium/processes/metabolism.py
+++ b/vivarium/processes/metabolism.py
@@ -108,7 +108,7 @@ class Metabolism(Process):
     defaults = {
         'constrained_reaction_ids': [],
         'model_path': 'models/iAF1260b.json',
-        'default_upper_bound': 1000.0,
+        'default_upper_bound': 0.0,
         'regulation': {},
         'initial_state': {},
         'exchange_threshold': 1e-6, # external concs lower than exchange_threshold are considered depleted
@@ -249,7 +249,6 @@ class Metabolism(Process):
                     'global': 'global'},
                 'config': {
                     'from_path': ('..', '..'),
-                    'initial_mass': self.initial_mass
                 }}}
 
     def next_update(self, timestep, states):

--- a/vivarium/processes/minimal_expression.py
+++ b/vivarium/processes/minimal_expression.py
@@ -31,7 +31,9 @@ class MinimalExpression(Process):
         'concentrations_deriver_key': 'expression_concentrations_deriver',
     }
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
 
         expression_rates = initial_parameters.get('expression_rates')
         self.internal_states = list(expression_rates.keys()) if expression_rates else []

--- a/vivarium/processes/multibody_physics.py
+++ b/vivarium/processes/multibody_physics.py
@@ -103,7 +103,10 @@ class Multibody(Process):
         'time_step': 2,
     }
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
+
         # agents
         self.initial_agents = initial_parameters.get('agents', self.defaults['initial_agents'])
 

--- a/vivarium/processes/ode_expression.py
+++ b/vivarium/processes/ode_expression.py
@@ -24,6 +24,146 @@ from vivarium.processes.derive_globals import AVOGADRO
 NAME = 'ode_expression'
 
 class ODE_expression(Process):
+    '''Models gene expression using ordinary differential equations
+
+     This :term:`process class` models the rates of transcription,
+     translation, and degradation using ordinary differential
+     equations (ODEs). These ODEs are as follows:
+
+     * Transcription: :math:`\\frac{dM}{dt} = k_M - d_M M`
+
+         * :math:`M`: Concentration of mRNA
+         * :math:`k_M`: Trancription rate
+         * :math:`d_M`: Degradation rate
+
+     * Translation: :math:`\\frac{dP}{dt} = k_P m_P - d_P P`
+
+         * :math:`P`: Concentration of protein
+         * :math:`m_P`: Concentration of transcript
+         * :math:`k_P`: Translation rate
+         * :math:`d_P`: Degradation rate
+
+     The transcription rate abstracts over factors that include gene
+     copy number, RNA polymerase abundance, promoter strengths, and
+     nucleotide availability. The translation rate similarly
+     abstracts over factors that include ribosome availability, the
+     binding strength of the mRNA to the ribosome, the availability
+     of tRNAs, and the availability of free amino acids.
+
+     This process class also models genetic regulation with boolean
+     logic statements. This restricts us to modeling binary
+     regulation: reactions can be completely suppressed, but they
+     cannot be only slowed. For example, we can model a statement
+     like:
+
+         If :math:`[glucose] > 0.1`, completely inhibit LacY
+         expression.
+
+     But we cannot model a statement like this:
+
+         If :math:`[glucose] > 0.1`, reduce LacY expression by 50%.
+
+     .. note::
+         This model does **not** include:
+
+             * Kinetic regulation
+             * Cooperativity
+             * Autoinhibition
+             * Autoactivation
+
+     :term:`Ports`:
+
+     * **internal**: Expects a :term:`store` with all of the
+       transcripts and proteins being modeled. This store should also
+       include any internal regulators.
+     * **external**: Expects a store with all external regulators.
+       These variables are not updated; they are only read.
+
+     Arguments:
+         initial_parameters: A dictionary of configuration options.
+             The following configuration options may be provided:
+
+             * **transcription_rates** (:py:class:`dict`): Maps
+               transcript names (the keys of the dict) to
+               transcription rates (values of the dict).
+             * **translation_rates** (:py:class:`dict`): Maps protein
+               names (the keys of the dict) to translation rates (the
+               values of the dict).
+             * **degradation_rates** (:py:class:`dict`): Maps from
+               names of substrates (transcripts or proteins) to
+               degrade to their degradation rates.
+             * **protein_map** (:py:class:`dict`): Maps from protein
+               name to transcript name for each transcript-protein
+               pair.
+             * **initial_state** (:py:class:`dict`): Maps from
+               :term:`port` names to the initial state of that port.
+               Each initial state is specified as a dictionary with
+               :term:`variable` names as keys and variable values as
+               values.
+             * **regulators** (:py:class:`list`): List of the
+               molecules that regulate any of the modeled
+               transcription or translation reactions. Each molecule
+               is a tuple of the port and the molecule's variable
+               name.
+             * **regulation** (:py:class:`dict`): Maps from reaction
+               product (transcript or protein) name to a boolean
+               regulation statement. For example, to only transcribe
+               ``lacy_RNA`` if external ``glc__D_e`` concentration is
+               at most 0.1, we would pass:
+
+               .. code-block:: python
+
+                 {'lacy_RNA': 'if not (external, glc__D_e) > 0.1'}
+
+     Example instantiation of a :term:`process` modeling LacY
+     expression:
+
+     >>> initial_state = {
+     ...     'internal': {
+     ...         'lacy_RNA': 0.0,
+     ...         'LacY': 0.0,
+     ...     },
+     ...     'external': {
+     ...         'glc__D_e': 2.0,
+     ...     }
+     ... }
+     >>> config = {
+     ...     'transcription_rates': {
+     ...         'lacy_RNA': 3.0,
+     ...     },
+     ...     'translation_rates': {
+     ...         'LacY': 4.0,
+     ...     },
+     ...     'degradation_rates': {
+     ...         'lacy_RNA': 1.0,
+     ...         'LacY': 0.0,
+     ...     },
+     ...     'protein_map': {
+     ...         'LacY': 'lacy_RNA',
+     ...     },
+     ...     'initial_state': initial_state,
+     ...     'regulators': [('external', 'glc__D_e')],
+     ...     'regulation': {
+     ...         'lacy_RNA': 'if not (external, glc__D_e) > 1.0',
+     ...     },
+     ... }
+     >>> expression_process = ODE_expression(config)
+     >>> state = expression_process.default_state()
+     >>> state == initial_state
+     True
+     >>> # When external glc__D_e present, no transcription
+     >>> expression_process.next_update(1, state)
+     {'internal': {'lacy_RNA': 0.0, 'LacY': 0.0}}
+     >>> # But translation and degradation still occur
+     >>> state['internal']['lacy_RNA'] = 1.0
+     >>> expression_process.next_update(1, state)
+     {'internal': {'lacy_RNA': -1.0, 'LacY': 4.0}}
+     >>> # When external glc__D_e low, LacY transcribed
+     >>> state['external']['glc__D_e'] = 0.5
+     >>> expression_process.next_update(1, state)
+     {'internal': {'lacy_RNA': 2.0, 'LacY': 4.0}}
+
+     '''
 
     defaults = {
         'transcription_rates': {},
@@ -36,147 +176,10 @@ class ODE_expression(Process):
         'counts_deriver_key': 'expression_counts',
     }
 
-    def __init__(self, initial_parameters={}):
-        '''Models gene expression using ordinary differential equations
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
 
-        This :term:`process class` models the rates of transcription,
-        translation, and degradation using ordinary differential
-        equations (ODEs). These ODEs are as follows:
-
-        * Transcription: :math:`\\frac{dM}{dt} = k_M - d_M M`
-
-            * :math:`M`: Concentration of mRNA
-            * :math:`k_M`: Trancription rate
-            * :math:`d_M`: Degradation rate
-
-        * Translation: :math:`\\frac{dP}{dt} = k_P m_P - d_P P`
-
-            * :math:`P`: Concentration of protein
-            * :math:`m_P`: Concentration of transcript
-            * :math:`k_P`: Translation rate
-            * :math:`d_P`: Degradation rate
-
-        The transcription rate abstracts over factors that include gene
-        copy number, RNA polymerase abundance, promoter strengths, and
-        nucleotide availability. The translation rate similarly
-        abstracts over factors that include ribosome availability, the
-        binding strength of the mRNA to the ribosome, the availability
-        of tRNAs, and the availability of free amino acids.
-
-        This process class also models genetic regulation with boolean
-        logic statements. This restricts us to modeling binary
-        regulation: reactions can be completely suppressed, but they
-        cannot be only slowed. For example, we can model a statement
-        like:
-
-            If :math:`[glucose] > 0.1`, completely inhibit LacY
-            expression.
-
-        But we cannot model a statement like this:
-
-            If :math:`[glucose] > 0.1`, reduce LacY expression by 50%.
-
-        .. note::
-            This model does **not** include:
-
-                * Kinetic regulation
-                * Cooperativity
-                * Autoinhibition
-                * Autoactivation
-
-        :term:`Ports`:
-
-        * **internal**: Expects a :term:`store` with all of the
-          transcripts and proteins being modeled. This store should also
-          include any internal regulators.
-        * **external**: Expects a store with all external regulators.
-          These variables are not updated; they are only read.
-
-        Arguments:
-            initial_parameters: A dictionary of configuration options.
-                The following configuration options may be provided:
-
-                * **transcription_rates** (:py:class:`dict`): Maps
-                  transcript names (the keys of the dict) to
-                  transcription rates (values of the dict).
-                * **translation_rates** (:py:class:`dict`): Maps protein
-                  names (the keys of the dict) to translation rates (the
-                  values of the dict).
-                * **degradation_rates** (:py:class:`dict`): Maps from
-                  names of substrates (transcripts or proteins) to
-                  degrade to their degradation rates.
-                * **protein_map** (:py:class:`dict`): Maps from protein
-                  name to transcript name for each transcript-protein
-                  pair.
-                * **initial_state** (:py:class:`dict`): Maps from
-                  :term:`port` names to the initial state of that port.
-                  Each initial state is specified as a dictionary with
-                  :term:`variable` names as keys and variable values as
-                  values.
-                * **regulators** (:py:class:`list`): List of the
-                  molecules that regulate any of the modeled
-                  transcription or translation reactions. Each molecule
-                  is a tuple of the port and the molecule's variable
-                  name.
-                * **regulation** (:py:class:`dict`): Maps from reaction
-                  product (transcript or protein) name to a boolean
-                  regulation statement. For example, to only transcribe
-                  ``lacy_RNA`` if external ``glc__D_e`` concentration is
-                  at most 0.1, we would pass:
-
-                  .. code-block:: python
-
-                    {'lacy_RNA': 'if not (external, glc__D_e) > 0.1'}
-
-        Example instantiation of a :term:`process` modeling LacY
-        expression:
-
-        >>> initial_state = {
-        ...     'internal': {
-        ...         'lacy_RNA': 0.0,
-        ...         'LacY': 0.0,
-        ...     },
-        ...     'external': {
-        ...         'glc__D_e': 2.0,
-        ...     }
-        ... }
-        >>> config = {
-        ...     'transcription_rates': {
-        ...         'lacy_RNA': 3.0,
-        ...     },
-        ...     'translation_rates': {
-        ...         'LacY': 4.0,
-        ...     },
-        ...     'degradation_rates': {
-        ...         'lacy_RNA': 1.0,
-        ...         'LacY': 0.0,
-        ...     },
-        ...     'protein_map': {
-        ...         'LacY': 'lacy_RNA',
-        ...     },
-        ...     'initial_state': initial_state,
-        ...     'regulators': [('external', 'glc__D_e')],
-        ...     'regulation': {
-        ...         'lacy_RNA': 'if not (external, glc__D_e) > 1.0',
-        ...     },
-        ... }
-        >>> expression_process = ODE_expression(config)
-        >>> state = expression_process.default_state()
-        >>> state == initial_state
-        True
-        >>> # When external glc__D_e present, no transcription
-        >>> expression_process.next_update(1, state)
-        {'internal': {'lacy_RNA': 0.0, 'LacY': 0.0}}
-        >>> # But translation and degradation still occur
-        >>> state['internal']['lacy_RNA'] = 1.0
-        >>> expression_process.next_update(1, state)
-        {'internal': {'lacy_RNA': -1.0, 'LacY': 4.0}}
-        >>> # When external glc__D_e low, LacY transcribed
-        >>> state['external']['glc__D_e'] = 0.5
-        >>> expression_process.next_update(1, state)
-        {'internal': {'lacy_RNA': 2.0, 'LacY': 4.0}}
-
-        '''
         # TODO -- kinetic regulation, cooperativity, autoinhibition, autactivation
 
         # ode gene expression

--- a/vivarium/processes/template_process.py
+++ b/vivarium/processes/template_process.py
@@ -12,7 +12,9 @@ class Template(Process):
         'parameters': {}
     }
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
 
         ports = {
             'internal': ['A'],

--- a/vivarium/processes/timeline.py
+++ b/vivarium/processes/timeline.py
@@ -9,7 +9,10 @@ from vivarium.core.process import Process
 
 class TimelineProcess(Process):
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
+
         self.timeline = copy.deepcopy(initial_parameters['timeline'])
 
         # get ports

--- a/vivarium/processes/toxin-antitoxin.py
+++ b/vivarium/processes/toxin-antitoxin.py
@@ -39,7 +39,9 @@ class ToxinAntitoxin(Process):
         }
     }
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
 
         ports = {
             'internal': list(self.defaults['initial_state'].keys()),

--- a/vivarium/processes/translation.py
+++ b/vivarium/processes/translation.py
@@ -406,9 +406,9 @@ class Translation(Process):
                 for protein in self.all_protein_keys},
 
             'concentrations': {
-                molecule: add_mass({
+                molecule: {
                     '_default': 0.0,
-                    '_updater': 'set'}, molecular_weight, molecule)
+                    '_updater': 'set'}
                 for molecule in self.protein_keys}}
 
     def derivers(self):

--- a/vivarium/processes/transport_lookup.py
+++ b/vivarium/processes/transport_lookup.py
@@ -53,7 +53,10 @@ FLUX_UNITS = COUNTS_UNITS / VOLUME_UNITS / TIME_UNITS
 
 
 class TransportLookup(Process):
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
+
         self.media_id = 'minimal' # initial_parameters.get('media_id', 'minimal')
         self.lookup_type = 'average' # initial_parameters.get('lookup', 'average')
         self.nAvogadro = constants.N_A * 1/units.mol

--- a/vivarium/processes/tree_mass.py
+++ b/vivarium/processes/tree_mass.py
@@ -29,7 +29,10 @@ class TreeMass(Deriver):
         'initial_mass': 0.0 * units.fg,
     }
 
-    def __init__(self, initial_parameters={}):
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
+
         self.from_path = self.or_default(initial_parameters, 'from_path')
         self.initial_mass = self.or_default(initial_parameters, 'initial_mass')
 


### PR DESCRIPTION
This completes the migration of the ```chemotaxis_master``` compartment to the new tree framework, and also adds a ```chemotaxis_master``` experiment. 

```compartment.generate(config)``` now does a merge of ```config``` with ```self.config```, so that you only have to pass in parameters that overwrite the defaults passed into the compartment's constructor, rather than the entire parameter set.

I also corrected a big that led to impossibly fast growth -- ```TreeMass``` deriver has an ```initial_mass``` parameter that is like dark mass, added to the total mass of the compartment.  ```Metabolism``` was passing its initial mass to ```TreeMass```, and also declaring masses of all its molecules. This led ```TreeMass``` to double count those initial masses, leading to doubling in the first time step, followed by division. Easy fix.