### PR TITLE
Static Field

### DIFF
--- a/vivarium/compartments/lattice.py
+++ b/vivarium/compartments/lattice.py
@@ -11,7 +11,7 @@ from vivarium.core.composition import (
 # processes
 from vivarium.processes.multibody_physics import (
     Multibody,
-    random_body_config,
+    agent_body_config,
 )
 from vivarium.plots.multibody_physics import plot_snapshots
 from vivarium.processes.diffusion_field import (
@@ -80,7 +80,7 @@ def get_lattice_config(config={}):
     body_config = {
         'bounds': bounds,
         'agent_ids': agent_ids}
-    mbp_config.update(random_body_config(body_config))
+    mbp_config.update(agent_body_config(body_config))
 
     # diffusion config
     dff_config = get_gaussian_config({

--- a/vivarium/compartments/static_lattice.py
+++ b/vivarium/compartments/static_lattice.py
@@ -11,7 +11,7 @@ from vivarium.core.composition import (
 # processes
 from vivarium.processes.multibody_physics import (
     Multibody,
-    random_body_config,
+    agent_body_config,
 )
 from vivarium.plots.multibody_physics import plot_snapshots
 from vivarium.processes.static_field import StaticField
@@ -70,7 +70,7 @@ def get_static_lattice_config(config={}):
     body_config = {
         'bounds': bounds,
         'agent_ids': agent_ids}
-    mbp_config.update(random_body_config(body_config))
+    mbp_config.update(agent_body_config(body_config))
 
     # field config
     field_config = {

--- a/vivarium/compartments/static_lattice.py
+++ b/vivarium/compartments/static_lattice.py
@@ -26,7 +26,7 @@ class StaticLattice(Compartment):
             'bounds': [10, 10],
             'agents': {}
         },
-        'diffusion': {
+        'field': {
             'molecules': ['glc'],
             'n_bins': [10, 10],
             'bounds': [10, 10],

--- a/vivarium/compartments/static_lattice.py
+++ b/vivarium/compartments/static_lattice.py
@@ -1,0 +1,138 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+
+from vivarium.core.experiment import Compartment
+from vivarium.core.composition import (
+    compartment_in_experiment,
+    COMPARTMENT_OUT_DIR,
+)
+
+# processes
+from vivarium.processes.multibody_physics import (
+    Multibody,
+    random_body_config,
+)
+from vivarium.plots.multibody_physics import plot_snapshots
+from vivarium.processes.static_field import StaticField
+
+NAME = 'static_lattice'
+
+
+class StaticLattice(Compartment):
+
+    defaults = {
+        'multibody': {
+            'bounds': [10, 10],
+            'agents': {}
+        },
+        'diffusion': {
+            'molecules': ['glc'],
+            'n_bins': [10, 10],
+            'bounds': [10, 10],
+        }
+    }
+
+    def __init__(self, config):
+        self.config = config
+
+    def generate_processes(self, config=None):
+        multibody = Multibody(config['multibody'])
+        field = StaticField(config['field'])
+
+        return {
+            'multibody': multibody,
+            'field': field}
+
+    def generate_topology(self, config=None):
+        return {
+            'multibody': {
+                'agents': ('agents',)},
+            'field': {
+                'agents': ('agents',),
+                'fields': ('fields',)}}
+
+
+def get_static_lattice_config(config={}):
+    bounds = config.get('bounds', [25, 25])
+    molecules = config.get('molecules', ['glc'])
+    n_bins = config.get('n_bins', tuple(bounds))
+    center = config.get('center', [0.5, 0.5])
+    deviation = config.get('deviation', 5)
+    n_agents = config.get('n_agents', 1)
+    agent_ids = [str(agent_id) for agent_id in range(n_agents)]
+
+    # multibody config
+    mbp_config = {
+        # 'animate': True,
+        'jitter_force': 1e2,
+        'bounds': bounds}
+    body_config = {
+        'bounds': bounds,
+        'agent_ids': agent_ids}
+    mbp_config.update(random_body_config(body_config))
+
+    # field config
+    field_config = {
+        'molecules': molecules,
+        'n_bins': n_bins,
+        'bounds': bounds,
+        # 'agents': agents,
+        'gradient': {
+            'type': 'exponential',
+            'molecules': {
+                mol_id: {
+                    'center': [0.0, 0.0],
+                    'base': 1 + 1e-1}
+                for mol_id in molecules}},
+        # 'initial_state': {
+        #     mol_id: np.ones((n_bins[0], n_bins[1]))
+        #     for mol_id in molecules}
+    }
+
+    return {
+        'bounds': bounds,
+        'multibody': mbp_config,
+        'field': field_config}
+
+def test_static_lattice(config=get_static_lattice_config(), end_time=10):
+
+    # configure the compartment
+    compartment = StaticLattice(config)
+
+    # configure experiment
+    experiment_settings = {
+        'compartment': config}
+    experiment = compartment_in_experiment(
+        compartment,
+        experiment_settings)
+
+    # run experiment
+    timestep = 1
+    time = 0
+    while time < end_time:
+        experiment.update(timestep)
+        time += timestep
+    return experiment.emitter.get_data()
+
+
+
+if __name__ == '__main__':
+    out_dir = os.path.join(COMPARTMENT_OUT_DIR, NAME)
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    config = get_static_lattice_config()
+    data = test_static_lattice(config, 40)
+
+    # make snapshot plot
+    agents = {time: time_data['agents'] for time, time_data in data.items()}
+    fields = {time: time_data['fields'] for time, time_data in data.items()}
+    data = {
+        'agents': agents,
+        'fields': fields,
+        'config': config}
+    plot_config = {
+        'out_dir': out_dir,
+        'filename': 'snapshots'}
+    plot_snapshots(data, plot_config)

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -111,9 +111,18 @@ class Emitter(object):
     def emit(self, data):
         print(data)
 
+    def get_data(self):
+        return []
+
+    def get_path_timeseries(self):
+        return path_timeseries_from_data(self.get_data())
+
     def get_timeseries(self):
-        raise Exception('emitter does not get timeseries')
-        return {}
+        return timeseries_from_data(self.get_data())
+
+    def get_timeseries_old(self):
+        return timeseries_from_data_old(self.get_data())
+
 
 class NullEmitter(Emitter):
     '''
@@ -121,6 +130,7 @@ class NullEmitter(Emitter):
     '''
     def emit(self, data):
         pass
+
 
 class TimeSeriesEmitter(Emitter):
 
@@ -137,15 +147,6 @@ class TimeSeriesEmitter(Emitter):
 
     def get_data(self):
         return self.saved_data
-
-    def get_path_timeseries(self):
-        return path_timeseries_from_data(self.saved_data)
-
-    def get_timeseries(self):
-        return timeseries_from_data(self.saved_data)
-
-    def get_timeseries_old(self):
-        return timeseries_from_data_old(self.saved_data)
 
 
 class KafkaEmitter(Emitter):
@@ -207,3 +208,12 @@ class DatabaseEmitter(Emitter):
 
         table = getattr(self.db, data_config['table'])
         table.insert_one(data)
+
+    def get_data(self):
+        query = {'experiment_id': self.experiment_id}
+        data = self.client.find(query)
+
+        # TODO -- pull it out of data
+        import ipdb; ipdb.set_trace()
+
+        return data

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -720,7 +720,8 @@ class Compartment(object):
             'topology': assoc_in({}, path, topology)}
 
     def get_parameters(self):
-        processes = self.generate_processes({})
+        network = self.generate({})
+        processes = network['processes']
         return {
             process_id: process.parameters
             for process_id, process in processes.items()}

--- a/vivarium/experiments/chemotaxis_master.py
+++ b/vivarium/experiments/chemotaxis_master.py
@@ -102,7 +102,8 @@ def get_chemotaxis_experiment_config():
             'molecules': {
                 ligand_id: {
                     'center': [0.0, 0.0],
-                    'base': 1+1e-1}}},
+                    'base': 1+1e-1,
+                    'scale': 0.1}}},
         'diffusion': 1e-1,
         'n_bins': n_bins,
         'size': bounds}

--- a/vivarium/experiments/chemotaxis_master.py
+++ b/vivarium/experiments/chemotaxis_master.py
@@ -23,7 +23,7 @@ from vivarium.compartments.chemotaxis_master import ChemotaxisMaster
 
 # processes
 from vivarium.processes.multibody_physics import (
-    random_body_config,
+    agent_body_config,
 )
 from vivarium.plots.multibody_physics import plot_snapshots, plot_trajectory, plot_motility
 
@@ -92,7 +92,7 @@ def get_chemotaxis_experiment_config():
     body_config = {
         'bounds': bounds,
         'agent_ids': agent_ids}
-    multibody_config.update(random_body_config(body_config))
+    multibody_config.update(agent_body_config(body_config))
 
     # diffusion
     diffusion_config = {

--- a/vivarium/experiments/chemotaxis_minimal.py
+++ b/vivarium/experiments/chemotaxis_minimal.py
@@ -25,7 +25,7 @@ from vivarium.compartments.chemotaxis_minimal import (
 from vivarium.processes.multibody_physics import (
     agent_body_config,
 )
-from vivarium.plots.multibody_physics import plot_snapshots, plot_trajectory, plot_motility
+from vivarium.plots.multibody_physics import plot_trajectory, plot_motility
 
 
 def make_chemotaxis_experiment(config={}):
@@ -56,14 +56,10 @@ def make_chemotaxis_experiment(config={}):
 
 # configurations
 def get_chemotaxis_experiment_config():
-
     ligand_id = 'glc'
-    initial_ligand = 1+1e-1
-    n_agents = 1
-    bins_microns = 2
+    initial_ligand = 1e-1
     bounds = [100, 500]
-    n_bins = [bound * bins_microns for bound in bounds]
-
+    n_agents = 1
     agent_ids = [str(agent_id) for agent_id in range(n_agents)]
 
     ## minimal chemotaxis agent
@@ -94,8 +90,8 @@ def get_chemotaxis_experiment_config():
             'molecules': {
                 ligand_id: {
                     'center': [0.5, 0.0],
-                    'base': initial_ligand}}},
-        'n_bins': n_bins,
+                    'scale': initial_ligand,
+                    'base': 0.1}}},
         'size': bounds}
 
     return {
@@ -105,36 +101,21 @@ def get_chemotaxis_experiment_config():
             'multibody': multibody_config,
             'field': field_config}}
 
-def run_chemotaxis_experiment(time=5, out_dir='out'):
+def run_chemotaxis_experiment(out_dir='out'):
     chemotaxis_config = get_chemotaxis_experiment_config()
     experiment = make_chemotaxis_experiment(chemotaxis_config)
 
     # simulate
     settings = {
+        'total_time': 30,
         'timestep': 0.01,
-        'total_time': time,
         'return_raw_data': True}
     raw_data = simulate_experiment(experiment, settings)
-
-    # extract data
-    multibody_config = chemotaxis_config['environment']['multibody']
-    agents = {time: time_data['agents'] for time, time_data in raw_data.items()}
-    fields = {time: time_data['fields'] for time, time_data in raw_data.items()}
 
     # agents plot
     plot_settings = {
         'agents_key': 'agents'}
     plot_agents_multigen(raw_data, plot_settings, out_dir)
-
-    # snapshot plot
-    snapshots_data = {
-        'agents': agents,
-        'fields': fields,
-        'config': multibody_config}
-    plot_config = {
-        'out_dir': out_dir,
-        'filename': 'snapshots'}
-    plot_snapshots(snapshots_data, plot_config)
 
     # trajectory and motility plots
     agents_timeseries = timeseries_from_data(raw_data)
@@ -149,4 +130,4 @@ if __name__ == '__main__':
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    run_chemotaxis_experiment(5, out_dir)
+    run_chemotaxis_experiment(out_dir)

--- a/vivarium/experiments/chemotaxis_minimal.py
+++ b/vivarium/experiments/chemotaxis_minimal.py
@@ -26,6 +26,7 @@ from vivarium.processes.multibody_physics import (
     agent_body_config,
 )
 from vivarium.plots.multibody_physics import plot_trajectory, plot_motility
+from vivarium.processes.static_field import make_field
 
 
 def make_chemotaxis_experiment(config={}):
@@ -79,7 +80,7 @@ def get_chemotaxis_experiment_config():
     body_config = {
         'bounds': bounds,
         'agent_ids': agent_ids,
-        'location': [0.5, 0.0]}
+        'location': [0.5, 0.1]}
     multibody_config.update(agent_body_config(body_config))
 
     # field
@@ -92,7 +93,7 @@ def get_chemotaxis_experiment_config():
                     'center': [0.5, 0.0],
                     'scale': initial_ligand,
                     'base': 0.1}}},
-        'size': bounds}
+        'bounds': bounds}
 
     return {
         'agent_ids': agent_ids,
@@ -118,8 +119,13 @@ def run_chemotaxis_experiment(out_dir='out'):
     plot_agents_multigen(raw_data, plot_settings, out_dir)
 
     # trajectory and motility plots
+    # get a sample field
+    field_config = chemotaxis_config['environment']['field']
+    field = make_field(field_config)
     agents_timeseries = timeseries_from_data(raw_data)
-    trajectory_config = {'bounds': chemotaxis_config['environment']['multibody']['bounds']}
+    trajectory_config = {
+        'bounds': chemotaxis_config['environment']['multibody']['bounds'],
+        'field': field}
 
     plot_motility(agents_timeseries, out_dir)
     plot_trajectory(agents_timeseries, trajectory_config, out_dir)

--- a/vivarium/experiments/chemotaxis_minimal.py
+++ b/vivarium/experiments/chemotaxis_minimal.py
@@ -33,7 +33,7 @@ def make_chemotaxis_experiment(config={}):
     agent_ids = config.get('agent_ids', [])
     emitter = config.get('emitter', {'type': 'timeseries'})
 
-    # get the environment
+    # initialize the environment
     env_config = config.get('environment', {})
     environment = StaticLattice(env_config)
     network = environment.generate({})

--- a/vivarium/experiments/chemotaxis_minimal.py
+++ b/vivarium/experiments/chemotaxis_minimal.py
@@ -15,10 +15,7 @@ from vivarium.core.composition import (
 )
 
 # compartments
-from vivarium.compartments.lattice import (
-    Lattice,
-    get_lattice_config
-)
+from vivarium.compartments.static_lattice import StaticLattice
 from vivarium.compartments.chemotaxis_minimal import (
     ChemotaxisMinimal,
     get_chemotaxis_config
@@ -38,7 +35,7 @@ def make_chemotaxis_experiment(config={}):
 
     # get the environment
     env_config = config.get('environment', {})
-    environment = Lattice(env_config)
+    environment = StaticLattice(env_config)
     network = environment.generate({})
     processes = network['processes']
     topology = network['topology']
@@ -87,8 +84,8 @@ def get_chemotaxis_experiment_config():
         'agent_ids': agent_ids}
     multibody_config.update(random_body_config(body_config))
 
-    # diffusion
-    diffusion_config = {
+    # field
+    field_config = {
         'molecules': [ligand_id],
         'gradient': {
             'type': 'exponential',
@@ -96,7 +93,6 @@ def get_chemotaxis_experiment_config():
                 ligand_id: {
                     'center': [0.0, 0.0],
                     'base': 1+1e-1}}},
-        'diffusion': 1e-1,
         'n_bins': n_bins,
         'size': bounds}
 
@@ -105,7 +101,7 @@ def get_chemotaxis_experiment_config():
         'chemotaxis': chemotaxis_config,
         'environment': {
             'multibody': multibody_config,
-            'diffusion': diffusion_config}}
+            'field': field_config}}
 
 def run_chemotaxis_experiment(time=5, out_dir='out'):
     chemotaxis_config = get_chemotaxis_experiment_config()

--- a/vivarium/experiments/chemotaxis_minimal.py
+++ b/vivarium/experiments/chemotaxis_minimal.py
@@ -23,7 +23,7 @@ from vivarium.compartments.chemotaxis_minimal import (
 
 # processes
 from vivarium.processes.multibody_physics import (
-    random_body_config,
+    agent_body_config,
 )
 from vivarium.plots.multibody_physics import plot_snapshots, plot_trajectory, plot_motility
 
@@ -59,7 +59,7 @@ def get_chemotaxis_experiment_config():
 
     ligand_id = 'glc'
     initial_ligand = 0.1
-    n_agents = 1
+    n_agents = 4
     bins_microns = 2
     bounds = [100, 500]
     n_bins = [bound * bins_microns for bound in bounds]
@@ -82,8 +82,9 @@ def get_chemotaxis_experiment_config():
 
     body_config = {
         'bounds': bounds,
-        'agent_ids': agent_ids}
-    multibody_config.update(random_body_config(body_config))
+        'agent_ids': agent_ids,
+        'location': [0.5, 0.05]}
+    multibody_config.update(agent_body_config(body_config))
 
     # field
     field_config = {

--- a/vivarium/experiments/chemotaxis_minimal.py
+++ b/vivarium/experiments/chemotaxis_minimal.py
@@ -59,9 +59,10 @@ def get_chemotaxis_experiment_config():
 
     ligand_id = 'glc'
     initial_ligand = 0.1
-    n_agents = 3
-    bounds = [50, 50]
-    n_bins = [50, 50]
+    n_agents = 1
+    bins_microns = 2
+    bounds = [100, 500]
+    n_bins = [bound * bins_microns for bound in bounds]
 
     agent_ids = [str(agent_id) for agent_id in range(n_agents)]
 
@@ -91,7 +92,7 @@ def get_chemotaxis_experiment_config():
             'type': 'exponential',
             'molecules': {
                 ligand_id: {
-                    'center': [0.0, 0.0],
+                    'center': [0.5, 0.0],
                     'base': 1+1e-1}}},
         'n_bins': n_bins,
         'size': bounds}
@@ -109,7 +110,7 @@ def run_chemotaxis_experiment(time=5, out_dir='out'):
 
     # simulate
     settings = {
-        'timestep': 0.1,
+        'timestep': 0.01,
         'total_time': time,
         'return_raw_data': True}
     raw_data = simulate_experiment(experiment, settings)

--- a/vivarium/experiments/chemotaxis_minimal.py
+++ b/vivarium/experiments/chemotaxis_minimal.py
@@ -58,8 +58,8 @@ def make_chemotaxis_experiment(config={}):
 def get_chemotaxis_experiment_config():
 
     ligand_id = 'glc'
-    initial_ligand = 0.1
-    n_agents = 4
+    initial_ligand = 1+1e-1
+    n_agents = 1
     bins_microns = 2
     bounds = [100, 500]
     n_bins = [bound * bins_microns for bound in bounds]
@@ -83,7 +83,7 @@ def get_chemotaxis_experiment_config():
     body_config = {
         'bounds': bounds,
         'agent_ids': agent_ids,
-        'location': [0.5, 0.05]}
+        'location': [0.5, 0.0]}
     multibody_config.update(agent_body_config(body_config))
 
     # field
@@ -94,7 +94,7 @@ def get_chemotaxis_experiment_config():
             'molecules': {
                 ligand_id: {
                     'center': [0.5, 0.0],
-                    'base': 1+1e-1}}},
+                    'base': initial_ligand}}},
         'n_bins': n_bins,
         'size': bounds}
 

--- a/vivarium/library/pymunk_multibody.py
+++ b/vivarium/library/pymunk_multibody.py
@@ -81,7 +81,7 @@ class MultiBody(object):
         'angular_damping': 0.7,  # less damping for angular velocity seems to improve behavior
         'friction': 0.9,  # TODO -- does this do anything?
         'physics_dt': 0.005,
-        'force_scaling': 100,  # scales from pN
+        'force_scaling': 20,  # scales from pN
 
         # configured parameters
         'jitter_force': 1e-3,  # pN

--- a/vivarium/plots/multibody_physics.py
+++ b/vivarium/plots/multibody_physics.py
@@ -75,7 +75,7 @@ def plot_agents(ax, agents, agent_colors={}):
 def plot_snapshots(data, plot_config):
     '''
         - agents (dict): with {time: agent_data}
-        - fields TODO
+        - fields (dict): with {time: field_data}
         - config (dict): the environment config for the simulation
     '''
     check_plt_backend()

--- a/vivarium/plots/multibody_physics.py
+++ b/vivarium/plots/multibody_physics.py
@@ -170,8 +170,9 @@ def plot_snapshots(data, plot_config):
         else:
             row_idx = 0
             ax = init_axes(fig, bounds[0], bounds[1], grid, row_idx, col_idx, time)
-            agents_now = agents[time]
-            plot_agents(ax, agents_now, agent_colors)
+            if agents:
+                agents_now = agents[time]
+                plot_agents(ax, agents_now, agent_colors)
 
     fig_path = os.path.join(out_dir, filename)
     plt.subplots_adjust(wspace=0.7, hspace=0.1)

--- a/vivarium/plots/multibody_physics.py
+++ b/vivarium/plots/multibody_physics.py
@@ -184,6 +184,7 @@ def plot_trajectory(agent_timeseries, config, out_dir='out', filename='trajector
     check_plt_backend()
 
     bounds = config.get('bounds', DEFAULT_BOUNDS)
+    field = config.get('field')
     x_length = bounds[0]
     y_length = bounds[1]
     y_ratio = y_length / x_length
@@ -205,6 +206,17 @@ def plot_trajectory(agent_timeseries, config, out_dir='out', filename='trajector
     # make the figure
     fig = plt.figure(figsize=(8, 8*y_ratio))
 
+    if field is not None:
+        field = np.transpose(field)
+        shape = field.shape
+        im = plt.imshow(field,
+                        origin='lower',
+                        extent=[0, shape[1], 0, shape[0]],
+                        # vmin=vmin,
+                        # vmax=vmax,
+                        cmap='Greys'
+                        )
+
     for agent_id, agent_trajectory in trajectories.items():
         # convert trajectory to 2D array
         locations_array = np.array(agent_trajectory)
@@ -216,7 +228,7 @@ def plot_trajectory(agent_timeseries, config, out_dir='out', filename='trajector
         segments = np.concatenate([points[:-1], points[1:]], axis=1)
         lc = LineCollection(segments, cmap=plt.get_cmap('cool'))
         lc.set_array(times)
-        lc.set_linewidth(3)
+        lc.set_linewidth(6)
 
         # plot line
         line = plt.gca().add_collection(lc)

--- a/vivarium/processes/diffusion_field.py
+++ b/vivarium/processes/diffusion_field.py
@@ -247,6 +247,7 @@ class DiffusionField(Process):
                     'external': local_concentration_schema}}}
         schema['agents'].update(glob_schema)
 
+        # fields
         fields_schema = {
              'fields': {
                  field: {
@@ -254,12 +255,22 @@ class DiffusionField(Process):
                      '_updater': 'accumulate',
                      '_emit': True}
                  for field in self.molecule_ids}}
+        glob_fields_schema = {
+                 '*': {
+                     '_default': self.empty_field,
+                     '_updater': 'accumulate',
+                     '_emit': True}}
+        fields_schema['fields'].update(glob_fields_schema)
         schema.update(fields_schema)
         return schema
 
     def next_update(self, timestep, states):
         fields = states['fields'].copy()
         agents = states['agents']
+
+        # import ipdb; ipdb.set_trace()
+        # TODO -- any unexpected fields?
+        # agents['*']['boundary']['external']
 
         # uptake/secretion from agents
         delta_exchanges = self.apply_exchanges(agents)

--- a/vivarium/processes/diffusion_field.py
+++ b/vivarium/processes/diffusion_field.py
@@ -268,9 +268,14 @@ class DiffusionField(Process):
         fields = states['fields'].copy()
         agents = states['agents']
 
-        # import ipdb; ipdb.set_trace()
-        # TODO -- any unexpected fields?
-        # agents['*']['boundary']['external']
+        # check for unexpected fields
+        new_fields = {}
+        for agent_id, specs in agents.items():
+            external = specs['boundary']['external']
+            for mol_id, concentration in external.items():
+                if mol_id not in self.molecule_ids and concentration is not None:
+                    self.molecule_ids.append(mol_id)
+                    new_fields[mol_id] = concentration * self.ones_field()
 
         # uptake/secretion from agents
         delta_exchanges = self.apply_exchanges(agents)
@@ -438,13 +443,13 @@ def test_diffusion_field(config=get_gaussian_config(), time=10):
 
 def plot_fields(data, config, out_dir='out', filename='fields'):
     fields = {time: time_data['fields'] for time, time_data in data.items()}
-    data = {
+    snapshots_data = {
         'fields': fields,
         'config': config}
     plot_config = {
         'out_dir': out_dir,
         'filename': filename}
-    plot_snapshots(data, plot_config)
+    plot_snapshots(snapshots_data, plot_config)
 
 
 if __name__ == '__main__':

--- a/vivarium/processes/metabolism.py
+++ b/vivarium/processes/metabolism.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import argparse
+import logging as log
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -164,7 +165,7 @@ class Metabolism(Process):
         internal_state = {mol_id: int(coeff * scaling_factor)
             for mol_id, coeff in composition.items()}
         self.initial_mass = get_fg_from_counts(internal_state, mw)
-        print('metabolism initial mass: {}'.format(self.initial_mass))
+        log.info('metabolism initial mass: {}'.format(self.initial_mass))
 
         ## Get external state from minimal_external fba solution
         external_state = {state_id: 0.0 for state_id in self.fba.external_molecules}

--- a/vivarium/processes/static_field.py
+++ b/vivarium/processes/static_field.py
@@ -1,0 +1,217 @@
+from __future__ import absolute_import, division, print_function
+
+import sys
+import os
+import argparse
+
+import numpy as np
+from scipy import constants
+from scipy.ndimage import convolve
+import matplotlib.pyplot as plt
+
+from vivarium.core.process import Process
+from vivarium.core.composition import (
+    simulate_process,
+    PROCESS_OUT_DIR
+)
+
+from vivarium.plots.multibody_physics import plot_snapshots
+from vivarium.processes.diffusion_field import make_gradient, plot_fields
+
+
+NAME = 'static_field'
+
+
+class StaticField(Process):
+
+    defaults = {
+        'molecules': ['glc'],
+        'initial_state': {},
+        'n_bins': [10, 10],
+        'bounds': [10, 10],
+        'gradient': {},
+        'agents': {},
+        'boundary_port': 'boundary',
+        'external_port': 'external',
+    }
+
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
+
+        # initial state
+        self.molecule_ids = initial_parameters.get('molecules', self.defaults['molecules'])
+        self.initial_state = initial_parameters.get('initial_state', self.defaults['initial_state'])
+
+        # parameters
+        self.n_bins = initial_parameters.get('n_bins', self.defaults['n_bins'])
+        self.bounds = initial_parameters.get('bounds', self.defaults['bounds'])
+        self.boundary_port = initial_parameters.get('boundary_port', self.defaults['boundary_port'])
+        self.external_port = initial_parameters.get('external_port', self.defaults['external_port'])
+
+        # initialize gradient fields
+        gradient = initial_parameters.get('gradient', self.defaults['gradient'])
+        if gradient:
+            gradient_fields = make_gradient(gradient, self.n_bins, self.bounds)
+            self.initial_state.update(gradient_fields)
+
+        # agents
+        self.initial_agents = initial_parameters.get('agents', self.defaults['agents'])
+
+        # make ports
+        ports = {
+             'fields': self.molecule_ids,
+             'agents': ['*']}
+
+        parameters = {}
+        parameters.update(initial_parameters)
+
+        super(StaticField, self).__init__(ports, parameters)
+
+    def ports_schema(self):
+        local_concentration_schema = {
+            molecule: {
+                '_default': 0.0,
+                '_updater': 'set'}
+            for molecule in self.molecule_ids}
+
+        schema = {'agents': {}}
+        for agent_id, states in self.initial_agents.items():
+            location = states[self.boundary_port].get('location', [])
+            exchange = states[self.boundary_port].get('exchange', {})
+            schema['agents'][agent_id] = {
+                self.boundary_port: {
+                    'location': {
+                        '_value': location},
+                    'exchange': {
+                        mol_id: {
+                            '_value': value}
+                        for mol_id, value in exchange.items()}}}
+            # schema['agents'][agent_id][self.boundary_port].update(local_concentration_schema)
+
+        glob_schema = {
+            '*': {
+                self.boundary_port: {
+                    'location': {
+                        '_default': [0.5, 0.5],
+                        '_updater': 'set'},
+                    'exchange': local_concentration_schema,
+                    'external': local_concentration_schema}}}
+        schema['agents'].update(glob_schema)
+
+        # fields
+        fields_schema = {
+             'fields': {
+                 field: {
+                     '_value': self.initial_state.get(field, self.ones_field()),
+                     '_updater': 'accumulate',
+                     '_emit': True}
+                 for field in self.molecule_ids}}
+        glob_fields_schema = {
+                 '*': {
+                     '_default': self.empty_field,
+                     '_updater': 'accumulate',
+                     '_emit': True}}
+        fields_schema['fields'].update(glob_fields_schema)
+        schema.update(fields_schema)
+        return schema
+
+    def next_update(self, timestep, states):
+        fields = states['fields'].copy()
+        agents = states['agents']
+
+        # check for unexpected fields
+        new_fields = {}
+        for agent_id, specs in agents.items():
+            external = specs['boundary']['external']
+            for mol_id, concentration in external.items():
+                if mol_id not in self.molecule_ids and concentration is not None:
+                    self.molecule_ids.append(mol_id)
+                    new_fields[mol_id] = concentration * self.ones_field()
+
+        # get each agent's local environment
+        local_environments = self.get_local_environments(agents, fields)
+
+        return {'agents': local_environments}
+
+
+    def get_bin_site(self, location):
+        bin = np.array([
+            location[0] * self.n_bins[0] / self.bounds[0],
+            location[1] * self.n_bins[1] / self.bounds[1]])
+        bin_site = tuple(np.floor(bin).astype(int) % self.n_bins)
+        return bin_site
+
+    def get_single_local_environments(self, specs, fields):
+        bin_site = self.get_bin_site(specs['location'])
+        local_environment = {}
+        for mol_id, field in fields.items():
+            local_environment[mol_id] = field[bin_site]
+        return local_environment
+
+    def get_local_environments(self, agents, fields):
+        local_environments = {}
+        if agents:
+            for agent_id, specs in agents.items():
+                local_environments[agent_id] = {self.boundary_port: {}}
+                local_environments[agent_id][self.boundary_port][self.external_port] = \
+                    self.get_single_local_environments(specs[self.boundary_port], fields)
+        return local_environments
+
+    def empty_field(self):
+        return np.zeros((self.n_bins[0], self.n_bins[1]), dtype=np.float64)
+
+    def ones_field(self):
+        return np.ones((self.n_bins[0], self.n_bins[1]), dtype=np.float64)
+
+
+
+def get_config(config={}):
+
+    molecules = ['glc']
+    bounds = (20, 20)
+    n_bins = (10, 10)
+    n_agents = 3
+
+    agents = {}
+    for agent in range(n_agents):
+        agent_id = str(agent)
+        agents[agent_id] = {
+            'boundary': {
+                'location': [
+                        np.random.uniform(0, bounds[0]),
+                        np.random.uniform(0, bounds[1])],
+                'external': {
+                    mol_id: 0 for mol_id in molecules}}}
+    return {
+        'molecules': molecules,
+        'n_bins': n_bins,
+        'bounds': bounds,
+        'agents': agents,
+        'gradient': {
+            'type': 'exponential',
+            'molecules': {
+                mol_id: {
+                    'center': [0.0, 0.0],
+                    'base': 1 + 1e-1}
+                for mol_id in molecules}},
+        'initial_state': {
+            mol_id: np.ones((n_bins[0], n_bins[1]))
+            for mol_id in molecules}}
+
+def test_fields(config=get_config(), time=2):
+    fields = StaticField(config)
+    settings = {
+        'return_raw_data': True,
+        'total_time': 10,
+        'timestep': 1}
+    return simulate_process(fields, settings)
+
+if __name__ == '__main__':
+    out_dir = os.path.join(PROCESS_OUT_DIR, NAME)
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    config = get_config()
+    data = test_fields(config, 10)
+    plot_fields(data, config, out_dir, 'exponential')

--- a/vivarium/processes/static_field.py
+++ b/vivarium/processes/static_field.py
@@ -9,20 +9,20 @@ from scipy import constants
 from scipy.ndimage import convolve
 import matplotlib.pyplot as plt
 
-from vivarium.core.process import Process
+from vivarium.core.process import Deriver
 from vivarium.core.composition import (
     simulate_process,
     PROCESS_OUT_DIR
 )
 
 from vivarium.plots.multibody_physics import plot_snapshots
-from vivarium.processes.diffusion_field import make_gradient, plot_fields
+from vivarium.processes.diffusion_field import plot_fields
 
 
 NAME = 'static_field'
 
 
-class StaticField(Process):
+class StaticField(Deriver):
 
     defaults = {
         'molecules': ['glc'],
@@ -32,7 +32,7 @@ class StaticField(Process):
         'gradient': {},
         'agents': {},
         'boundary_port': 'boundary',
-        'external_port': 'external',
+        'external_key': 'external',
     }
 
     def __init__(self, initial_parameters=None):
@@ -40,28 +40,27 @@ class StaticField(Process):
             initial_parameters = {}
 
         # initial state
-        self.molecule_ids = initial_parameters.get('molecules', self.defaults['molecules'])
-        self.initial_state = initial_parameters.get('initial_state', self.defaults['initial_state'])
+        self.molecules = self.or_default(
+            initial_parameters, 'molecules')
+        self.initial_state = self.or_default(
+            initial_parameters, 'initial_state')
 
         # parameters
-        self.n_bins = initial_parameters.get('n_bins', self.defaults['n_bins'])
-        self.bounds = initial_parameters.get('bounds', self.defaults['bounds'])
-        self.boundary_port = initial_parameters.get('boundary_port', self.defaults['boundary_port'])
-        self.external_port = initial_parameters.get('external_port', self.defaults['external_port'])
+        self.bounds = self.or_default(
+            initial_parameters, 'bounds')
+        self.boundary_port = self.or_default(
+            initial_parameters, 'boundary_port')
+        self.external_key = self.or_default(
+            initial_parameters, 'external_key')
 
         # initialize gradient fields
-        gradient = initial_parameters.get('gradient', self.defaults['gradient'])
-        if gradient:
-            gradient_fields = make_gradient(gradient, self.n_bins, self.bounds)
-            self.initial_state.update(gradient_fields)
+        self.gradient = initial_parameters.get('gradient', self.defaults['gradient'])
 
         # agents
         self.initial_agents = initial_parameters.get('agents', self.defaults['agents'])
 
         # make ports
-        ports = {
-             'fields': self.molecule_ids,
-             'agents': ['*']}
+        ports = {'agents': ['*']}
 
         parameters = {}
         parameters.update(initial_parameters)
@@ -73,7 +72,7 @@ class StaticField(Process):
             molecule: {
                 '_default': 0.0,
                 '_updater': 'set'}
-            for molecule in self.molecule_ids}
+            for molecule in self.molecules}
 
         schema = {}
         glob_schema = {
@@ -82,116 +81,60 @@ class StaticField(Process):
                     'location': {
                         '_default': [0.5, 0.5],
                         '_updater': 'set'},
-                    'exchange': local_concentration_schema,
-                    'external': local_concentration_schema}}}
+                    # 'exchange': local_concentration_schema,
+                    self.external_key: local_concentration_schema}}}
         schema['agents'] = glob_schema
-
-        # fields
-        fields_schema = {
-             'fields': {
-                 field: {
-                     '_value': self.initial_state.get(field, self.ones_field()),
-                     '_updater': 'accumulate',
-                     '_emit': True}
-                 for field in self.molecule_ids}}
-        schema.update(fields_schema)
         return schema
 
     def next_update(self, timestep, states):
-        fields = states['fields'].copy()
         agents = states['agents']
 
-        # check for unexpected fields
-        new_fields = {}
-        for agent_id, specs in agents.items():
-            external = specs['boundary']['external']
-            for mol_id, concentration in external.items():
-                if mol_id not in self.molecule_ids and concentration is not None:
-                    self.molecule_ids.append(mol_id)
-                    new_fields[mol_id] = concentration * self.ones_field()
-
         # get each agent's local environment
-        local_environments = self.get_local_environments(agents, fields)
+        local_environments = {}
+        for agent_id, state in agents.items():
+            location = state[self.boundary_port]['location']
+            local_environments[agent_id] = {
+                self.boundary_port: {
+                    self.external_key: self.get_concentration(location)}}
 
         return {'agents': local_environments}
 
+    def get_concentration(self, location):
+        concentrations = {}
+        if self.gradient['type'] == 'gaussian':
+            import ipdb;
+            ipdb.set_trace()
+            for molecule_id, specs in self.gradient['molecules'].items():
+                deviation = specs['deviation']
+                dx = (location[0] - specs['center'][0]) * self.bounds[0]
+                dy = (location[1] - specs['center'][1]) * self.bounds[1]
+                distance = np.sqrt(dx ** 2 + dy ** 2)
+                concentrations[molecule_id] = gaussian(deviation, distance)
 
-    def get_bin_site(self, location):
-        bin = np.array([
-            location[0] * self.n_bins[0] / self.bounds[0],
-            location[1] * self.n_bins[1] / self.bounds[1]])
-        bin_site = tuple(np.floor(bin).astype(int) % self.n_bins)
-        return bin_site
+        elif self.gradient['type'] == 'linear':
+            for molecule_id, specs in self.gradient['molecules'].items():
+                slope = specs['slope']
+                base = specs.get('base', 0.0)
+                dx = (location[0] - specs['center'][0]) * self.bounds[0]
+                dy = (location[1] - specs['center'][1]) * self.bounds[1]
+                distance = np.sqrt(dx ** 2 + dy ** 2)
+                concentrations[molecule_id] = base + slope * distance
 
-    def get_single_local_environments(self, specs, fields):
-        bin_site = self.get_bin_site(specs['location'])
-        local_environment = {}
-        for mol_id, field in fields.items():
-            local_environment[mol_id] = field[bin_site]
-        return local_environment
+        elif self.gradient['type'] == 'exponential':
+            for molecule_id, specs in self.gradient['molecules'].items():
+                base = specs['base']
+                scale = specs.get('scale', 1)
+                dx = (location[0] - specs['center'][0]) * self.bounds[0]
+                dy = (location[1] - specs['center'][1]) * self.bounds[1]
+                distance = np.sqrt(dx ** 2 + dy ** 2)
+                concentrations[molecule_id] = scale * base ** (distance/1000)
 
-    def get_local_environments(self, agents, fields):
-        local_environments = {}
-        if agents:
-            for agent_id, specs in agents.items():
-                local_environments[agent_id] = {self.boundary_port: {}}
-                local_environments[agent_id][self.boundary_port][self.external_port] = \
-                    self.get_single_local_environments(specs[self.boundary_port], fields)
-        return local_environments
-
-    def empty_field(self):
-        return np.zeros((self.n_bins[0], self.n_bins[1]), dtype=np.float64)
-
-    def ones_field(self):
-        return np.ones((self.n_bins[0], self.n_bins[1]), dtype=np.float64)
-
-
-
-def get_config(config={}):
-    molecules = ['glc']
-    bounds = (20, 20)
-    n_bins = (10, 10)
-    n_agents = 3
-
-    agents = {}
-    for agent in range(n_agents):
-        agent_id = str(agent)
-        agents[agent_id] = {
-            'boundary': {
-                'location': [
-                        np.random.uniform(0, bounds[0]),
-                        np.random.uniform(0, bounds[1])],
-                'external': {
-                    mol_id: 0 for mol_id in molecules}}}
-    return {
-        'molecules': molecules,
-        'n_bins': n_bins,
-        'bounds': bounds,
-        'agents': agents,
-        'gradient': {
-            'type': 'exponential',
-            'molecules': {
-                mol_id: {
-                    'center': [0.0, 0.0],
-                    'base': 1 + 1e-1}
-                for mol_id in molecules}},
-        'initial_state': {
-            mol_id: np.ones((n_bins[0], n_bins[1]))
-            for mol_id in molecules}}
-
-def test_fields(config=get_config(), time=2):
-    fields = StaticField(config)
-    settings = {
-        'return_raw_data': True,
-        'total_time': 10,
-        'timestep': 1}
-    return simulate_process(fields, settings)
+        return concentrations
 
 if __name__ == '__main__':
     out_dir = os.path.join(PROCESS_OUT_DIR, NAME)
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    config = get_config()
-    data = test_fields(config, 10)
-    plot_fields(data, config, out_dir, 'exponential')
+    # TODO -- make plots of different field options
+

--- a/vivarium/processes/static_field.py
+++ b/vivarium/processes/static_field.py
@@ -105,13 +105,13 @@ class StaticField(Process):
                  field: {
                      '_value': self.initial_state.get(field, self.ones_field()),
                      '_updater': 'accumulate',
-                     '_emit': True}
+                     '_emit': False}
                  for field in self.molecule_ids}}
         glob_fields_schema = {
                  '*': {
                      '_default': self.empty_field,
                      '_updater': 'accumulate',
-                     '_emit': True}}
+                     '_emit': False}}
         fields_schema['fields'].update(glob_fields_schema)
         schema.update(fields_schema)
         return schema

--- a/vivarium/processes/static_field.py
+++ b/vivarium/processes/static_field.py
@@ -132,7 +132,10 @@ class StaticField(Deriver):
         return concentrations
 
 
-def get_exponential_config(bounds, center, molecule):
+def get_exponential_config():
+    molecule = 'glc'
+    center = [0.1, 0.5]
+    bounds = [20, 30]
     scale = 1
     base = 0.1
     return {
@@ -146,15 +149,13 @@ def get_exponential_config(bounds, center, molecule):
                     'scale': scale,
                     'base': base}}}}
 
-def make_field():
-    molecule = 'glc'
-    center = [0.1, 0.5]
-    bins_per_micron = 1
-    bounds = [20, 30]
-    n_bins = [bound*bins_per_micron for bound in bounds]
-
-    config = get_exponential_config(bounds, center, molecule)
+def make_field(config=get_exponential_config()):
     process = StaticField(config)
+    molecules = config['molecules']
+    bounds = config['bounds']
+    bins_per_micron = 1
+    n_bins = [bound * bins_per_micron for bound in bounds]
+    molecule = molecules[0]  # TODO get all fields
 
     field = np.zeros((n_bins[0], n_bins[1]), dtype=np.float64)
     for x in range(n_bins[0]):
@@ -188,4 +189,3 @@ if __name__ == '__main__':
 
     field = make_field()
     plot_field(field, out_dir)
-    

--- a/vivarium/processes/static_field.py
+++ b/vivarium/processes/static_field.py
@@ -75,18 +75,7 @@ class StaticField(Process):
                 '_updater': 'set'}
             for molecule in self.molecule_ids}
 
-        schema = {'agents': {}}
-        # for agent_id, states in self.initial_agents.items():
-        #     location = states[self.boundary_port].get('location', [])
-        #     exchange = states[self.boundary_port].get('exchange', {})
-        #     schema['agents'][agent_id] = {
-        #         self.boundary_port: {
-        #             'location': {
-        #                 '_value': location},
-        #             'exchange': {
-        #                 mol_id: {
-        #                     '_value': value}
-        #                 for mol_id, value in exchange.items()}}}
+        schema = {}
         glob_schema = {
             '*': {
                 self.boundary_port: {
@@ -95,7 +84,7 @@ class StaticField(Process):
                         '_updater': 'set'},
                     'exchange': local_concentration_schema,
                     'external': local_concentration_schema}}}
-        schema['agents'].update(glob_schema)
+        schema['agents'] = glob_schema
 
         # fields
         fields_schema = {
@@ -103,7 +92,7 @@ class StaticField(Process):
                  field: {
                      '_value': self.initial_state.get(field, self.ones_field()),
                      '_updater': 'accumulate',
-                     '_emit': False}
+                     '_emit': True}
                  for field in self.molecule_ids}}
         schema.update(fields_schema)
         return schema
@@ -159,7 +148,6 @@ class StaticField(Process):
 
 
 def get_config(config={}):
-
     molecules = ['glc']
     bounds = (20, 20)
     n_bins = (10, 10)

--- a/vivarium/processes/static_field.py
+++ b/vivarium/processes/static_field.py
@@ -76,19 +76,17 @@ class StaticField(Process):
             for molecule in self.molecule_ids}
 
         schema = {'agents': {}}
-        for agent_id, states in self.initial_agents.items():
-            location = states[self.boundary_port].get('location', [])
-            exchange = states[self.boundary_port].get('exchange', {})
-            schema['agents'][agent_id] = {
-                self.boundary_port: {
-                    'location': {
-                        '_value': location},
-                    'exchange': {
-                        mol_id: {
-                            '_value': value}
-                        for mol_id, value in exchange.items()}}}
-            # schema['agents'][agent_id][self.boundary_port].update(local_concentration_schema)
-
+        # for agent_id, states in self.initial_agents.items():
+        #     location = states[self.boundary_port].get('location', [])
+        #     exchange = states[self.boundary_port].get('exchange', {})
+        #     schema['agents'][agent_id] = {
+        #         self.boundary_port: {
+        #             'location': {
+        #                 '_value': location},
+        #             'exchange': {
+        #                 mol_id: {
+        #                     '_value': value}
+        #                 for mol_id, value in exchange.items()}}}
         glob_schema = {
             '*': {
                 self.boundary_port: {
@@ -107,12 +105,6 @@ class StaticField(Process):
                      '_updater': 'accumulate',
                      '_emit': False}
                  for field in self.molecule_ids}}
-        glob_fields_schema = {
-                 '*': {
-                     '_default': self.empty_field,
-                     '_updater': 'accumulate',
-                     '_emit': False}}
-        fields_schema['fields'].update(glob_fields_schema)
         schema.update(fields_schema)
         return schema
 

--- a/vivarium/processes/translation.py
+++ b/vivarium/processes/translation.py
@@ -7,6 +7,8 @@ Stochastic Translation
 import copy
 import numpy as np
 import random
+import logging as log
+
 from arrow import StochasticSystem
 
 from vivarium.core.process import Process
@@ -340,8 +342,7 @@ class Translation(Process):
         self.concentrations_deriver_key = self.or_default(
             initial_parameters, 'concentrations_deriver_key')
 
-        if VERBOSE:
-            print('translation parameters: {}'.format(self.parameters))
+        log.info('translation parameters: {}'.format(self.parameters))
 
         super(Translation, self).__init__(self.ports, self.parameters)
 


### PR DESCRIPTION
Here we add a new process ```static_field```, which calculates an agent's local environment with a function (exponential, linear, or gaussian), rather than lookup from saved numpy array. This assumes no diffusion -- the fields remain constant. This saves us from having to handle the large arrays, and gives more continuous values. The process is used in a ```static_lattice``` compartment, which can be used in chemotaxis experiments.

There are a number of additional changes.
- the chemoreceptors are again initializing at a steady state by calling ```run_to_steady_state()``` in the constructor.
- ```chemotaxis_master``` experiment gets all of the expected external states out of the agent, and uses it to initialize the lattice fields (too many fields! this is why I made the static_field for more lightweight experiments).
