### PR TITLE
Fix mother machine

### DIFF
--- a/vivarium/experiments/mother_machine.py
+++ b/vivarium/experiments/mother_machine.py
@@ -189,4 +189,4 @@ if __name__ == '__main__':
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    run_mother_machine(200, out_dir)
+    run_mother_machine(400, out_dir)

--- a/vivarium/library/pymunk_multibody.py
+++ b/vivarium/library/pymunk_multibody.py
@@ -194,18 +194,36 @@ class MultiBody(object):
     def add_barriers(self, bounds, barriers):
         """ Create static barriers """
         thickness = 2.0
+        offset = thickness
         x_bound = bounds[0]
         y_bound = bounds[1]
 
         static_body = self.space.static_body
         static_lines = [
-            pymunk.Segment(static_body, (0.0, 0.0), (x_bound, 0.0), thickness),
-            pymunk.Segment(static_body, (x_bound, 0.0), (x_bound, y_bound), thickness),
-            pymunk.Segment(static_body, (x_bound, y_bound), (0.0, y_bound), thickness),
-            pymunk.Segment(static_body, (0.0, y_bound), (0.0, 0.0), thickness),
+            pymunk.Segment(
+                static_body,
+                (0.0-offset, 0.0-offset),
+                (x_bound+offset, 0.0-offset),
+                thickness),
+            pymunk.Segment(
+                static_body,
+                (x_bound+offset, 0.0-offset),
+                (x_bound+offset, y_bound+offset),
+                thickness),
+            pymunk.Segment(
+                static_body,
+                (x_bound+offset, y_bound+offset),
+                (0.0-offset, y_bound+offset),
+                thickness),
+            pymunk.Segment(
+                static_body,
+                (0.0-offset, y_bound+offset),
+                (0.0-offset, 0.0-offset),
+                thickness),
         ]
 
         if barriers:
+            spacer_thickness = barriers.get('spacer_thickness', 0.1)
             channel_height = barriers.get('channel_height')
             channel_space = barriers.get('channel_space')
             n_lines = math.floor(x_bound/channel_space)
@@ -214,7 +232,7 @@ class MultiBody(object):
                 pymunk.Segment(
                     static_body,
                     (channel_space * line, 0),
-                    (channel_space * line, channel_height), thickness)
+                    (channel_space * line, channel_height), spacer_thickness)
                 for line in range(n_lines)]
             static_lines += machine_lines
 

--- a/vivarium/plots/multibody_physics.py
+++ b/vivarium/plots/multibody_physics.py
@@ -112,8 +112,8 @@ def plot_snapshots(data, plot_config):
         field_ids = list(fields[time_vec[0]].keys())
         field_range = {}
         for field_id in field_ids:
-            field_min = min([field_data[field_id].min() for t, field_data in fields.items()])
-            field_max = max([field_data[field_id].max() for t, field_data in fields.items()])
+            field_min = min([min(min(field_data[field_id])) for t, field_data in fields.items()])
+            field_max = max([max(max(field_data[field_id])) for t, field_data in fields.items()])
             field_range[field_id] = [field_min, field_max]
 
     # get agent ids
@@ -154,7 +154,6 @@ def plot_snapshots(data, plot_config):
                                 vmin=vmin,
                                 vmax=vmax,
                                 cmap='BuPu')
-
                 if agents:
                     agents_now = agents[time]
                     plot_agents(ax, agents_now, agent_colors)

--- a/vivarium/processes/multibody_physics.py
+++ b/vivarium/processes/multibody_physics.py
@@ -266,42 +266,6 @@ def agent_body_config(config):
         for agent_id in agent_ids}
     return {'agents': agent_config}
 
-def mother_machine_body_config(config):
-    # cell dimensions
-    width = 1
-    length = 2
-    volume = volume_from_length(length, width)
-
-    agent_ids = config['agent_ids']
-    bounds = config.get('bounds', DEFAULT_BOUNDS)
-    channel_space = config.get('channel_space', 1)
-    n_agents = len(agent_ids)
-
-    # possible locations, shuffled for index-in
-    n_spaces = math.floor(bounds[0]/channel_space)
-    assert n_agents < n_spaces, 'more agents than mother machine spaces'
-
-    possible_locations = [
-        [x*channel_space - channel_space/2, 0.01]
-        for x in range(1, n_spaces)]
-    random.shuffle(possible_locations)
-
-    agent_config = {
-        agent_id: {
-            'boundary': {
-                'location': possible_locations[index],
-                'angle': PI/2,
-                'volume': volume,
-                'length': length,
-                'width': width,
-                'mass': 1 * units.fg,
-                'forces': [0, 0]}}
-        for index, agent_id in enumerate(agent_ids)}
-
-    return {
-        'agents': agent_config,
-        'bounds': bounds}
-
 def get_baseline_config(config={}):
     animate = config.get('animate', False)
     bounds = config.get('bounds', [500, 500])


### PR DESCRIPTION
This rehabilitates the ```mother_machine``` experiment: ```snapshots``` plot is now using lists of lists for the fields (the numpy serializer is doing its job and serializing numpy arrays, but not yet de-serializing).  And the ```pymunk_multibody``` library is setting a different thickness for the barriers between mother machine channels -- I had set the thickness of the external barrier really high to avoid chemotaxis agents slamming through barriers, and this unintentionally made the mother machine barriers thick as well..