### PR TITLE
Fix Use of Set Operators on dict.keys()

### DIFF
--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -879,8 +879,10 @@ class Store(object):
         if set(schema.keys()) & self.schema_keys:
             self.get_path(topology).apply_config(schema)
         else:
-            mismatch_topology = topology.keys() - schema.keys()
-            mismatch_schema = schema.keys() - topology.keys()
+            mismatch_topology = (
+                set(topology.keys()) - set(schema.keys()))
+            mismatch_schema = (
+                set(schema.keys()) - set(topology.keys()))
             if mismatch_topology:
                 raise Exception(
                     'topology at path {} and source {} has keys that are not in the schema: {}'.format(

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -876,7 +876,7 @@ class Store(object):
 
         source = source or self.path_for()
 
-        if schema.keys() & self.schema_keys:
+        if set(schema.keys()) & self.schema_keys:
             self.get_path(topology).apply_config(schema)
         else:
             mismatch_topology = topology.keys() - schema.keys()

--- a/vivarium/processes/transcription.py
+++ b/vivarium/processes/transcription.py
@@ -502,7 +502,7 @@ class Transcription(Process):
         chromosome_dict = chromosome.to_dict()
         rnaps = chromosome_dict['rnaps']
 
-        completed_rnaps = original_rnap_keys - rnaps.keys()
+        completed_rnaps = set(original_rnap_keys) - set(rnaps.keys())
         rnap_updates = {
             rnap_id: rnap
             for rnap_id, rnap in rnaps.items()

--- a/vivarium/processes/translation.py
+++ b/vivarium/processes/translation.py
@@ -533,7 +533,8 @@ class Translation(Process):
             key: count * -1
             for key, count in elongation.monomers.items()}
 
-        completed_ribosomes = original_ribosome_keys - ribosomes.keys()
+        completed_ribosomes = (
+            set(original_ribosome_keys) - set(ribosomes.keys()))
         ribosome_updates = {
             id: ribosome
             for id, ribosome in ribosomes.items()


### PR DESCRIPTION
Calling set operators on the result of dict.keys(), e.g.

```
dict.keys() & someSet
```

fails in Python 2. This commit fixes all such patterns in the code base
based on a search for the substring `.keys()` in `/vivarium/`.

I'm working on setting up GitHub actions to run our unit tests continuously in py2 and py3 so we don't run into any more issues like this