### PR TITLE
Fix Bug in assoc_path

### DIFF
--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -69,21 +69,16 @@ def assoc_in(d, path, value):
 
 
 def assoc_path(d, path, value):
-    if not path:
-        return
-    head = path[0]
-    if len(path) == 1:
-        if (
-            isinstance(d.get(head), dict)
-            and isinstance(value, dict)
-        ):
-            d[head].update(value)
-        else:
+    if path:
+        head = path[0]
+        if len(path) == 1:
             d[head] = value
+        else:
+            if head not in d:
+                d[head] = {}
+            assoc_path(d[head], path[1:], value)
     else:
-        if head not in d:
-            d[head] = {}
-        assoc_path(d[head], path[1:], value)
+        value
 
 
 def update_in(d, path, f):
@@ -1035,7 +1030,10 @@ def inverse_topology(outer, update, topology):
             else:
                 for child, child_update in update.items():
                     inner = normalize_path(outer + path + (child,))
-                    assoc_path(inverse, inner, child_update)
+                    if isinstance(child_update, dict):
+                        update_in(inverse, inner, lambda current: deep_merge(current, child_update))
+                    else:
+                        assoc_path(inverse, inner, child_update)
 
         elif key in update:
             value = update[key]
@@ -1056,7 +1054,10 @@ def inverse_topology(outer, update, topology):
 
             else:
                 inner = normalize_path(outer + path)
-                assoc_path(inverse, inner, value)
+                if isinstance(value, dict):
+                    update_in(inverse, inner, lambda current: deep_merge(current, value))
+                else:
+                    assoc_path(inverse, inner, value)
 
     return inverse
 

--- a/vivarium/library/dict_utils.py
+++ b/vivarium/library/dict_utils.py
@@ -53,6 +53,8 @@ def deep_merge(dct, merge_dct):
     Recursive dict merge
     This mutates dct - the contents of merge_dct are added to dct (which is also returned).
     If you want to keep dct you could call it like deep_merge(dict(dct), merge_dct)'''
+    if dct is None:
+        dct = {}
     for k, v in merge_dct.items():
         if (k in dct and isinstance(dct[k], dict)
                 and isinstance(merge_dct[k], collections.Mapping)):


### PR DESCRIPTION
Consider the case when we are using `inverse_topology` to get the
absolute form of an update with two ports, `global` and `port`. Say the
topology maps `global` to `boundary` and `port` to
`('boundary', 'store')`. Before this commit, if inverse_topology handled
`port` and then `global`, it would first create a dictionary with the
value of `port` at `('boundary', 'global', 'store')`. However, next when
handling `global`, it would overwrite `store` with the value of `global`
instead of merging the dictionaries.

This commit fixes `assoc_path` and creates a test to check for any
regressions.