### PR TITLE
Fix Analysis Script to Match Tags Plot

### DIFF
--- a/vivarium/analysis/analyze.py
+++ b/vivarium/analysis/analyze.py
@@ -63,7 +63,7 @@ def plot(args):
             with open(args.tags, 'r') as f:
                 reader = csv.reader(f)
                 molecules = [
-                    (store, molecule) for store, molecule in reader
+                    tuple(path) for path in reader
                 ]
             tags_data = {
                 'agents': agents,


### PR DESCRIPTION
Now that the tags plot expects a full path to the tagged molecule, we
need to change the analysis script accordingly. Here we do so. This also
requires that the CSV of tagged molecules be updated to include as the
first item of every row the store (`boundary`) to access.