### PR TITLE
Parameter scan with compartment

### DIFF
--- a/vivarium/compartments/master.py
+++ b/vivarium/compartments/master.py
@@ -8,6 +8,7 @@ from vivarium.core.composition import (
     plot_simulation_output,
     COMPARTMENT_OUT_DIR
 )
+from vivarium.library.dict_utils import deep_merge
 from vivarium.compartments.gene_expression import plot_gene_expression_output
 
 # processes
@@ -38,32 +39,35 @@ class Master(Compartment):
     defaults = {
         'global_path': ('global',),
         'external_path': ('external',),
-        'transport': get_glc_lct_config(),
-        'metabolism': default_metabolism_config(),
+        'config': {
+            'transport': get_glc_lct_config(),
+            'metabolism': default_metabolism_config()
+        }
     }
 
-    def __init__(self, config):
-        self.config = config
-        self.global_path = config.get('global_path', self.defaults['global_path'])
-        self.external_path = config.get('external_path', self.defaults['external_path'])
+    def __init__(self, config=None):
+        if not config:
+            config = {}
+        self.config = deep_merge(self.defaults['config'], config)
+        self.global_path = self.or_default(
+            config, 'global_path')
+        self.external_path = self.or_default(
+            config, 'external_path')
 
     def generate_processes(self, config):
 
-        ## Declare the processes.
         # Transport
-        # load the kinetic parameters
-        transport_config = config.get('transport', self.defaults['transport'])
+        transport_config = config.get('transport')
         transport = ConvenienceKinetics(transport_config)
         target_fluxes = transport.kinetic_rate_laws.reaction_ids
 
         # Metabolism
-        # get target fluxes from transport
-        # load regulation function
-        metabolism_config = config.get('metabolism', self.defaults['metabolism'])
+        # add target fluxes from transport
+        metabolism_config = config.get('metabolism')
         metabolism_config.update({'constrained_reaction_ids': target_fluxes})
         metabolism = Metabolism(metabolism_config)
 
-        # expression
+        # Expression
         transcription_config = config.get('transcription', {})
         translation_config = config.get('translation', {})
         degradation_config = config.get('degradation', {})
@@ -88,24 +92,21 @@ class Master(Compartment):
             'division': division}
 
     def generate_topology(self, config):
-        external_path = config.get('external_path', self.external_path)
-        global_path = config.get('global_path', self.global_path)
-
         return {
             'transport': {
                 'internal': ('metabolites',),
-                'external': external_path,
+                'external': self.external_path,
                 'exchange': ('null',),  # metabolism's exchange is used
                 'fluxes': ('flux_bounds',),
-                'global': global_path},
+                'global': self.global_path},
 
             'metabolism': {
                 'internal': ('metabolites',),
-                'external': external_path,
+                'external': self.external_path,
                 'reactions': ('reactions',),
                 'exchange': ('exchange',),
                 'flux_bounds': ('flux_bounds',),
-                'global': global_path},
+                'global': self.global_path},
 
             'transcription': {
                 'chromosome': ('chromosome',),
@@ -113,7 +114,7 @@ class Master(Compartment):
                 'proteins': ('proteins',),
                 'transcripts': ('transcripts',),
                 'factors': ('concentrations',),
-                'global': global_path},
+                'global': self.global_path},
 
             'translation': {
                 'ribosomes': ('ribosomes',),
@@ -121,21 +122,21 @@ class Master(Compartment):
                 'transcripts': ('transcripts',),
                 'proteins': ('proteins',),
                 'concentrations': ('concentrations',),
-                'global': global_path},
+                'global': self.global_path},
 
             'degradation': {
                 'transcripts': ('transcripts',),
                 'proteins': ('proteins',),
                 'molecules': ('metabolites',),
-                'global': global_path},
+                'global': self.global_path},
 
             'complexation': {
                 'monomers': ('proteins',),
                 'complexes': ('proteins',),
-                'global': global_path},
+                'global': self.global_path},
 
             'division': {
-                'global': global_path}}
+                'global': self.global_path}}
 
 
 def run_master(out_dir):

--- a/vivarium/compartments/transport_metabolism.py
+++ b/vivarium/compartments/transport_metabolism.py
@@ -59,6 +59,7 @@ def default_expression_config():
 
     return config
 
+
 class TransportMetabolism(Compartment):
     """
     Transport/Metabolism Compartment, with ODE expression
@@ -66,47 +67,40 @@ class TransportMetabolism(Compartment):
 
     defaults = {
         'boundary_path': ('boundary',),
-        'agents_path': ('..', '..', 'agents',),
+        'agents_path': ('agents',),
         'daughter_path': tuple(),
-        'transport': get_glc_lct_config(),
-        'metabolism': default_metabolism_config(),
-        'expression': default_expression_config(),
         'division': {}}
 
-    def __init__(self, config):
+    default_config = {
+        'transport': get_glc_lct_config(),
+        'metabolism': default_metabolism_config(),
+        'expression': default_expression_config()}
+
+    def __init__(self, config=None):
+        if not config:
+            config = self.default_config
         self.config = config
 
         self.boundary_path = config.get('boundary_path', self.defaults['boundary_path'])
         self.agents_path = config.get('agents_path', self.defaults['agents_path'])
         self.daughter_path = config.get('daughter_path', self.defaults['daughter_path'])
 
-        self.transport_config = config.get('transport', self.defaults['transport'])
-        self.metabolism_config = config.get('metabolism', self.defaults['metabolism'])
-        self.expression_config = config.get('expression', self.defaults['expression'])
-        self.division_config = config.get('division', self.defaults['division'])
-
     def generate_processes(self, config):
         agent_id = config.get('agent_id', '0')  # TODO -- configure the agent_id
 
         # Transport
         # load the kinetic parameters
-        transport = ConvenienceKinetics(config.get(
-            'transport',
-            self.transport_config))
+        transport = ConvenienceKinetics(config.get('transport', {}))
 
         # Metabolism
         # get target fluxes from transport, and update constrained_reaction_ids
-        metabolism_config = config.get(
-            'metabolism',
-            self.metabolism_config)
+        metabolism_config = config.get('metabolism', {})
         target_fluxes = transport.kinetic_rate_laws.reaction_ids
         metabolism_config.update({'constrained_reaction_ids': target_fluxes})
         metabolism = Metabolism(metabolism_config)
 
         # Gene expression
-        expression = ODE_expression(config.get(
-            'expression',
-            self.expression_config))
+        expression = ODE_expression(config.get( 'expression', {}))
 
         # Division
         division_config = dict(
@@ -160,12 +154,6 @@ class TransportMetabolism(Compartment):
 
 
 # simulate
-default_compartment_config = {
-    'external_path': ('external',),
-    'exchange_path': ('exchange',),
-    'global_path': ('global',),
-    'agents_path': ('agents',)}
-
 def test_txp_mtb_ge():
     default_test_setting = {
         'environment': {
@@ -177,10 +165,10 @@ def test_txp_mtb_ge():
         'timestep': 1,
         'total_time': 10}
 
-    compartment = TransportMetabolism(default_compartment_config)
+    compartment = TransportMetabolism({})
     return simulate_compartment_in_experiment(compartment, default_test_setting)
 
-def simulate_txp_mtb_ge(config=default_compartment_config, out_dir='out'):
+def simulate_txp_mtb_ge(config={}, out_dir='out'):
 
     end_time = 200  # 2520 sec (42 min) is the expected doubling time in minimal media
     timeline = [
@@ -203,7 +191,7 @@ def simulate_txp_mtb_ge(config=default_compartment_config, out_dir='out'):
                 'external': ('boundary', 'external')}}}
 
     # run simulation
-    compartment = TransportMetabolism(default_compartment_config)
+    compartment = TransportMetabolism({})
     timeseries = simulate_compartment_in_experiment(compartment, sim_settings)
 
     # calculate growth
@@ -234,8 +222,8 @@ def simulate_txp_mtb_ge(config=default_compartment_config, out_dir='out'):
     plot_simulation_output(timeseries, plot_settings, out_dir)
 
 # parameters
-def scan_txp_mtb_ge():
-    composite_function = compose_txp_mtb_ge
+def scan_transport_metabolism():
+    compartment = TransportMetabolism({})
 
     # parameters to be scanned, and their values
     scan_params = {
@@ -244,20 +232,20 @@ def scan_txp_mtb_ge():
          'EX_glc__D_e',
          ('internal', 'EIIglc'),
          'kcat_f'):
-            get_parameters_logspace(1e3, 1e6, 4),
+            get_parameters_logspace(1e3, 1e6, 3),
         ('transport',
          'kinetic_parameters',
          'EX_lcts_e',
          ('internal', 'LacY'),
          'kcat_f'):
-            get_parameters_logspace(1e3, 1e6, 4),
+            get_parameters_logspace(1e3, 1e6, 3),
     }
 
     # metrics are the outputs of a scan
     metrics = [
         ('reactions', 'EX_glc__D_e'),
         ('reactions', 'EX_lcts_e'),
-        ('global', 'mass')
+        ('boundary', 'mass')
     ]
 
     # define conditions
@@ -286,21 +274,24 @@ def scan_txp_mtb_ge():
     # set up scan options
     timeline = [(10, {})]
     sim_settings = {
-        'environment_port': 'environment',
-        'exchange_port': 'exchange',
-        'environment_volume': 1e-6,  # L
-        'timeline': timeline}
-    scan_options = {
-        'simulate_with_environment': True,
-        'simulation_settings': sim_settings}
+        'environment': {
+            'volume': 1e-14 * units.L,
+            'ports': {
+                'external': ('boundary', 'external'),
+                'exchange': ('boundary', 'exchange'),
+            }},
+        'timeline': {
+            'timeline': timeline,
+            'ports': {
+                'external': ('boundary', 'external')}}}
 
     # run scan
     scan_config = {
-        'composite': composite_function,
+        'compartment': compartment,
         'scan_parameters': scan_params,
-        'conditions': conditions,
+        # 'conditions': conditions,
         'metrics': metrics,
-        'options': scan_options}
+        'settings': sim_settings}
     results = parameter_scan(scan_config)
 
     return results
@@ -318,7 +309,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.scan:
-        results = scan_txp_mtb_ge()
+        results = scan_transport_metabolism()
         plot_scan_results(results, out_dir)
     else:
         config = {}

--- a/vivarium/compartments/transport_metabolism.py
+++ b/vivarium/compartments/transport_metabolism.py
@@ -223,6 +223,8 @@ def simulate_txp_mtb_ge(config={}, out_dir='out'):
 
 # parameters
 def scan_transport_metabolism():
+
+    # initialize the compartment
     compartment = TransportMetabolism({})
 
     # parameters to be scanned, and their values
@@ -289,7 +291,7 @@ def scan_transport_metabolism():
     scan_config = {
         'compartment': compartment,
         'scan_parameters': scan_params,
-        # 'conditions': conditions,
+        'conditions': conditions,
         'metrics': metrics,
         'settings': sim_settings}
     results = parameter_scan(scan_config)

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -110,7 +110,6 @@ def process_in_experiment(process, settings={}):
 
 def compartment_in_experiment(compartment, settings={}):
     compartment_config = settings.get('compartment', {})
-    emitter = settings.get('emitter', {'type': 'timeseries'})
     timeline = settings.get('timeline', {})
     environment = settings.get('environment', {})
     outer_path = settings.get('outer_path', tuple())
@@ -148,7 +147,7 @@ def compartment_in_experiment(compartment, settings={}):
     return Experiment({
         'processes': processes,
         'topology': topology,
-        'emitter': emitter,
+        'emitter': settings.get('emitter', {'type': 'timeseries'}),
         'initial_state': settings.get('initial_state', {})})
 
 

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -732,6 +732,9 @@ class Compartment(object):
             'processes': assoc_in({}, path, processes),
             'topology': assoc_in({}, path, topology)}
 
+    def or_default(self, parameters, key):
+        return parameters.get(key, self.defaults[key])
+
     def get_parameters(self):
         network = self.generate({})
         processes = network['processes']

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -651,7 +651,6 @@ class Store(object):
         target.apply_defaults()
 
 
-# Compartment
 def generate_derivers(processes, topology):
     deriver_processes = {}
     deriver_topology = {}

--- a/vivarium/parameters/parameters.py
+++ b/vivarium/parameters/parameters.py
@@ -9,7 +9,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from vivarium.core.composition import simulate_compartment_in_experiment
-from vivarium.compartments.master import Master
 
 
 def get_nested(dict, keys):
@@ -42,12 +41,13 @@ def get_parameters_logspace(min, max, number):
     range = np.logspace(np.log10(min), np.log10(max), number, endpoint=True)
     return list(range)
 
-def run_sim_get_output(new_compartment, condition, metrics, settings):
+def run_compartment_get_output(compartment, parameters, condition, metrics, settings):
     settings['initial_state'] = condition
     settings['return_raw_data'] = True
+    settings['compartment'] = parameters
 
     # run the simulation and get the last state
-    sim_out = simulate_compartment_in_experiment(new_compartment, settings)
+    sim_out = simulate_compartment_in_experiment(compartment, settings)
     time_vec = list(sim_out.keys())
     last_state = sim_out[time_vec[-1]]
 
@@ -56,6 +56,18 @@ def run_sim_get_output(new_compartment, condition, metrics, settings):
     for output_value in metrics:
         output.append(get_nested(last_state, output_value))
     return output
+
+
+def check_path_exists(path, dict):
+    if len(path) > 0:
+        key = path[0]
+        if key in dict:
+            sub_path = path[1:]
+            sub_dict = dict[key]
+            check_path_exists(sub_path, sub_dict)
+        else:
+            raise Exception('parameter path does not exist: {}'.format(path))
+
 
 def parameter_scan(config):
     '''
@@ -74,7 +86,9 @@ def parameter_scan(config):
     scan_params = config['scan_parameters']
     metrics = config['metrics']
     settings = config.get('settings', {})
-    conditions = config.get('conditions', [{}])
+    conditions = config.get('conditions')
+    if not conditions:
+        conditions = [{}]
     n_conditions = len(conditions)
 
     ## Set up the parameters
@@ -84,8 +98,11 @@ def parameter_scan(config):
     print('parameter scan size: {}'.format(n_combinations))
 
     # get default parameters from baseline compartment object
-    default_compartment = compartment({})
-    default_params = default_compartment.get_parameters()
+    default_params = compartment.get_parameters()
+
+    # check that scan parameters are in default parameters
+    for path in scan_params.keys():
+        check_path_exists(path, default_params)
 
     # get parameter sets for scan
     param_keys = list(scan_params.keys())
@@ -97,7 +114,8 @@ def parameter_scan(config):
     results = []
     for params_index, param_set in enumerate(param_sets):
         # set up the parameters
-        parameters = copy.deepcopy(default_params)
+        # parameters = copy.deepcopy(default_params)
+        parameters = {}
         for param_key, param_value in param_set.items():
             parameters = set_nested(parameters, param_key, param_value)
 
@@ -109,25 +127,18 @@ def parameter_scan(config):
                 condition_index+1,
                 n_conditions))
 
-            # make compartment with new parameters
-            new_compartment = compartment(parameters)
+            output = run_compartment_get_output(
+                compartment,
+                parameters,
+                condition_state,
+                metrics,
+                settings)
 
-            # run a sim with the new_compartment and condition
-            try:
-                output = run_sim_get_output(
-                    new_compartment,
-                    condition_state,
-                    metrics,
-                    settings)
-
-                result = {
-                    'parameter_index': params_index,
-                    'condition_index': condition_index,
-                    'output': output}
-                results.append(result)
-
-            except:
-                print('failed simulation: parameter set {}, condition {}'.format(params_index, condition_index))
+            result = {
+                'parameter_index': params_index,
+                'condition_index': condition_index,
+                'output': output}
+            results.append(result)
 
     # organize data by metric
     output_data = {
@@ -137,6 +148,7 @@ def parameter_scan(config):
         'conditions': {idx: condition for idx, condition in enumerate(conditions)}}
 
     return organize_param_scan_results(output_data)
+
 
 def organize_param_scan_results(data):
     results = data['results']
@@ -166,6 +178,7 @@ def organize_param_scan_results(data):
         'metric_data': metric_data,
         'parameter_sets': parameter_sets,
         'conditions': conditions}
+
 
 def plot_scan_results(results, out_dir='out', filename='parameter_scan'):
     metric_data = results['metric_data']
@@ -227,45 +240,3 @@ def plot_scan_results(results, out_dir='out', filename='parameter_scan'):
     fig_path = os.path.join(out_dir, filename)
     plt.subplots_adjust(wspace=0.3, hspace=0.5)
     plt.savefig(fig_path, bbox_inches='tight')
-
-def scan_master():
-    compartment = Master
-
-    # define scanned parameters, which replace defaults
-    scan_params = {
-        ('transport',
-         'kinetic_parameters',
-         'EX_glc__D_e',
-         ('internal', 'EIIglc'),
-         'kcat_f'):
-            get_parameters_logspace(1e-3, 1e0, 6)}
-
-    # metrics to collect from scan output
-    metrics = [
-        ('reactions', 'EX_glc__D_e'),
-        ('reactions', 'GLCptspp'),
-        ('global', 'volume')]
-
-    # set up simulation settings and scan options
-    timeline = [(30, {})]
-    settings = {
-        # 'environment_volume': 1e-6,  # L
-        'timeline': timeline}
-
-    scan_config = {
-        'compartment': compartment,
-        'scan_parameters': scan_params,
-        'metrics': metrics,
-        'settings': settings}
-    results = parameter_scan(scan_config)
-
-    return results
-
-
-if __name__ == '__main__':
-    out_dir = os.path.join('out', 'parameters', 'master')
-    if not os.path.exists(out_dir):
-        os.makedirs(out_dir)
-
-    results = scan_master()
-    plot_scan_results(results, out_dir)


### PR DESCRIPTION
This PR rehabilitates the ```parameter_scan``` in ```parameters.py``` to use the new compartment object.  Parameters are passed in through ```compartment.generate```, and conditions through experiment's ```initial_state```.  

I added a test for parameter scanning, which uses a toy model with a ```ConvenienceKinetics``` process. The test scans a k_cat in 3 different conditions, and measures the resulting flux.  The resulting output looks like this:
![test_scan](https://user-images.githubusercontent.com/6809431/84575501-59032500-ad62-11ea-956c-ac2b6dc2672e.png)
