### PR TITLE
Continuous Integration

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,35 @@
+# Modified from GitHub Actions template
+
+name: Pytest
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+        pip install numpy
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Create output directory
+      run: |
+        mkdir out
+    - name: Test with pytest
+      run: |
+        pytest

--- a/vivarium/library/pretty.py
+++ b/vivarium/library/pretty.py
@@ -12,7 +12,7 @@ def _json_serialize(elem):
     if isinstance(elem, np.int64):
         return int(elem)
     if inspect.isfunction(elem):
-        return f'<function {elem.__name__}>'
+        return '<function {}>'.format(elem.__name__)
     if inspect.isclass(elem):
         return str(elem)
     if isinstance(elem, (Compartment, Process)):


### PR DESCRIPTION
This sets up continuous integration with GitHub Actions to run pytest on all commits to `master` and all PRs to `master` to make sure we don't break anything moving forward. Right now it only tests Python versions 3.6, 3.7, and 3.8 because the tests fail on older Python versions