### PR TITLE
Serialize Emitted Data for Pymongo

### DIFF
--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -1265,7 +1265,8 @@ class Experiment(object):
             'time': self.local_time})
         emit_config = {
             'table': 'history',
-            'data': data}
+            'data': serialize_dictionary(data),
+        }
         self.emitter.emit(emit_config)
 
     def send_updates(self, updates, derivers=None):

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -36,6 +36,9 @@ def serialize_dictionary(d):
             serialized[key] = serialize_dictionary(serializer_registry.access('process').serialize(value))
         elif isinstance(value, Generator):
             serialized[key] = serialize_dictionary(serializer_registry.access('compartment').serialize(value))
+        elif isinstance(value, (np.integer, np.floating)):
+            serialized[key] = serializer_registry.access(
+                'numpy_scalar').serialize(value)
         else:
             serialized[key] = value
     return serialized

--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -256,6 +256,29 @@ class NumpySerializer(Serializer):
     def deserialize(self, data):
         return np.array(data)
 
+class NumpyScalarSerializer(Serializer):
+    def serialize(self, data):
+        if isinstance(data, np.integer):
+            return int(data)
+        if isinstance(data, np.floating):
+            return float(data)
+        raise ValueError(
+            'Cannot serialize numpy scalar {} of type {}.'.format(
+                data, type(data)
+            )
+        )
+
+    def deserialize(self, data):
+        if isinstance(data, int):
+            return np.int64(data)
+        if isinstance(data, float):
+            return np.float64(data)
+        raise ValueError(
+            'Cannot deserialize scalar {} of type {}.'.format(
+                data, type(data)
+            )
+        )
+
 class UnitsSerializer(Serializer):
     def serialize(self, data):
         return data.magnitude
@@ -275,6 +298,7 @@ class FunctionSerializer(Serializer):
 # register serializers in the serializer_registry
 serializer_registry = Registry()
 serializer_registry.register('numpy', NumpySerializer())
+serializer_registry.register('numpy_scalar', NumpyScalarSerializer())
 serializer_registry.register('units', UnitsSerializer())
 serializer_registry.register('process', ProcessSerializer())
 serializer_registry.register('compartment', GeneratorSerializer())


### PR DESCRIPTION
MongoDB doesn't understand numpy scalars, so we need to transform them
into ints and floats before emitting them. We add functionality to the
serializers to handle numpy scalars and use them when emitting data.