### PR TITLE
Specify divider for branches

### DIFF
--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -500,9 +500,9 @@ class Store(object):
                 divider = self.divider['divider']
                 topology = self.divider['topology']
                 state = self.outer.get_values(topology)
-                return divider(self.value, state)
+                return divider(self.get_value(), state)
             else:
-                return self.divider(self.value)
+                return self.divider(self.get_value())
         elif self.inner:
             daughters = [{}, {}]
             for key, child in self.inner.items():
@@ -763,6 +763,8 @@ class Store(object):
                         node = self.get_path(path)
                         for child, child_node in node.inner.items():
                             state[child] = child_node.schema_topology(subschema, {})
+                elif key == '_divider':
+                    pass
                 elif isinstance(path, dict):
                     node, path = self.outer_path(path)
                     state[key] = node.schema_topology(subschema, path)
@@ -1560,6 +1562,7 @@ def test_topology_ports():
                     '_updater': 'set',
                     '_default': self.radius},
                 'quarks': {
+                    '_divider': 'split_dict',
                     '*': {
                         'color': {
                             '_updater': 'set',
@@ -1683,6 +1686,7 @@ def test_topology_ports():
     experiment.update(10.0)
 
     log.debug(pf(experiment.state.get_config(True)))
+    log.debug(pf(experiment.state.divide_value()))
 
 
 def test_timescales():

--- a/vivarium/core/repository.py
+++ b/vivarium/core/repository.py
@@ -199,6 +199,8 @@ def divide_split_dict(state):
             making any assumptions about which keys will be sent to
             which daughter cell.
     """
+    if state is None:
+        state = {}
     d1 = dict(list(state.items())[len(state) // 2:])
     d2 = dict(list(state.items())[:len(state) // 2])
     return [d1, d2]


### PR DESCRIPTION
Dividers already work for individual values, but a need arose for dividing a collection of entities specified by a `*` schema, essentially splitting them up between the daughters. This PR shifts the special `_divider` key out of `schema_keys` (which means it does not necessarily denote a leaf) and now supports operation at any point in the tree. 

Tested using @eagmon's `split_dict` divider which now works for the quarks example at least. One test is failing (injector.py) but it is failing in master also? So, should be good to go. 