### PR TITLE
Agent shapes

### DIFF
--- a/local/draw_pygame.py
+++ b/local/draw_pygame.py
@@ -54,6 +54,8 @@ class DrawPygame(object):
 
 if __name__ == '__main__':
     test_multibody(
-        total_time=10,
-        agent_shape='circle',
+        total_time=60,
+        n_agents=10,
+        jitter_force=1e2,
+        agent_shape='segment',
         screen=DrawPygame())

--- a/local/draw_pygame.py
+++ b/local/draw_pygame.py
@@ -55,5 +55,5 @@ class DrawPygame(object):
 if __name__ == '__main__':
     test_multibody(
         total_time=10,
-        shape='capsule',
+        agent_shape='circle',
         screen=DrawPygame())

--- a/local/draw_pygame.py
+++ b/local/draw_pygame.py
@@ -1,0 +1,59 @@
+import os
+
+os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = "hide"
+import pygame
+from pygame.locals import *
+from pygame.color import *
+
+import pymunk.pygame_util
+
+from vivarium.library.pymunk_multibody import test_multibody
+
+
+class DrawPygame(object):
+    defaults = {}
+
+    def __init__(self):
+        self.running = False  # TODO -- is this used?
+        self.screen = None
+
+    def configure(self, config):
+        self.bounds = config['bounds']
+        self.space = config['space']
+
+        pygame.init()
+        self.screen = pygame.display.set_mode((
+            int(self.bounds[0]),
+            int(self.bounds[1])),
+            RESIZABLE)
+        self.clock = pygame.time.Clock()
+        self.draw_options = pymunk.pygame_util.DrawOptions(self.screen)
+
+    def process_events(self):
+        for event in pygame.event.get():
+            if event.type == QUIT:
+                self.running = False
+            elif event.type == KEYDOWN and event.key == K_ESCAPE:
+                self.running = False
+
+    def clear_screen(self):
+        self.screen.fill(THECOLORS["white"])
+
+    def draw_objects(self):
+        self.space.debug_draw(self.draw_options)
+
+    def update_screen(self):
+        self.process_events()
+        self.clear_screen()
+        self.draw_objects()
+        pygame.display.flip()
+
+        # Delay fixed time between frames
+        self.clock.tick(2)
+
+
+if __name__ == '__main__':
+    test_multibody(
+        total_time=10,
+        shape='capsule',
+        screen=DrawPygame())

--- a/vivarium/library/pymunk_multibody.py
+++ b/vivarium/library/pymunk_multibody.py
@@ -332,10 +332,9 @@ class MultiBody(object):
         position = body.position
         angle = body.angle
 
-        # make shape, moment of inertia, and add a body
+        # get shape, inertia, make body, assign body to shape
         new_shape = self.get_shape(boundary)
-
-        inertia = pymunk.moment_for_poly(mass, new_shape.get_vertices())
+        inertia = self.get_inertia(new_shape, mass)
         new_body = pymunk.Body(mass, inertia)
         new_shape.body = new_body
 

--- a/vivarium/library/pymunk_multibody.py
+++ b/vivarium/library/pymunk_multibody.py
@@ -67,7 +67,35 @@ def random_body_position(body):
             location = (width, random.uniform(0, length))
     return location
 
+def get_shape(agent_shape, boundary):
 
+    if agent_shape == 'capsule':
+        width = boundary['width']
+        length = boundary['length']
+
+        half_length = length / 2
+        half_width = width / 2
+
+        shape = pymunk.Poly(None, (
+            (-half_length, -half_width),
+            (half_length, -half_width),
+            (half_length, half_width),
+            (-half_length, half_width)))
+
+    elif agent_shape == 'rectangle':
+        width = boundary['width']
+        length = boundary['length']
+
+        half_length = length / 2
+        half_width = width / 2
+
+        shape = pymunk.Poly(None, (
+            (-half_length, -half_width),
+            (half_length, -half_width),
+            (half_length, half_width),
+            (-half_length, half_width)))
+
+    return shape
 
 class MultiBody(object):
     """
@@ -75,6 +103,7 @@ class MultiBody(object):
     """
 
     defaults = {
+        'agent_shape': 'rectangle',
         # hardcoded parameters
         'elasticity': 0.9,
         'damping': 0.5,  # 1 is no damping, 0 is full damping
@@ -100,6 +129,7 @@ class MultiBody(object):
         self.force_scaling = self.defaults['force_scaling']
 
         # configured parameters
+        self.agent_shape = config.get('agent_shape', self.defaults['agent_shape'])
         self.jitter_force = config.get('jitter_force', self.defaults['jitter_force'])
         self.bounds = config.get('bounds', self.defaults['bounds'])
         barriers = config.get('barriers', self.defaults['barriers'])
@@ -243,21 +273,15 @@ class MultiBody(object):
 
     def add_body_from_center(self, body_id, specs):
         boundary = specs['boundary']
-        width = boundary['width']
-        length = boundary['length']
         mass = boundary['mass']
         center_position = boundary['location']
         angle = boundary['angle']
         angular_velocity = boundary.get('angular_velocity', 0.0)
+        width = boundary['width']
+        length = boundary['length']
 
-        half_length = length / 2
-        half_width = width / 2
-
-        shape = pymunk.Poly(None, (
-            (-half_length, -half_width),
-            (half_length, -half_width),
-            (half_length, half_width),
-            (-half_length, half_width)))
+        # get agent_shape
+        shape = get_shape(self.agent_shape, boundary)
 
         inertia = pymunk.moment_for_poly(mass, shape.get_vertices())
         body = pymunk.Body(mass, inertia)
@@ -292,13 +316,7 @@ class MultiBody(object):
         angle = body.angle
 
         # make shape, moment of inertia, and add a body
-        half_length = length/2
-        half_width = width/2
-        new_shape = pymunk.Poly(None, (
-            (-half_length, -half_width),
-            (half_length, -half_width),
-            (half_length, half_width),
-            (-half_length, half_width)))
+        new_shape = get_shape(self.agent_shape, boundary)
 
         inertia = pymunk.moment_for_poly(mass, new_shape.get_vertices())
         new_body = pymunk.Body(mass, inertia)

--- a/vivarium/library/pymunk_multibody.py
+++ b/vivarium/library/pymunk_multibody.py
@@ -393,24 +393,28 @@ class MultiBody(object):
 def test_multibody(
         total_time=2,
         agent_shape='rectangle',
+        n_agents=1,
+        jitter_force=1e1,
         screen=None):
 
     bounds = [500, 500]
     center_location = [0.5*loc for loc in bounds]
     agents = {
-        '1': {
+        str(agent_idx): {
             'boundary': {
                 'location': center_location,
-                'angle': PI/2,
+                'angle': random.uniform(0,2*PI),
                 'volume': 15,
                 'length': 30,
                 'width': 10,
                 'mass': 1,
                 'thrust': 1e3,
-                'torque': 0.0}}}
+                'torque': 0.0}}
+        for agent_idx in range(n_agents)
+    }
     config = {
         'agent_shape': agent_shape,
-        'jitter_force': 1e1,
+        'jitter_force': jitter_force,
         'bounds': bounds,
         'barriers': False,
         'initial_agents': agents,
@@ -420,7 +424,7 @@ def test_multibody(
 
     # run simulation
     time = 0
-    time_step = 0.1
+    time_step = 1
     while time < total_time:
         time += time_step
         multibody.run(time_step)

--- a/vivarium/library/pymunk_multibody.py
+++ b/vivarium/library/pymunk_multibody.py
@@ -68,6 +68,9 @@ def random_body_position(body):
     return location
 
 def get_shape(agent_shape, boundary):
+    '''
+    shape documentation at: https://pymunk-tutorial.readthedocs.io/en/latest/shape/shape.html
+    '''
 
     if agent_shape == 'capsule':
         width = boundary['width']
@@ -75,12 +78,11 @@ def get_shape(agent_shape, boundary):
 
         half_length = length / 2
         half_width = width / 2
-
-        shape = pymunk.Poly(None, (
-            (-half_length, -half_width),
-            (half_length, -half_width),
-            (half_length, half_width),
-            (-half_length, half_width)))
+        shape = pymunk.Segment(
+            None,
+            (-half_length, 0),
+            (half_length, 0),
+            radius=half_width)
 
     elif agent_shape == 'rectangle':
         width = boundary['width']
@@ -89,8 +91,8 @@ def get_shape(agent_shape, boundary):
         half_length = length / 2
         half_width = width / 2
 
-        shape = pymunk.Poly(None, (
-            (-half_length, -half_width),
+        shape = pymunk.Poly(None,
+            ((-half_length, -half_width),
             (half_length, -half_width),
             (half_length, half_width),
             (-half_length, half_width)))

--- a/vivarium/library/pymunk_multibody.py
+++ b/vivarium/library/pymunk_multibody.py
@@ -75,7 +75,7 @@ class MultiBody(object):
     """
 
     defaults = {
-        'agent_shape': 'rectangle',
+        'agent_shape': 'segment',
         # hardcoded parameters
         'elasticity': 0.9,
         'damping': 0.5,  # 1 is no damping, 0 is full damping

--- a/vivarium/processes/multibody_physics.py
+++ b/vivarium/processes/multibody_physics.py
@@ -89,17 +89,35 @@ class Multibody(Process):
     To run with animation on set animate: True, and use the TKAgg matplotlib backend:
     > MPLBACKEND=TKAgg python vivarium/processes/multibody_physics.py
 
+    Ports:
+
+        * ``agents``: The store containing all agent sub-compartments. Each agent in
+          this store has values for location, angle, length, width, mass, thrust, and torque.
+
+    Arguments:
+        initial_parameters(dict): Accepts the following configuration keys:
+
+            * **jitter_force**: force applied to random positions along agent
+              bodies to mimic thermal fluctuations. Produces Brownian motion.
+            * **agent_shape** (:py:class:`str`): agents can take the shapes
+              ``rectangle``, `segment```, or ``circle``.
+            * **bounds** (:py:class:`list`): size of the environment in
+              micrometers, with [x, y].
+            * **mother_machine** (:py:class:`bool`): if True, mother machine
+              barriers are introduced.
+
     Notes:
-    - rotational diffusion in liquid medium with viscosity = 1 mPa.s: Dr = 3.5+/-0.3 rad^2/s
-        (Saragosti, et al. 2012. Modeling E. coli tumbles by rotational diffusion.)
-    - translational diffusion in liquid medium with viscosity = 1 mPa.s: Dt=100 micrometers^2/s
-        (Saragosti, et al. 2012. Modeling E. coli tumbles by rotational diffusion.)
+        * rotational diffusion in liquid medium with viscosity = 1 mPa.s: Dr = 3.5+/-0.3 rad^2/s
+          (Saragosti, et al. 2012. Modeling E. coli tumbles by rotational diffusion.)
+        * translational diffusion in liquid medium with viscosity = 1 mPa.s: Dt=100 micrometers^2/s
+          (Saragosti, et al. 2012. Modeling E. coli tumbles by rotational diffusion.)
 
     """
 
     defaults = {
         'agents': {},
         'jitter_force': 1e-3,  # pN
+        'agent_shape': 'segment',
         'bounds': DEFAULT_BOUNDS,
         'mother_machine': False,
         'animate': False,


### PR DESCRIPTION
This adds ```segment``` and ```circle``` agent shapes to ```multibody_physics```, in addition to the previous ```rectangle```. Agent shapes can be set by the argument ```agent_shape``` in ```multibody_physics```. All agents in a given simulation take the same shape once it has been set. The default is now ```segment```, since it is the closest to E. coli's true shape (see figure below).

- Additionally, all trace of pygame has been removed from ```pymunk_multibody``` library, and for debugging with pygame there is now a ```draw_pygame``` file under the directory ```local.
- I also added a docstring to ```multibody_physics``` process in the style of @U8NWXD!

![Screen Shot 2020-07-03 at 8 15 14 AM](https://user-images.githubusercontent.com/6809431/86481750-75610480-bd05-11ea-8d33-779a9808e96c.png)
