### PR TITLE
1D env process for simulation, rework emitter timeseries output

### DIFF
--- a/vivarium/compartments/chemotaxis_master.py
+++ b/vivarium/compartments/chemotaxis_master.py
@@ -192,7 +192,7 @@ def run_chemotaxis_master(out_dir):
         gene_exp_plot_config,
         out_dir)
 
-def test_chemotaxis_master(total_time=10):
+def test_chemotaxis_master(total_time=2):
     compartment_config = {
         'external_path': ('external',),
         'exchange_path': ('exchange',),

--- a/vivarium/compartments/chemotaxis_minimal.py
+++ b/vivarium/compartments/chemotaxis_minimal.py
@@ -5,7 +5,6 @@ import random
 
 from vivarium.core.experiment import Compartment
 from vivarium.core.composition import (
-    add_timeline_to_compartment,
     simulate_compartment_in_experiment,
     plot_simulation_output,
     COMPARTMENT_OUT_DIR
@@ -94,9 +93,6 @@ if __name__ == '__main__':
         'initial_conc': initial_conc,
         'base': 1+4e-4,
         'speed': 14}
-    timeline_config = {
-        'timeline': get_exponential_random_timeline(exponential_random_config),
-        'path': {'external': ('external',)}}
 
     # make the compartment
     config = {
@@ -105,11 +101,11 @@ if __name__ == '__main__':
         'external_path': environment_port}
     compartment = ChemotaxisMinimal(get_chemotaxis_config(config))
 
-    # add the timeline
-    compartment = add_timeline_to_compartment(compartment, timeline_config)
-
     # run experiment
     experiment_settings = {
+        'timeline': {
+            'timeline': get_exponential_random_timeline(exponential_random_config),
+            'ports': {'external': ('boundary',)}},
         'timestep': 1,
         'total_time': 100}
     timeseries = simulate_compartment_in_experiment(compartment, experiment_settings)

--- a/vivarium/compartments/lattice.py
+++ b/vivarium/compartments/lattice.py
@@ -45,22 +45,19 @@ class Lattice(Compartment):
     }
 
     def __init__(self, config):
-        self.multibody_config = config.get('multibody', self.defaults['multibody'])
-        self.diffusion_config = config.get('diffusion', self.defaults['diffusion'])
+        self.config = config
+        # self.multibody_config = config.get('multibody', self.defaults['multibody'])
+        # self.diffusion_config = config.get('diffusion', self.defaults['diffusion'])
 
-    def generate_processes(self, config={}):
-        multibody = Multibody(config.get(
-            'multibody',
-            self.multibody_config))
-        diffusion = DiffusionField(config.get(
-            'diffusion_field',
-            self.diffusion_config))
+    def generate_processes(self, config=None):
+        multibody = Multibody(config['multibody'])
+        diffusion = DiffusionField(config['diffusion'])
 
         return {
             'multibody': multibody,
             'diffusion': diffusion}
 
-    def generate_topology(self, config={}):
+    def generate_topology(self, config=None):
         return {
             'multibody': {
                 'agents': ('agents',)},

--- a/vivarium/compartments/transport_metabolism.py
+++ b/vivarium/compartments/transport_metabolism.py
@@ -5,9 +5,9 @@ import argparse
 
 import matplotlib.pyplot as plt
 
+from vivarium.library.dict_utils import get_value_from_path
 from vivarium.library.units import units
 from vivarium.core.experiment import Compartment
-from vivarium.core.emitter import get_timeseries_from_path
 from vivarium.core.composition import (
     simulate_compartment_in_experiment,
     plot_simulation_output,
@@ -223,11 +223,11 @@ def plot_diauxic_shift(timeseries, settings={}, out_dir='out'):
 
     time = [t/60 for t in timeseries['time']]  # convert to minutes
 
-    environment = get_timeseries_from_path(timeseries, external_path)
-    cell = get_timeseries_from_path(timeseries, internal_path)
-    cell_counts = get_timeseries_from_path(timeseries, internal_counts_path)
-    reactions = get_timeseries_from_path(timeseries, reactions_path)
-    globals = get_timeseries_from_path(timeseries, global_path)
+    environment = get_value_from_path(timeseries, external_path)
+    cell = get_value_from_path(timeseries, internal_path)
+    cell_counts = get_value_from_path(timeseries, internal_counts_path)
+    reactions = get_value_from_path(timeseries, reactions_path)
+    globals = get_value_from_path(timeseries, global_path)
 
     # environment
     lactose = environment['lcts_e']

--- a/vivarium/compartments/transport_metabolism.py
+++ b/vivarium/compartments/transport_metabolism.py
@@ -5,6 +5,7 @@ import argparse
 
 import matplotlib.pyplot as plt
 
+from vivarium.library.units import units
 from vivarium.core.experiment import Compartment
 from vivarium.core.composition import (
     simulate_compartment_in_experiment,
@@ -126,26 +127,29 @@ class TransportMetabolism(Compartment):
         }
 
     def generate_topology(self, config):
+        exchange_path =  self.boundary_path + ('exchange',)
+        external_path = self.boundary_path + ('external',)
+        # properties_path = self.boundary_path + ('properties',)
         return {
             'transport': {
                 'internal': ('cytoplasm',),
-                'external': self.boundary_path,
+                'external': external_path,
                 'exchange': ('null',),  # metabolism's exchange is used
                 'fluxes': ('flux_bounds',),
                 'global': self.boundary_path,
             },
             'metabolism': {
                 'internal': ('cytoplasm',),
-                'external': self.boundary_path,
+                'external': external_path,
                 'reactions': ('reactions',),
-                'exchange': ('exchange',),
+                'exchange': exchange_path,
                 'flux_bounds': ('flux_bounds',),
                 'global': self.boundary_path,
             },
             'expression': {
                 'counts': ('cytoplasm_counts',),
                 'internal': ('cytoplasm',),
-                'external': self.boundary_path,
+                'external': external_path,
                 'global': self.boundary_path,
             },
             'division': {
@@ -167,6 +171,12 @@ def test_txp_mtb_ge(total_time=10):
 
     # simulate
     settings = {
+        'environment': {
+            'volume': 1e-12 * units.L,
+            'ports': {
+                'exchange': ('boundary', 'exchange',),
+                'external': ('boundary', 'external'),
+            }},
         'timestep': 1,
         'total_time': total_time}
     return simulate_compartment_in_experiment(compartment, settings)
@@ -174,6 +184,11 @@ def test_txp_mtb_ge(total_time=10):
 def simulate_txp_mtb_ge(config={}, out_dir='out'):
     # run simulation
     timeseries = test_txp_mtb_ge(20)  # 2520 sec (42 min) is the expected doubling time in minimal media
+
+
+    import ipdb; ipdb.set_trace()
+
+
     volume_ts = timeseries['boundary']['volume']
     try:
         print('growth: {}'.format(volume_ts[-1] / volume_ts[0]))
@@ -196,12 +211,8 @@ def simulate_txp_mtb_ge(config={}, out_dir='out'):
     plot_settings = {
         'max_rows': 30,
         'remove_zeros': True,
-        'overlay': {
-            'reactions': 'flux_bounds'},
-        'skip_ports': ['null', 'exchange'],
-        'show_state': [
-            ('reactions', 'EX_glc__D_e'),
-            ('reactions', 'EX_lcts_e')]}
+        'skip_ports': ['null', 'reactions'],
+    }
     plot_simulation_output(timeseries, plot_settings, out_dir)
 
 # plots

--- a/vivarium/compartments/transport_metabolism.py
+++ b/vivarium/compartments/transport_metabolism.py
@@ -7,6 +7,7 @@ import matplotlib.pyplot as plt
 
 from vivarium.library.units import units
 from vivarium.core.experiment import Compartment
+from vivarium.core.emitter import get_timeseries_from_path
 from vivarium.core.composition import (
     simulate_compartment_in_experiment,
     plot_simulation_output,
@@ -185,10 +186,7 @@ def simulate_txp_mtb_ge(config={}, out_dir='out'):
     # run simulation
     timeseries = test_txp_mtb_ge(20)  # 2520 sec (42 min) is the expected doubling time in minimal media
 
-
-    import ipdb; ipdb.set_trace()
-
-
+    # calculate growth
     volume_ts = timeseries['boundary']['volume']
     try:
         print('growth: {}'.format(volume_ts[-1] / volume_ts[0]))
@@ -198,10 +196,10 @@ def simulate_txp_mtb_ge(config={}, out_dir='out'):
     ## plot
     # diauxic plot
     settings = {
-        'internal_port': 'cytoplasm',
-        'external_port': 'boundary',
-        'global_port': 'boundary',
-        'exchange_port': 'exchange',
+        'internal_path': ('cytoplasm',),
+        'external_path': ('boundary', 'external'),
+        'global_path': ('boundary',),
+        'exchange_path': ('boundary', 'exchange'),
         'environment_volume': 1e-13,  # L
         # 'timeline': timeline
     }
@@ -217,18 +215,19 @@ def simulate_txp_mtb_ge(config={}, out_dir='out'):
 
 # plots
 def plot_diauxic_shift(timeseries, settings={}, out_dir='out'):
-    external_port = settings.get('external_port', 'environment')
-    internal_port = settings.get('internal_port', 'cytoplasm')
-    internal_counts_port = settings.get('internal_counts_port', 'cytoplasm_counts')
-    reactions_port = settings.get('reactions_port', 'reactions')
-    global_port = settings.get('global_port', 'global')
+    external_path = settings.get('external_path', ('environment',))
+    internal_path = settings.get('internal_path', ('cytoplasm',))
+    internal_counts_path = settings.get('internal_counts_path', ('cytoplasm_counts',))
+    reactions_path = settings.get('reactions_path', ('reactions',))
+    global_path = settings.get('global_path', ('global',))
 
     time = [t/60 for t in timeseries['time']]  # convert to minutes
-    environment = timeseries[external_port]
-    cell = timeseries[internal_port]
-    cell_counts = timeseries[internal_counts_port]
-    reactions = timeseries[reactions_port]
-    globals = timeseries[global_port]
+
+    environment = get_timeseries_from_path(timeseries, external_path)
+    cell = get_timeseries_from_path(timeseries, internal_path)
+    cell_counts = get_timeseries_from_path(timeseries, internal_counts_path)
+    reactions = get_timeseries_from_path(timeseries, reactions_path)
+    globals = get_timeseries_from_path(timeseries, global_path)
 
     # environment
     lactose = environment['lcts_e']

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -28,7 +28,7 @@ from vivarium.processes.timeline import (
     TimelineCompartment,
     TimelineProcess
 )
-from vivarium.processes.homogeneous_environment import HomogeneousEnvironment
+from vivarium.processes.one_dim_environment import OneDimEnvironment
 
 REFERENCE_DATA_DIR = os.path.join('vivarium', 'reference_data')
 TEST_OUT_DIR = os.path.join('out', 'tests')
@@ -78,7 +78,7 @@ def process_in_experiment(process, settings={}):
                 port: (port,) for port in timeline_process.ports}})
 
     if environment:
-        environment_process = HomogeneousEnvironment(environment)
+        environment_process = OneDimEnvironment(environment)
         processes.update({'environment_process': environment_process})
         topology.update({
             'environment_process': {
@@ -115,7 +115,7 @@ def compartment_in_experiment(compartment, settings={}):
         environment requires ports for exchange and environment
         '''
         ports = environment['ports']
-        environment_process = HomogeneousEnvironment(environment)
+        environment_process = OneDimEnvironment(environment)
         processes.update({'environment_process': environment_process})
         topology.update({
             'environment_process': {

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -79,11 +79,16 @@ def process_in_experiment(process, settings={}):
                 port: (port,) for port in timeline_process.ports}})
 
     if environment:
+        '''
+        environment requires ports for exchange and external
+        '''
+        ports = environment['ports']
         environment_process = OneDimEnvironment(environment)
         processes.update({'environment_process': environment_process})
         topology.update({
             'environment_process': {
-                port: (port,) for port in environment_process.ports}})
+                port_id: ports[port_id]
+                for port_id in environment_process.ports}})
 
     # add derivers
     derivers = generate_derivers(processes, topology)
@@ -113,7 +118,7 @@ def compartment_in_experiment(compartment, settings={}):
 
     if environment:
         '''
-        environment requires ports for exchange and environment
+        environment requires ports for exchange and external
         '''
         ports = environment['ports']
         environment_process = OneDimEnvironment(environment)

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -82,7 +82,9 @@ def process_in_experiment(process, settings={}):
         '''
         environment requires ports for exchange and external
         '''
-        ports = environment['ports']
+        ports = environment.get(
+            'ports',
+            {'external': ('external',), 'exchange': ('exchange',)})
         environment_process = OneDimEnvironment(environment)
         processes.update({'environment_process': environment_process})
         topology.update({

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -173,6 +173,7 @@ def simulate_experiment(experiment, settings={}):
     timestep = settings.get('timestep', 1)
     total_time = settings.get('total_time', 10)
     return_raw_data = settings.get('return_raw_data', False)
+    return_old_timeseries = settings.get('return_old_timeseries', False)
 
     if 'timeline' in settings:
         total_time = settings['timeline']['timeline'][-1][0]
@@ -182,6 +183,8 @@ def simulate_experiment(experiment, settings={}):
 
     if return_raw_data:
         return experiment.emitter.get_data()
+    elif return_old_timeseries:
+        return experiment.emitter.get_timeseries_old()
     else:
         return experiment.emitter.get_timeseries()
 

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -98,6 +98,7 @@ def process_in_experiment(process, settings={}):
 def compartment_in_experiment(compartment, settings={}):
     compartment_config = settings.get('compartment', {})
     emitter = settings.get('emitter', {'type': 'timeseries'})
+    timeline = settings.get('timeline', {})
     environment = settings.get('environment', {})
     outer_path = settings.get('outer_path', tuple())
 
@@ -105,24 +106,28 @@ def compartment_in_experiment(compartment, settings={}):
     processes = network['processes']
     topology = network['topology']
 
+    if timeline:
+        ports = timeline['ports']
+        timeline_process = TimelineProcess({'timeline': timeline})
+
     if environment:
-        # TODO -- make a compartment_in_environment
+        '''
+        environment requires ports for exchange and environment
+        '''
+        ports = environment['ports']
         environment_process = HomogeneousEnvironment(environment)
+        processes.update({'environment_process': environment_process})
+        topology.update({
+            'environment_process': {
+                port_id: ports[port_id]
+                for port_id in environment_process.ports}})
 
-        update_in(
-            processes,
-            outer_path,
-            lambda existing: deep_merge(
-                existing,
-                {'environment_process': environment_process}))
+        # import ipdb;
+        # ipdb.set_trace()
 
-        update_in(
-            topology,
-            outer_path,
-            lambda existing: deep_merge(
-                existing,
-                {'environment_process': {
-                    port: (port,) for port in environment_process.ports}}))
+
+
+
 
     return Experiment({
         'processes': processes,

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -83,6 +83,23 @@ def timeseries_from_data(data):
     embedded_timeseries['time'] = times_vector
     return embedded_timeseries
 
+def timeseries_from_data_old(data):
+    time_vec = list(data.keys())
+    initial_state = data[time_vec[0]]
+    timeseries = {port: {state: []
+                         for state, initial in states.items()}
+                  for port, states in initial_state.items()}
+    timeseries['time'] = time_vec
+
+    for time, all_states in data.items():
+        for port, states in all_states.items():
+            if port not in timeseries:
+                timeseries[port] = {}
+            for state_id, state in states.items():
+                if state_id not in timeseries[port]:
+                    timeseries[port][state_id] = []  # TODO -- record appearance of new states
+                timeseries[port][state_id].append(state)
+    return timeseries
 
 class Emitter(object):
     '''
@@ -126,6 +143,9 @@ class TimeSeriesEmitter(Emitter):
 
     def get_timeseries(self):
         return timeseries_from_data(self.saved_data)
+
+    def get_timeseries_old(self):
+        return timeseries_from_data_old(self.saved_data)
 
 
 class KafkaEmitter(Emitter):

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -63,6 +63,9 @@ def configure_emitter(config, processes, topology):
 
 def path_timeseries_from_data(data):
     embedded_timeseries = timeseries_from_data(data)
+    return path_timeseries_from_embedded_timeseries(embedded_timeseries)
+
+def path_timeseries_from_embedded_timeseries(embedded_timeseries):
     times_vector = embedded_timeseries.pop('time')
     path_timeseries = make_path_dict(embedded_timeseries)
     path_timeseries['time'] = times_vector

--- a/vivarium/library/pymunk_multibody.py
+++ b/vivarium/library/pymunk_multibody.py
@@ -365,14 +365,15 @@ def test_multibody(total_time=2, debug=False):
     center_location = [0.5*loc for loc in bounds]
     agents = {
         '1': {
-            'location': center_location,
-            'angle': PI/2,
-            'volume': 15,
-            'length': 30,
-            'width': 10,
-            'mass': 1,
-            'thrust': 1e3,
-            'torque': 0.0}}
+            'boundary': {
+                'location': center_location,
+                'angle': PI/2,
+                'volume': 15,
+                'length': 30,
+                'width': 10,
+                'mass': 1,
+                'thrust': 1e3,
+                'torque': 0.0}}}
     config = {
         'jitter_force': 1e1,
         'bounds': bounds,

--- a/vivarium/plots/Mears2014_flagella_activity.py
+++ b/vivarium/plots/Mears2014_flagella_activity.py
@@ -1,0 +1,175 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib import colors
+from matplotlib.patches import Patch
+
+
+
+def plot_activity(output, out_dir='out', filename='motor_control'):
+    # receptor_activities = output['receptor_activities']
+    CheY_vec = output['internal']['CheY']
+    CheY_P_vec = output['internal']['CheY_P']
+    cw_bias_vec = output['internal']['cw_bias']
+    motile_state_vec = output['internal']['motile_state']
+    motile_force_vec = output['internal']['motile_force']
+    flagella_activity = output['flagella_activity']['flagella']
+    time_vec = output['time']
+
+    # get flagella ids by order appearance
+    flagella_ids = []
+    for state in flagella_activity:
+        flg_ids = list(state.keys())
+        for flg_id in flg_ids:
+            if flg_id not in flagella_ids:
+                flagella_ids.append(flg_id)
+
+    # make flagella activity grid
+    activity_grid = np.zeros((len(flagella_ids), len(time_vec)))
+    total_CW = np.zeros((len(time_vec)))
+    for time_index, flagella_state in enumerate(flagella_activity):
+        for flagella_id, rotation_states in flagella_state.items():
+
+            # get this flagella's index
+            flagella_index = flagella_ids.index(flagella_id)
+
+            modified_rotation_state = 0
+            CW_rotation_state = 0
+            if rotation_states == -1:
+                modified_rotation_state = 1
+            elif rotation_states == 1:
+                modified_rotation_state = 2
+                CW_rotation_state = 1
+
+            activity_grid[flagella_index, time_index] = modified_rotation_state
+            total_CW += np.array(CW_rotation_state)
+
+    # grid for cell state
+    motile_state_grid = np.zeros((1, len(time_vec)))
+    motile_state_grid[0, :] = motile_state_vec
+
+    # set up colormaps
+    # cell motile state
+    cmap1 = colors.ListedColormap(['steelblue', 'lightgray', 'darkorange'])
+    bounds1 = [-1, -1/3, 1/3, 1]
+    norm1 = colors.BoundaryNorm(bounds1, cmap1.N)
+    motile_legend_elements = [
+        Patch(facecolor='steelblue', edgecolor='k', label='Run'),
+        Patch(facecolor='darkorange', edgecolor='k', label='Tumble'),
+        Patch(facecolor='lightgray', edgecolor='k', label='N/A')]
+
+    # rotational state
+    cmap2 = colors.ListedColormap(['lightgray', 'steelblue', 'darkorange'])
+    bounds2 = [0, 0.5, 1.5, 2]
+    norm2 = colors.BoundaryNorm(bounds2, cmap2.N)
+    rotational_legend_elements = [
+        Patch(facecolor='steelblue', edgecolor='k', label='CCW'),
+        Patch(facecolor='darkorange', edgecolor='k', label='CW'),
+        Patch(facecolor='lightgray', edgecolor='k', label='N/A')]
+
+    # plot results
+    cols = 1
+    rows = 5
+    plt.figure(figsize=(4 * cols, 1.5 * rows))
+
+    # define subplots
+    ax1 = plt.subplot(rows, cols, 1)
+    ax2 = plt.subplot(rows, cols, 2)
+    ax3 = plt.subplot(rows, cols, 3)
+    ax4 = plt.subplot(rows, cols, 4)
+    ax5 = plt.subplot(rows, cols, 5)
+
+    # plot Che-P state
+    ax1.plot(time_vec, CheY_vec, label='CheY')
+    ax1.plot(time_vec, CheY_P_vec, label='CheY_P')
+    ax1.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+    ax1.set_xticks([])
+    ax1.set_xlim(time_vec[0], time_vec[-1])
+    ax1.set_ylabel('concentration \n (uM)')
+
+    # plot CW bias
+    ax2.plot(time_vec, cw_bias_vec)
+    ax2.set_xticks([])
+    ax2.set_xlim(time_vec[0], time_vec[-1])
+    ax2.set_ylabel('CW bias')
+
+    # plot flagella states in a grid
+    if len(activity_grid) > 0:
+        ax3.imshow(activity_grid,
+                   interpolation='nearest',
+                   aspect='auto',
+                   cmap=cmap2,
+                   norm=norm2,
+                   # extent=[-1,1,-1,1]
+                   extent=[time_vec[0], time_vec[-1], len(flagella_ids)+0.5, 0.5]
+                   )
+        plt.locator_params(axis='y', nbins=len(flagella_ids))
+        ax3.set_yticks(list(range(1, len(flagella_ids) + 1)))
+        ax3.set_xticks([])
+        ax3.set_ylabel('flagella #')
+
+        # legend
+        ax3.legend(
+            handles=rotational_legend_elements,
+            loc='center left',
+            bbox_to_anchor=(1, 0.5))
+    else:
+        # no flagella
+        ax3.set_axis_off()
+
+    # plot cell motile state
+    ax4.imshow(motile_state_grid,
+               interpolation='nearest',
+               aspect='auto',
+               cmap=cmap1,
+               norm=norm1,
+               extent=[time_vec[0], time_vec[-1], 0, 1])
+    ax4.set_yticks([])
+    ax4.set_xticks([])
+    ax4.set_ylabel('cell motile state')
+
+    # legend
+    ax4.legend(
+        handles=motile_legend_elements,
+        loc='center left',
+        bbox_to_anchor=(1, 0.5))
+
+    # plot motor thrust
+    ax5.plot(time_vec, motile_force_vec)
+    ax5.set_xlim(time_vec[0], time_vec[-1])
+    ax5.set_ylabel('total motor thrust (pN)')
+    ax5.set_xlabel('time (sec)')
+
+
+    # save figure
+    fig_path = os.path.join(out_dir, filename)
+    plt.subplots_adjust(wspace=0.7, hspace=0.3)
+    plt.savefig(fig_path + '.png', bbox_inches='tight')
+
+
+def plot_motor_PMF(output, out_dir='out', figname='motor_PMF'):
+    motile_state = output['motile_state']
+    motile_force = output['motile_force']
+    motile_torque = output['motile_torque']
+    PMF = output['PMF']
+
+    # plot results
+    cols = 1
+    rows = 1
+    plt.figure(figsize=(10 * cols, 2 * rows))
+
+    # define subplots
+    ax1 = plt.subplot(rows, cols, 1)
+
+    # plot motile_state
+    ax1.plot(PMF, motile_force)
+    ax1.set_xlabel('PMF (mV)')
+    ax1.set_ylabel('force')
+
+    # save figure
+    fig_path = os.path.join(out_dir, figname)
+    plt.subplots_adjust(wspace=0.7, hspace=0.3)
+    plt.savefig(fig_path + '.png', bbox_inches='tight')

--- a/vivarium/plots/metabolism.py
+++ b/vivarium/plots/metabolism.py
@@ -1,0 +1,137 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+
+import matplotlib.pyplot as plt
+
+from vivarium.library.units import units
+from vivarium.processes.derive_globals import AVOGADRO
+
+
+def plot_exchanges(timeseries, sim_config, out_dir='out', filename='exchanges'):
+    # plot exchanges with the environment
+
+    nAvogadro = AVOGADRO
+    env_volume = sim_config['environment']['volume']
+    external_ts = timeseries['external']
+    internal_ts = timeseries['internal']
+    global_ts = timeseries['global']
+
+    # pull volume and mass out from internal
+    volume = global_ts.pop('volume') * units.fL
+    mass = global_ts.pop('mass')
+
+    # conversion factor
+    mmol_to_counts = [nAvogadro.to('1/mmol') * vol.to('L') for vol in volume]
+
+    # plot results
+    cols = 1
+    rows = 3
+    plt.figure(figsize=(cols * 6, rows * 1.5))
+
+    # define subplots
+    ax1 = plt.subplot(rows, cols, 1)
+    ax2 = plt.subplot(rows, cols, 2)
+    ax3 = plt.subplot(rows, cols, 3)
+
+    # plot external state
+    for mol_id, series in external_ts.items():
+        ax1.plot(series, label=mol_id)
+    ax1.legend(loc='center left', bbox_to_anchor=(1.0, 0.5), ncol=2)
+    ax1.title.set_text('environment: {} (L)'.format(env_volume))
+    ax1.set_ylabel('concentrations (logs)')
+    ax1.set_yscale('log')
+
+    # plot internal counts
+    for mol_id, counts_series in internal_ts.items():
+        # conc_series = [(count / conversion).to('mmol/L').magnitude
+        #    for count, conversion in zip(counts_series, mmol_to_counts)]
+        ax2.plot(counts_series, label=mol_id)
+
+    # # plot internal concentrations
+    # for mol_id, counts_series in internal_ts.items():
+    #     conc_series = [(count / conversion).to('mmol/L').magnitude
+    #        for count, conversion in zip(counts_series, mmol_to_counts)]
+    #     ax2.plot(conc_series, label=mol_id)
+
+    # ax2.legend(loc='center left', bbox_to_anchor=(1.6, 0.5), ncol=3)
+    # ax2.title.set_text('internal metabolites')
+    # ax2.set_ylabel('conc (mM)')
+
+    ax2.legend(loc='center left', bbox_to_anchor=(1.6, 0.5), ncol=3)
+    ax2.title.set_text('internal metabolites')
+    ax2.set_ylabel('delta counts (log)')
+    ax2.set_yscale('log')
+
+    # plot mass
+    ax3.plot(mass, label='mass')
+    ax3.set_ylabel('mass (fg)')
+
+    # adjust axes
+    for axis in [ax1, ax2, ax3]:
+        axis.spines['right'].set_visible(False)
+        axis.spines['top'].set_visible(False)
+
+    ax1.set_xticklabels([])
+    ax2.set_xticklabels([])
+    ax3.set_xlabel('time (s)', fontsize=12)
+
+    # save figure
+    fig_path = os.path.join(out_dir, filename)
+    plt.subplots_adjust(wspace=0.3, hspace=0.5)
+    plt.savefig(fig_path, bbox_inches='tight')
+
+# energy carriers in BiGG models
+BiGG_energy_carriers = [
+    'atp_c',
+    'gtp_c',
+    'nad_c',
+    'nadp_c',
+    'fad_c',
+]
+
+def energy_synthesis_plot(timeseries, settings, out_dir, figname='energy_use'):
+    # plot the synthesis of energy carriers in BiGG model output
+
+    import ipdb; ipdb.set_trace()
+
+
+    energy_reactions = settings.get('reactions', {})
+    saved_reactions = timeseries['reactions']
+    time_vec = timeseries['time']
+
+    # get each energy carrier's total flux
+    carrier_use = {}
+    for reaction_id, coeffs in energy_reactions.items():
+        reaction_ts = saved_reactions[reaction_id]
+
+        for mol_id, coeff in coeffs.items():
+
+            # save if energy carrier is used
+            if coeff < 0:
+                added_flux = [-coeff*ts for ts in reaction_ts]
+                if mol_id not in carrier_use:
+                    carrier_use[mol_id] = added_flux
+                else:
+                    carrier_use[mol_id] = [
+                        sum(x) for x in zip(carrier_use[mol_id], added_flux)]
+
+    # make the figure
+    n_cols = 1
+    n_rows = 1
+    fig = plt.figure(figsize=(n_cols * 6, n_rows * 2))
+    grid = plt.GridSpec(n_rows, n_cols)
+
+    # first subplot
+    ax = fig.add_subplot(grid[0, 0])
+    for mol_id, series in carrier_use.items():
+        ax.plot(time_vec, series, label=mol_id)
+    ax.legend(loc='center left', bbox_to_anchor=(1.0, 0.5))
+    ax.set_title('energy use')
+    ax.set_xlabel('time ($s$)')
+    ax.set_ylabel('$(mmol*L^{{{}}}*s^{{{}}})$'.format(-1, -1))  # TODO -- use unit schema in figures
+
+    # save figure
+    fig_path = os.path.join(out_dir, figname)
+    plt.subplots_adjust(wspace=0.3, hspace=0.5)
+    plt.savefig(fig_path, bbox_inches='tight')

--- a/vivarium/processes/Endres2006_chemoreceptor.py
+++ b/vivarium/processes/Endres2006_chemoreceptor.py
@@ -251,7 +251,9 @@ def test_receptor(timeline=get_pulse_timeline(), timestep = 1):
     receptor = ReceptorCluster(process_config)
 
     # run experiment
-    experiment_settings = {'timeline': timeline}
+    experiment_settings = {
+        'timeline': {
+            'timeline': timeline}}
     return simulate_process_in_experiment(receptor, experiment_settings)
 
 

--- a/vivarium/processes/Mears2014_flagella_activity.py
+++ b/vivarium/processes/Mears2014_flagella_activity.py
@@ -8,9 +8,6 @@ import argparse
 
 import numpy as np
 from numpy import linspace
-import matplotlib.pyplot as plt
-from matplotlib import colors
-from matplotlib.patches import Patch
 
 from vivarium.library.dict_utils import deep_merge
 from vivarium.core.process import Process
@@ -18,7 +15,7 @@ from vivarium.core.composition import (
     simulate_process_in_experiment,
     PROCESS_OUT_DIR
 )
-
+from vivarium.plots.Mears2014_flagella_activity import plot_activity
 
 NAME = 'Mears2014_flagella_activity'
 
@@ -312,7 +309,9 @@ default_params = {'flagella': 5}
 default_timeline = [(10, {})]
 def test_activity(parameters=default_params, timeline=default_timeline):
     motor = FlagellaActivity(parameters)
-    settings = {'timeline': {'timeline': timeline}}
+    settings = {
+        'timeline': {'timeline': timeline},
+        'return_old_timeseries': True}
     return simulate_process_in_experiment(motor, settings)
 
 def test_motor_PMF():
@@ -348,169 +347,6 @@ def test_motor_PMF():
         'PMF': PMF_values,
     }
 
-def plot_activity(output, out_dir='out', filename='motor_control'):
-    # receptor_activities = output['receptor_activities']
-    CheY_vec = output['internal']['CheY']
-    CheY_P_vec = output['internal']['CheY_P']
-    cw_bias_vec = output['internal']['cw_bias']
-    motile_state_vec = output['internal']['motile_state']
-    motile_force_vec = output['internal']['motile_force']
-    flagella_activity = output['flagella_activity']['flagella']
-    time_vec = output['time']
-
-    # get flagella ids by order appearance
-    flagella_ids = []
-    for state in flagella_activity:
-        flg_ids = list(state.keys())
-        for flg_id in flg_ids:
-            if flg_id not in flagella_ids:
-                flagella_ids.append(flg_id)
-
-    # make flagella activity grid
-    activity_grid = np.zeros((len(flagella_ids), len(time_vec)))
-    total_CW = np.zeros((len(time_vec)))
-    for time_index, flagella_state in enumerate(flagella_activity):
-        for flagella_id, rotation_states in flagella_state.items():
-
-            # get this flagella's index
-            flagella_index = flagella_ids.index(flagella_id)
-
-            modified_rotation_state = 0
-            CW_rotation_state = 0
-            if rotation_states == -1:
-                modified_rotation_state = 1
-            elif rotation_states == 1:
-                modified_rotation_state = 2
-                CW_rotation_state = 1
-
-            activity_grid[flagella_index, time_index] = modified_rotation_state
-            total_CW += np.array(CW_rotation_state)
-
-    # grid for cell state
-    motile_state_grid = np.zeros((1, len(time_vec)))
-    motile_state_grid[0, :] = motile_state_vec
-
-    # set up colormaps
-    # cell motile state
-    cmap1 = colors.ListedColormap(['steelblue', 'lightgray', 'darkorange'])
-    bounds1 = [-1, -1/3, 1/3, 1]
-    norm1 = colors.BoundaryNorm(bounds1, cmap1.N)
-    motile_legend_elements = [
-        Patch(facecolor='steelblue', edgecolor='k', label='Run'),
-        Patch(facecolor='darkorange', edgecolor='k', label='Tumble'),
-        Patch(facecolor='lightgray', edgecolor='k', label='N/A')]
-
-    # rotational state
-    cmap2 = colors.ListedColormap(['lightgray', 'steelblue', 'darkorange'])
-    bounds2 = [0, 0.5, 1.5, 2]
-    norm2 = colors.BoundaryNorm(bounds2, cmap2.N)
-    rotational_legend_elements = [
-        Patch(facecolor='steelblue', edgecolor='k', label='CCW'),
-        Patch(facecolor='darkorange', edgecolor='k', label='CW'),
-        Patch(facecolor='lightgray', edgecolor='k', label='N/A')]
-
-    # plot results
-    cols = 1
-    rows = 5
-    plt.figure(figsize=(4 * cols, 1.5 * rows))
-
-    # define subplots
-    ax1 = plt.subplot(rows, cols, 1)
-    ax2 = plt.subplot(rows, cols, 2)
-    ax3 = plt.subplot(rows, cols, 3)
-    ax4 = plt.subplot(rows, cols, 4)
-    ax5 = plt.subplot(rows, cols, 5)
-
-    # plot Che-P state
-    ax1.plot(time_vec, CheY_vec, label='CheY')
-    ax1.plot(time_vec, CheY_P_vec, label='CheY_P')
-    ax1.legend(loc='center left', bbox_to_anchor=(1, 0.5))
-    ax1.set_xticks([])
-    ax1.set_xlim(time_vec[0], time_vec[-1])
-    ax1.set_ylabel('concentration \n (uM)')
-
-    # plot CW bias
-    ax2.plot(time_vec, cw_bias_vec)
-    ax2.set_xticks([])
-    ax2.set_xlim(time_vec[0], time_vec[-1])
-    ax2.set_ylabel('CW bias')
-
-    # plot flagella states in a grid
-    if len(activity_grid) > 0:
-        ax3.imshow(activity_grid,
-                   interpolation='nearest',
-                   aspect='auto',
-                   cmap=cmap2,
-                   norm=norm2,
-                   # extent=[-1,1,-1,1]
-                   extent=[time_vec[0], time_vec[-1], len(flagella_ids)+0.5, 0.5]
-                   )
-        plt.locator_params(axis='y', nbins=len(flagella_ids))
-        ax3.set_yticks(list(range(1, len(flagella_ids) + 1)))
-        ax3.set_xticks([])
-        ax3.set_ylabel('flagella #')
-
-        # legend
-        ax3.legend(
-            handles=rotational_legend_elements,
-            loc='center left',
-            bbox_to_anchor=(1, 0.5))
-    else:
-        # no flagella
-        ax3.set_axis_off()
-
-    # plot cell motile state
-    ax4.imshow(motile_state_grid,
-               interpolation='nearest',
-               aspect='auto',
-               cmap=cmap1,
-               norm=norm1,
-               extent=[time_vec[0], time_vec[-1], 0, 1])
-    ax4.set_yticks([])
-    ax4.set_xticks([])
-    ax4.set_ylabel('cell motile state')
-
-    # legend
-    ax4.legend(
-        handles=motile_legend_elements,
-        loc='center left',
-        bbox_to_anchor=(1, 0.5))
-
-    # plot motor thrust
-    ax5.plot(time_vec, motile_force_vec)
-    ax5.set_xlim(time_vec[0], time_vec[-1])
-    ax5.set_ylabel('total motor thrust (pN)')
-    ax5.set_xlabel('time (sec)')
-
-
-    # save figure
-    fig_path = os.path.join(out_dir, filename)
-    plt.subplots_adjust(wspace=0.7, hspace=0.3)
-    plt.savefig(fig_path + '.png', bbox_inches='tight')
-
-def plot_motor_PMF(output, out_dir='out', figname='motor_PMF'):
-    motile_state = output['motile_state']
-    motile_force = output['motile_force']
-    motile_torque = output['motile_torque']
-    PMF = output['PMF']
-
-    # plot results
-    cols = 1
-    rows = 1
-    plt.figure(figsize=(10 * cols, 2 * rows))
-
-    # define subplots
-    ax1 = plt.subplot(rows, cols, 1)
-
-    # plot motile_state
-    ax1.plot(PMF, motile_force)
-    ax1.set_xlabel('PMF (mV)')
-    ax1.set_ylabel('force')
-
-    # save figure
-    fig_path = os.path.join(out_dir, figname)
-    plt.subplots_adjust(wspace=0.7, hspace=0.3)
-    plt.savefig(fig_path + '.png', bbox_inches='tight')
 
 def run_variable_flagella(out_dir):
     # variable flagella

--- a/vivarium/processes/Mears2014_flagella_activity.py
+++ b/vivarium/processes/Mears2014_flagella_activity.py
@@ -312,7 +312,7 @@ default_params = {'flagella': 5}
 default_timeline = [(10, {})]
 def test_activity(parameters=default_params, timeline=default_timeline):
     motor = FlagellaActivity(parameters)
-    settings = {'timeline': timeline}
+    settings = {'timeline': {'timeline': timeline}}
     return simulate_process_in_experiment(motor, settings)
 
 def test_motor_PMF():

--- a/vivarium/processes/antibiotic_transport.py
+++ b/vivarium/processes/antibiotic_transport.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
+from vivarium.library.units import units
 from vivarium.core.composition import (
     simulate_process_in_experiment,
     plot_simulation_output,
@@ -132,11 +133,11 @@ def run_antibiotic_transport():
     settings = {
         'total_time': 4000,
         'environment': {
-            'volume': 1e-15,
-            'states': ['antibiotic'],
-            'environment_port': 'external',
-            'exchange_port': 'exchange'},
-    }
+            'volume': 1e-15 * units.L,
+            'ports': {
+                'external': ('external',),
+                'exchange': ('exchange',)
+            }}}
     return simulate_process_in_experiment(process, settings)
 
 

--- a/vivarium/processes/convenience_kinetics.py
+++ b/vivarium/processes/convenience_kinetics.py
@@ -473,9 +473,9 @@ def test_convenience_kinetics(end_time=2520):
     settings = {
         'environment': {
             'volume': 1e-14 * units.L,
-            'states': ['glc__D_e', 'lcts_e'],
-            'environment_port': 'external',
-            'exchange_port': 'exchange'},
+            'ports': {
+                'external': ('external',),
+                'exchange': ('exchange',)}},
         'timestep': 1,
         'total_time': end_time}
 

--- a/vivarium/processes/convenience_kinetics.py
+++ b/vivarium/processes/convenience_kinetics.py
@@ -472,7 +472,7 @@ def test_convenience_kinetics(end_time=2520):
 
     settings = {
         'environment': {
-            'volume': 1e-14,
+            'volume': 1e-14 * units.L,
             'states': ['glc__D_e', 'lcts_e'],
             'environment_port': 'external',
             'exchange_port': 'exchange'},

--- a/vivarium/processes/homogeneous_environment.py
+++ b/vivarium/processes/homogeneous_environment.py
@@ -13,55 +13,54 @@ class HomogeneousEnvironment(Deriver):
     ''' A minimal, non-spatial environment with volume'''
 
     defaults = {
-        'volume': 1e-12,
-        'states': [],
-        'environment_port': 'environment',
-        'exchange_port': 'exchange',
+        'volume': 1e-12 * units.L,
     }
 
     def __init__(self, initial_parameters=None):
         if initial_parameters is None:
             initial_parameters = {}
 
-        volume = initial_parameters.get('volume', self.defaults['volume']) * units.L
-        self.mmol_to_counts = (AVOGADRO.to('1/mmol') * volume).to('L/mmol').magnitude
-
-        environment_states = initial_parameters.get('states', self.defaults['states'])
-        self.environment_port = initial_parameters.get('environment_port', self.defaults['environment_port'])
-        self.exchange_port = initial_parameters.get('exchange_port', self.defaults['exchange_port'])
+        volume = initial_parameters.get('volume', self.defaults['volume'])
+        self.mmol_to_counts = (AVOGADRO.to('1/mmol') * volume).to('L/mmol')
 
         ports = {
-            self.environment_port: environment_states,
-            self.exchange_port: environment_states}
+            'external': [],
+            'exchange': []}
 
         parameters = initial_parameters
         super(HomogeneousEnvironment, self).__init__(ports, parameters)
 
     def ports_schema(self):
-        schema = {
-            self.exchange_port: {
-                mol_id: {
-                    '_default': 0.0}
-                for mol_id in self.ports['exchange']}}
-        return schema
+        return {
+            'external': {
+                '*': {
+                    '_default': 0.0
+                },  # glob should get all molecules names
+            },
+            'exchange': {
+                '*': {
+                    '_default': 0
+                }}}
 
     def next_update(self, timestep, states):
-        exchange = states[self.exchange_port]  # units: counts
+        exchange = states['exchange']  # units: counts
 
         ## apply exchange to environment
         # get counts, convert to concentration change
         update = {
-            self.exchange_port: {},
-            self.environment_port: {}}
+            'external': {},
+            'exchange': {}}
 
         for mol_id, delta_count in exchange.items():
             delta_concs = delta_count / self.mmol_to_counts
             if delta_concs != 0:
-                update[self.environment_port][mol_id] = delta_concs
+                update['external'][mol_id] = delta_concs
 
                 # reset exchange
-                update[self.exchange_port][mol_id] = {
+                update['exchange'][mol_id] = {
                     '_value': 0.0,
                     '_updater': 'set'}
+
+        import ipdb; ipdb.set_trace()
 
         return update

--- a/vivarium/processes/homogeneous_environment.py
+++ b/vivarium/processes/homogeneous_environment.py
@@ -24,8 +24,8 @@ class HomogeneousEnvironment(Deriver):
         self.mmol_to_counts = (AVOGADRO.to('1/mmol') * volume).to('L/mmol')
 
         ports = {
-            'external': [],
-            'exchange': []}
+            'external': ['*'],
+            'exchange': ['*']}
 
         parameters = initial_parameters
         super(HomogeneousEnvironment, self).__init__(ports, parameters)
@@ -60,7 +60,5 @@ class HomogeneousEnvironment(Deriver):
                 update['exchange'][mol_id] = {
                     '_value': 0.0,
                     '_updater': 'set'}
-
-        import ipdb; ipdb.set_trace()
 
         return update

--- a/vivarium/processes/membrane_potential.py
+++ b/vivarium/processes/membrane_potential.py
@@ -188,7 +188,7 @@ def test_mem_potential():
         (100, {('external', 'Na'): 2}),
         (500, {})]
 
-    settings = {'timeline': timeline}
+    settings = {'timeline': {'timeline': timeline}}
     return simulate_process_in_experiment(mp, settings)
 
 

--- a/vivarium/processes/metabolism.py
+++ b/vivarium/processes/metabolism.py
@@ -204,6 +204,7 @@ class Metabolism(Process):
         emit = {
             'internal': self.internal_state_ids,
             'external': self.fba.external_molecules,
+            'exchange': self.fba.external_molecules,
             'reactions': self.reaction_ids,
             'flux_bounds': self.constrained_reaction_ids,
             'global': ['mass']}

--- a/vivarium/processes/metabolism.py
+++ b/vivarium/processes/metabolism.py
@@ -40,6 +40,7 @@ from vivarium.library.units import units
 from vivarium.library.cobra_fba import CobraFBA
 from vivarium.library.dict_utils import tuplify_port_dicts
 from vivarium.library.regulation_logic import build_rule
+from vivarium.plots.metabolism import plot_exchanges, BiGG_energy_carriers, energy_synthesis_plot
 from vivarium.processes.derive_globals import AVOGADRO
 
 
@@ -419,11 +420,6 @@ def make_kinetic_rate(mol_id, vmax, km=0.0):
         return flux
     return rate
 
-def make_random_rate(mu=0, sigma=1):
-    def rate(state):
-        return np.random.normal(loc=mu, scale=sigma)
-    return rate
-
 def toy_transport():
     # process-like function for transport kinetics, used by simulate_metabolism
     transport_kinetics = {
@@ -466,153 +462,11 @@ def run_sim_save_network(config=get_toy_configuration(), out_dir='out/network'):
     nodes, edges = make_network(stoichiometry, info)
     save_network(nodes, edges, out_dir)
 
-def run_metabolism(metabolism, sim_settings):
-    environment_volume = sim_settings.get('environment_volume', 1e-12)
-    end_time = sim_settings.get('end_time', 10)
-    timestep = sim_settings.get('timestep', 1)
-    timeline = sim_settings.get('timeline')
-
-    settings = {
-        'environment': {
-            'volume': environment_volume,
-            'states': metabolism.ports['external'],
-            'environment_port': 'external',
-            'exchange_port': 'exchange'},
-        'timestep': timestep}
-    if timeline:
-        settings.update({'timeline': timeline})
-    else:
-        settings.update({'total_time': end_time})
-
+def run_metabolism(metabolism, settings=None):
+    if not settings:
+        settings = {
+            'end_time': 10}
     return simulate_process_in_experiment(metabolism, settings)
-
-# plots
-def plot_exchanges(timeseries, sim_config, out_dir='out', filename='exchanges'):
-    # plot focused on exchanges with the environment
-
-    nAvogadro = AVOGADRO
-    env_volume = sim_config['environment_volume']
-    timeline = sim_config['timeline']  # TODO -- add tickmarks for timeline events
-    external_ts = timeseries['external']
-    internal_ts = timeseries['internal']
-    global_ts = timeseries['global']
-
-    # pull volume and mass out from internal
-    volume = global_ts.pop('volume') * units.fL
-    mass = global_ts.pop('mass')
-
-    # conversion factor
-    mmol_to_counts = [nAvogadro.to('1/mmol') * vol.to('L') for vol in volume]
-
-    # plot results
-    cols = 1
-    rows = 3
-    plt.figure(figsize=(cols * 6, rows * 1.5))
-
-    # define subplots
-    ax1 = plt.subplot(rows, cols, 1)
-    ax2 = plt.subplot(rows, cols, 2)
-    ax3 = plt.subplot(rows, cols, 3)
-
-    # plot external state
-    for mol_id, series in external_ts.items():
-        ax1.plot(series, label=mol_id)
-    ax1.legend(loc='center left', bbox_to_anchor=(1.0, 0.5), ncol=2)
-    ax1.title.set_text('environment: {} (L)'.format(env_volume))
-    ax1.set_ylabel('concentrations (logs)')
-    ax1.set_yscale('log')
-
-    # plot internal counts
-    for mol_id, counts_series in internal_ts.items():
-        # conc_series = [(count / conversion).to('mmol/L').magnitude
-        #    for count, conversion in zip(counts_series, mmol_to_counts)]
-        ax2.plot(counts_series, label=mol_id)
-
-    # # plot internal concentrations
-    # for mol_id, counts_series in internal_ts.items():
-    #     conc_series = [(count / conversion).to('mmol/L').magnitude
-    #        for count, conversion in zip(counts_series, mmol_to_counts)]
-    #     ax2.plot(conc_series, label=mol_id)
-
-    # ax2.legend(loc='center left', bbox_to_anchor=(1.6, 0.5), ncol=3)
-    # ax2.title.set_text('internal metabolites')
-    # ax2.set_ylabel('conc (mM)')
-
-    ax2.legend(loc='center left', bbox_to_anchor=(1.6, 0.5), ncol=3)
-    ax2.title.set_text('internal metabolites')
-    ax2.set_ylabel('delta counts (log)')
-    ax2.set_yscale('log')
-
-    # plot mass
-    ax3.plot(mass, label='mass')
-    ax3.set_ylabel('mass (fg)')
-
-    # adjust axes
-    for axis in [ax1, ax2, ax3]:
-        axis.spines['right'].set_visible(False)
-        axis.spines['top'].set_visible(False)
-
-    ax1.set_xticklabels([])
-    ax2.set_xticklabels([])
-    ax3.set_xlabel('time (s)', fontsize=12)
-
-    # save figure
-    fig_path = os.path.join(out_dir, filename)
-    plt.subplots_adjust(wspace=0.3, hspace=0.5)
-    plt.savefig(fig_path, bbox_inches='tight')
-
-# energy carriers in BiGG models
-BiGG_energy_carriers = [
-    'atp_c',
-    'gtp_c',
-    'nad_c',
-    'nadp_c',
-    'fad_c',
-]
-
-def energy_synthesis_plot(timeseries, settings, out_dir, figname='energy_use'):
-    # plot the synthesis of energy carriers in BiGG model output
-
-    energy_reactions = settings.get('reactions', {})
-    saved_reactions = timeseries['reactions']
-    time_vec = timeseries['time']
-
-    # get each energy carrier's total flux
-    carrier_use = {}
-    for reaction_id, coeffs in energy_reactions.items():
-        reaction_ts = saved_reactions[reaction_id]
-
-        for mol_id, coeff in coeffs.items():
-
-            # save if energy carrier is used
-            if coeff < 0:
-                added_flux = [-coeff*ts for ts in reaction_ts]
-                if mol_id not in carrier_use:
-                    carrier_use[mol_id] = added_flux
-                else:
-                    carrier_use[mol_id] = [
-                        sum(x) for x in zip(carrier_use[mol_id], added_flux)]
-
-    # make the figure
-    n_cols = 1
-    n_rows = 1
-    fig = plt.figure(figsize=(n_cols * 6, n_rows * 2))
-    grid = plt.GridSpec(n_rows, n_cols)
-
-    # first subplot
-    ax = fig.add_subplot(grid[0, 0])
-    for mol_id, series in carrier_use.items():
-        ax.plot(time_vec, series, label=mol_id)
-    ax.legend(loc='center left', bbox_to_anchor=(1.0, 0.5))
-    ax.set_title('energy use')
-    ax.set_xlabel('time ($s$)')
-    ax.set_ylabel('$(mmol*L^{{{}}}*s^{{{}}})$'.format(-1, -1))  # TODO -- use unit schema in figures
-
-    # save figure
-    fig_path = os.path.join(out_dir, figname)
-    plt.subplots_adjust(wspace=0.3, hspace=0.5)
-    plt.savefig(fig_path, bbox_inches='tight')
-
 
 # tests
 def test_toy_metabolism():
@@ -649,7 +503,8 @@ def test_BiGG_metabolism(config=get_iAF1260b_config(), settings={}):
     run_metabolism(metabolism, settings)
 
 reference_sim_settings = {
-    'environment_volume': 1e-5,  # L
+    'environment': {
+        'volume': 1e-5 * units.L},
     'timestep': 1,
     'end_time': 20}
 
@@ -678,14 +533,20 @@ if __name__ == '__main__':
         metabolism = Metabolism(config)
 
         # simulation settings
-        timeline = [(2520, {})] # 2520 sec (42 min) is the expected doubling time in minimal media
         sim_settings = {
-            'environment_volume': 1e-5,  # L
-            'timestep': 1,
-            'timeline': timeline}
+            'environment': {
+                'volume': 1e-5 * units.L,
+                'ports': {
+                    'exchange': ('boundary', 'exchange',),
+                    'external': ('boundary', 'external'),
+                }},
+            # 'timestep': 1,
+            'total_time': 100,  # 2520 sec (42 min) is the expected doubling time in minimal media
+        }
 
         # run simulation
-        timeseries = run_metabolism(metabolism, sim_settings)
+        timeseries = simulate_process_in_experiment(metabolism, sim_settings)
+
         save_timeseries(timeseries, out_dir)
         volume_ts = timeseries['global']['volume']
         mass_ts = timeseries['global']['mass']
@@ -702,12 +563,12 @@ if __name__ == '__main__':
         plot_simulation_output(timeseries, plot_settings, out_dir, 'BiGG_simulation')
         plot_exchanges(timeseries, sim_settings, out_dir)
 
-        # make plot of energy reactions
-        stoichiometry = metabolism.fba.stoichiometry
-        energy_carriers = [get_synonym(mol_id) for mol_id in BiGG_energy_carriers]
-        energy_reactions = get_reactions(stoichiometry, energy_carriers)
-        energy_plot_settings = {'reactions': energy_reactions}
-        energy_synthesis_plot(timeseries, energy_plot_settings, out_dir)
+        # # make plot of energy reactions
+        # stoichiometry = metabolism.fba.stoichiometry
+        # energy_carriers = [get_synonym(mol_id) for mol_id in BiGG_energy_carriers]
+        # energy_reactions = get_reactions(stoichiometry, energy_carriers)
+        # energy_plot_settings = {'reactions': energy_reactions}
+        # energy_synthesis_plot(timeseries, energy_plot_settings, out_dir)
 
         # make a gephi network
         run_sim_save_network(get_iAF1260b_config(), out_dir)

--- a/vivarium/processes/metabolism.py
+++ b/vivarium/processes/metabolism.py
@@ -257,7 +257,7 @@ class Metabolism(Process):
         ## get the state
         external_state = states['external']
         constrained_reaction_bounds = states['flux_bounds']  # (units.mmol / units.L / units.s)
-        mmol_to_counts = states['global']['mmol_to_counts'] * units.L / units.mmol
+        mmol_to_counts = states['global']['mmol_to_counts']
 
         ## get flux constraints
         # exchange_constraints based on external availability

--- a/vivarium/processes/metabolism.py
+++ b/vivarium/processes/metabolism.py
@@ -495,7 +495,8 @@ def test_toy_metabolism():
                 'external': ('external',),
                 'exchange': ('exchange',)}},
         'timestep': 1.0,
-        'timeline': timeline}
+        'timeline': {
+            'timeline': timeline}}
     return simulate_process_in_experiment(toy_metabolism, settings)
 
 def test_BiGG_metabolism(config=get_iAF1260b_config(), settings={}):

--- a/vivarium/processes/metabolism.py
+++ b/vivarium/processes/metabolism.py
@@ -537,8 +537,8 @@ if __name__ == '__main__':
             'environment': {
                 'volume': 1e-5 * units.L,
                 'ports': {
-                    'exchange': ('boundary', 'exchange',),
-                    'external': ('boundary', 'external'),
+                    'exchange': ('exchange',),
+                    'external': ('external',),
                 }},
             # 'timestep': 1,
             'total_time': 100,  # 2520 sec (42 min) is the expected doubling time in minimal media

--- a/vivarium/processes/metabolism.py
+++ b/vivarium/processes/metabolism.py
@@ -490,7 +490,7 @@ def test_toy_metabolism():
 
     settings = {
         'environment': {
-            'volume': 1e-8,
+            'volume': 1e-8 * units.L,
             'states': toy_metabolism.ports['external'],
             'environment_port': 'external',
             'exchange_port': 'exchange'},

--- a/vivarium/processes/metabolism.py
+++ b/vivarium/processes/metabolism.py
@@ -491,9 +491,9 @@ def test_toy_metabolism():
     settings = {
         'environment': {
             'volume': 1e-8 * units.L,
-            'states': toy_metabolism.ports['external'],
-            'environment_port': 'external',
-            'exchange_port': 'exchange'},
+            'ports': {
+                'external': ('external',),
+                'exchange': ('exchange',)}},
         'timestep': 1.0,
         'timeline': timeline}
     return simulate_process_in_experiment(toy_metabolism, settings)

--- a/vivarium/processes/ode_expression.py
+++ b/vivarium/processes/ode_expression.py
@@ -380,7 +380,7 @@ def get_flagella_expression():
 
 def test_expression(config=get_lacy_config(), timeline=[(100, {})]):
     expression = ODE_expression(config)
-    settings = {'timeline': timeline}
+    settings = {'timeline': {'timeline': timeline}}
     return simulate_process_in_experiment(expression, settings)
 
 

--- a/vivarium/processes/one_dim_environment.py
+++ b/vivarium/processes/one_dim_environment.py
@@ -56,7 +56,4 @@ class OneDimEnvironment(Deriver):
                     '_value': 0.0,
                     '_updater': 'set'}
 
-
-        # import ipdb; ipdb.set_trace()
-
         return update

--- a/vivarium/processes/one_dim_environment.py
+++ b/vivarium/processes/one_dim_environment.py
@@ -49,11 +49,14 @@ class OneDimEnvironment(Deriver):
         for mol_id, delta_count in exchange.items():
             delta_concs = delta_count / self.mmol_to_counts
             if delta_concs != 0:
-                update['external'][mol_id] = delta_concs
+                update['external'][mol_id] = delta_concs.magnitude  # TODO -- remove magnitude
 
                 # reset exchange
                 update['exchange'][mol_id] = {
                     '_value': 0.0,
                     '_updater': 'set'}
+
+
+        # import ipdb; ipdb.set_trace()
 
         return update

--- a/vivarium/processes/one_dim_environment.py
+++ b/vivarium/processes/one_dim_environment.py
@@ -9,12 +9,11 @@ from vivarium.core.process import Deriver
 from vivarium.processes.derive_globals import AVOGADRO
 
 
-class HomogeneousEnvironment(Deriver):
-    ''' A minimal, non-spatial environment with volume'''
+class OneDimEnvironment(Deriver):
+    '''A non-spatial environment with volume'''
 
     defaults = {
-        'volume': 1e-12 * units.L,
-    }
+        'volume': 1e-12 * units.L}
 
     def __init__(self, initial_parameters=None):
         if initial_parameters is None:
@@ -28,24 +27,20 @@ class HomogeneousEnvironment(Deriver):
             'exchange': ['*']}
 
         parameters = initial_parameters
-        super(HomogeneousEnvironment, self).__init__(ports, parameters)
+        super(OneDimEnvironment, self).__init__(ports, parameters)
 
     def ports_schema(self):
         return {
             'external': {
                 '*': {
-                    '_default': 0.0
-                },  # glob should get all molecules names
-            },
+                    '_default': 0.0}},
             'exchange': {
                 '*': {
-                    '_default': 0
-                }}}
+                    '_default': 0}}}
 
     def next_update(self, timestep, states):
-        exchange = states['exchange']  # units: counts
+        exchange = states['exchange']
 
-        ## apply exchange to environment
         # get counts, convert to concentration change
         update = {
             'external': {},

--- a/vivarium/processes/timeline.py
+++ b/vivarium/processes/timeline.py
@@ -48,24 +48,3 @@ class TimelineProcess(Process):
                         '_updater': 'set'}
                 self.timeline.pop(0)
         return update
-
-
-class TimelineCompartment(Compartment):
-
-    def __init__(self, config):
-        self.timeline = config['timeline']
-        self.compartment = config['compartment']
-        self.topology = self.compartment.generate_topology({})
-        self.path = config['path']
-
-    def generate_processes(self, config):
-        processes = self.compartment.generate_processes({})
-        processes.update({
-            'timeline': TimelineProcess({'timeline': self.timeline})})
-        return processes
-
-    def generate_topology(self, config):
-        topology = {'timeline': self.path}
-        topology['timeline'].update({'global': ('global',)})
-        topology.update(self.topology)
-        return topology


### PR DESCRIPTION
Here is another step in the migration towards the new tree framework. Timeline and 1D_environment are now processes that can be composed with the main processes before running an experiment.  Timeline introduces pre-set perturbations through different ports throughout the simulation.  1D_environment mimics an environment of pre-set volume. These processes are configured and composed in ```composition.py```, under ```process_in_experiment``` or ```compartment_in_experiment```. 

config for a timeline. timelines are lists of tuples: [(time, {(path, to, variable): value})]. ports are where the timeline gets plugged in.
```
        'timeline': {
            'timeline': [(100, {
                ('environment', 'glc__D_e'): 3.0,
                ('environment', 'lcts_e'): 3.0,}),
            'ports': {'external': ('boundary',)}},
```

config for a 1D environment. Volume is declared with units (such as ```units.L```),  and ports for ```exchange``` and ```external``` are used to plug the processes in.
```
        'environment': {
            'volume': 1e-12 * units.L,
            'ports': {
                'exchange': ('boundary', 'exchange',),
                'external': ('boundary', 'external'),
            }}
```

Additionally, this PR sees a major rework of the timeseries emitter's method for getting timeseries from raw data.  Before tree was in place, timeseries only went one level down into port and made a timeseries of whatever value was there. Now, we need to go arbitrarily far down the tree hierarchy.  So the new timeseries returned might look something like this:
```
{
'time': [0, 1, 2, 3, 4, 5],
'internal': {
    'glc': [1, 1, 1, 1, 1, 1]},
'boundary': {
    'external': {
       'glc': [2, 2, 2, 2, 2, 2]}},
}
```