### PR TITLE
DB emitter and serializer

### DIFF
--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -206,15 +206,15 @@ class DatabaseEmitter(Emitter):
         data = data_config['data']
         data.update({
             'experiment_id': self.experiment_id})
-
         table = getattr(self.db, data_config['table'])
         table.insert_one(data)
 
     def get_data(self):
         query = {'experiment_id': self.experiment_id}
-        data = self.client.find(query)
-
-        # TODO -- pull it out of data
-        import ipdb; ipdb.set_trace()
-
+        data = self.history.find(query)
+        data = list(data)
+        data = [{
+            key: value for key, value in datum.items()
+            if key not in ['_id', 'experiment_id']}
+            for datum in data]
         return data

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -184,6 +184,7 @@ class DatabaseEmitter(Emitter):
         'database': 'DB_NAME'}
     '''
     client = None
+    default_host = 'localhost:27017'
 
     def __init__(self, config):
         self.config = config
@@ -191,7 +192,7 @@ class DatabaseEmitter(Emitter):
 
         # create singleton instance of mongo client
         if DatabaseEmitter.client is None:
-            DatabaseEmitter.client = MongoClient(config['host'])
+            DatabaseEmitter.client = MongoClient(config.get('host', self.default_host))
 
         self.db = getattr(self.client, config.get('database', 'simulations'))
         self.history = getattr(self.db, 'history')

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -756,7 +756,7 @@ def timestamp(dt=None):
 class Experiment(object):
     def __init__(self, config):
         self.config = config
-        self.experiment_id = config.get('experiment_id', uuid.uuid1())
+        self.experiment_id = config.get('experiment_id', str(uuid.uuid1()))
         self.description = config.get('description', '')
         self.processes = config['processes']
         self.topology = config['topology']
@@ -799,9 +799,11 @@ class Experiment(object):
             'time_created': timestamp(),
             'experiment_id': self.experiment_id,
             'description': self.description,
-            'processes': self.processes,
-            'topology': self.topology,
-            'state': self.state.get_config()}
+            # TODO -- serialize processes, topology, state
+            # 'processes': self.processes,
+            # 'topology': self.topology,
+            # 'state': self.state.get_config()
+        }
         emit_config = {
             'table': 'configuration',
             'data': data}

--- a/vivarium/core/repository.py
+++ b/vivarium/core/repository.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import copy
 import random
 
+import numpy as np
 
 from vivarium.library.dict_utils import deep_merge
 from vivarium.library.units import Quantity
@@ -88,4 +89,24 @@ deriver_library = {
     'counts_to_mmol': DeriveConcentrations,
     'mass': TreeMass,
     'globals': DeriveGlobals,
+}
+
+
+# Serializers
+class Serializer(object):
+    def serialize(self, data):
+        return data
+
+    def deserialize(self, data):
+        return data
+
+class NumpySerializer(Serializer):
+    def serialize(self, data):
+        return data.tolist()
+
+    def deserialize(self, data):
+        return np.array(data)
+
+serializer_library = {
+    'numpy': NumpySerializer(),
 }

--- a/vivarium/experiments/mother_machine.py
+++ b/vivarium/experiments/mother_machine.py
@@ -29,7 +29,7 @@ from vivarium.plots.multibody_physics import plot_snapshots
 def mother_machine_experiment(config):
     # configure the experiment
     agent_ids = config.get('agent_ids', [])
-    emitter = config.get('emitter', {'type': 'database'})
+    emitter = config.get('emitter', {'type': 'timeseries'})
 
     # get the environment
     environment = Lattice(config.get('environment', {}))
@@ -143,4 +143,4 @@ if __name__ == '__main__':
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    run_mother_machine(100, out_dir)
+    run_mother_machine(500, out_dir)

--- a/vivarium/experiments/mother_machine.py
+++ b/vivarium/experiments/mother_machine.py
@@ -143,4 +143,4 @@ if __name__ == '__main__':
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    run_mother_machine(400, out_dir)
+    run_mother_machine(100, out_dir)

--- a/vivarium/experiments/mother_machine.py
+++ b/vivarium/experiments/mother_machine.py
@@ -29,7 +29,7 @@ from vivarium.plots.multibody_physics import plot_snapshots
 def mother_machine_experiment(config):
     # configure the experiment
     agent_ids = config.get('agent_ids', [])
-    emitter = config.get('emitter', {'type': 'timeseries'})
+    emitter = config.get('emitter', {'type': 'database'})
 
     # get the environment
     environment = Lattice(config.get('environment', {}))
@@ -143,4 +143,4 @@ if __name__ == '__main__':
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    run_mother_machine(500, out_dir)
+    run_mother_machine(400, out_dir)

--- a/vivarium/processes/diffusion_field.py
+++ b/vivarium/processes/diffusion_field.py
@@ -255,7 +255,7 @@ class DiffusionField(Process):
         fields_schema = {
              'fields': {
                  field: {
-                     '_value': self.initial_state.get(field, self.ones_field()),
+                     '_default': self.initial_state.get(field, self.ones_field()),
                      '_updater': 'accumulate',
                      '_emit': True}
                  for field in self.molecule_ids}}


### PR DESCRIPTION
This brings back the ```DatabaseEmitter```, which saves experiment emissions to mongodb.  In order to get numpy arrays in there, we also now have serializers in the Store, and a serializer_library in ```repository```. The only serializer in the library is ```'numpy'``` -- this can be extended to whatever serializers we need in the future.