### PR TITLE
ADP from ATP hydrolysis in expression processes

### DIFF
--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -28,11 +28,10 @@ from vivarium.library.dict_utils import (
 )
 from vivarium.library.units import units
 
-# import classes for registration
-
 # processes
 from vivarium.processes.timeline import TimelineProcess
 from vivarium.processes.nonspatial_environment import NonSpatialEnvironment
+from vivarium.processes.agent_names import AgentNames
 
 # derivers
 import vivarium.processes.derive_globals
@@ -75,10 +74,20 @@ def agent_environment_experiment(
         agents_config=None,
         environment_config=None,
         initial_state=None,
-        settings=None,
         initial_agent_state=None,
-        invoke=None
+        settings=None,
+        invoke=None,
 ):
+    """ Make an experiment with agents placed in an environment under an `agents` store.
+     Arguments:
+        * **agents_config**: the configuration for the agents
+        * **environment_config**: the configuration for the environment
+        * **initial_state**: the initial state for the hierarchy, with environment at the
+          top level.
+        * **initial_agent_state**: the initial_state for agents, set under each agent_id.
+        * **settings**: settings include **emitter** and **agent_names**.
+        * **invoke**: is the invoke object for calling updates.
+    """
     if settings is None:
         settings = {}
 
@@ -128,6 +137,15 @@ def agent_environment_experiment(
     topology = network['topology']
     processes['agents'] = agents['processes']
     topology['agents'] = agents['topology']
+
+    if settings['agent_names'] is True:
+        # add an AgentNames processes, which saves the current agent names
+        # to as store at the top level of the hierarchy
+        processes['agent_names'] = AgentNames({})
+        topology['agent_names'] = {
+            'agents': ('agents',),
+            'names': ('names',)
+        }
 
     experiment_config = {
         'processes': processes,

--- a/vivarium/data/nucleotides.py
+++ b/vivarium/data/nucleotides.py
@@ -1,6 +1,6 @@
 #: Map from one-letter nucleotide abbreviations to monomers
 nucleotides = {
-    'A': 'rATP',
-    'G': 'rGTP',
-    'U': 'rUTP',
-    'C': 'rCTP'}
+    'A': 'ATP',
+    'G': 'GTP',
+    'U': 'UTP',
+    'C': 'CTP'}

--- a/vivarium/data/synonyms.py
+++ b/vivarium/data/synonyms.py
@@ -6,15 +6,16 @@ def invert_index(mapping):
     return inverse
 
 synonyms = {
-    'ATP': ['atp_c'],
+    # 'ATP': ['atp_c'],
+    'ADP': ['adp_c'],
     'GTP': ['gtp_c'],
     'NAD(H)': ['nad_c'],
     'NADP(H)': ['nadp_c'],
     'FAD(H2)': ['fad_c'],
-    'rATP': ['A', 'ATP', 'datp_c'],  # ATP name conflicts with the energy carrier
-    'rGTP': ['G', 'GTP', 'dgtp_c'],
-    'rUTP': ['U', 'UTP', 'dutp_c'],
-    'rCTP': ['C', 'CTP', 'dctp_c'],
+    'ATP': ['A', 'ATP', 'atp_c'],  # ATP name conflicts with the energy carrier
+    'GTP': ['G', 'GTP', 'gtp_c'],
+    'UTP': ['U', 'UTP', 'utp_c'],
+    'CTP': ['C', 'CTP', 'ctp_c'],
     'Alanine': ['ala__L_c'],
     'Arginine': ['arg__L_c'],
     'Asparagine': ['asn__L_c'],

--- a/vivarium/experiments/lattice_experiment.py
+++ b/vivarium/experiments/lattice_experiment.py
@@ -32,7 +32,7 @@ from vivarium.compartments.growth_division_minimal import GrowthDivisionMinimal
 from vivarium.compartments.transport_metabolism import TransportMetabolism
 from vivarium.compartments.flagella_expression import (
     FlagellaExpressionMetabolism,
-    get_flagella_initial_state,
+    get_flagella_metabolism_initial_state,
 )
 
 
@@ -406,7 +406,7 @@ def main():
         run_workflow(
             agent_type='flagella_metabolism',
             environment_type='iAF1260b',
-            initial_agent_state=get_flagella_initial_state(),
+            initial_agent_state=get_flagella_metabolism_initial_state(),
             experiment_settings=get_experiment_settings(
                 emit_step=120,
                 emitter='database',

--- a/vivarium/experiments/lattice_experiment.py
+++ b/vivarium/experiments/lattice_experiment.py
@@ -138,12 +138,14 @@ def get_experiment_settings(
         total_time=4000,
         emit_step=10,
         emitter='timeseries',
+        agent_names=False,
         return_raw_data=True,
 ):
     return {
         'total_time': total_time,
         'emit_step': emit_step,
         'emitter': emitter,
+        'agent_names': agent_names,
         'return_raw_data': return_raw_data
     }
 
@@ -283,12 +285,16 @@ def run_workflow(
         agent_type='growth_division_minimal',
         n_agents=1,
         environment_type='glc_lcts',
-        initial_state={},
-        initial_agent_state={},
+        initial_state=None,
+        initial_agent_state=None,
         out_dir='out',
         experiment_settings=get_experiment_settings(),
         plot_settings=get_plot_settings()
 ):
+    if initial_state is None:
+        initial_state = {}
+    if initial_agent_state is None:
+        initial_agent_state = {}
     # agent configuration
     agent_config = agents_library[agent_type]
     agent_config['number'] = n_agents
@@ -409,6 +415,7 @@ def main():
             initial_agent_state=get_flagella_metabolism_initial_state(),
             experiment_settings=get_experiment_settings(
                 emit_step=120,
+                agent_names=True,
                 emitter='database',
                 total_time=11000,
             ),

--- a/vivarium/experiments/lattice_experiment.py
+++ b/vivarium/experiments/lattice_experiment.py
@@ -82,7 +82,7 @@ agents_library = {
 def get_lattice_config(
     bounds=[20, 20],
     n_bins=[10, 10],
-    jitter_force=1e-3,
+    jitter_force=1e-4,
     depth=3000.0,
     diffusion=1e-2,
     molecules=['glc__D_e', 'lcts_e'],
@@ -164,24 +164,18 @@ def get_plot_settings(
                 'skip_paths': skip_paths,
                 'remove_zeros': True,
             },
-            'snapshots': {
-                'fields': fields,
-                'n_snapshots': n_snapshots,
-            },
-            'tags': {
-                'tagged_molecules': tags,
-                'n_snapshots': n_snapshots,
-                'background_color': background_color,
-            },
         }
     }
     if fields:
         settings['plot_types']['snapshots'] = {
-            'fields': fields
+            'fields': fields,
+            'n_snapshots': n_snapshots,
         }
     if tags:
         settings['plot_types']['tags'] = {
-            'tag_ids': tags
+            'tagged_molecules': tags,
+            'n_snapshots': n_snapshots,
+            'background_color': background_color,
         }
     return settings
 

--- a/vivarium/processes/agent_names.py
+++ b/vivarium/processes/agent_names.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+
+from vivarium.core.process import Deriver
+
+
+class AgentNames(Deriver):
+
+    name = 'agent_names'
+    defaults = {}
+
+    def __init__(self, initial_parameters=None):
+        if initial_parameters is None:
+            initial_parameters = {}
+        super(AgentNames, self).__init__(initial_parameters)
+
+    def ports_schema(self):
+        return {
+            'agents': {
+                '*': {}
+            },
+            'names': {
+                '_default': [],
+                '_updater': 'set',
+                '_emit': True,
+            },
+        }
+
+    def next_update(self, timestep, states):
+        agents = states['agents']
+        return {'names': list(agents.keys())}

--- a/vivarium/processes/degradation.py
+++ b/vivarium/processes/degradation.py
@@ -81,7 +81,7 @@ class RnaDegradation(Process):
         self.transcript_order = self.parameters['transcript_order']
         self.protein_order = self.parameters['protein_order']
         self.molecule_order = list(nucleotides.values())
-        self.molecule_order.append('ATP')
+        self.molecule_order.extend(['ATP', 'ADP'])
 
         self.partial_transcripts = {
             transcript: 0
@@ -175,6 +175,7 @@ class RnaDegradation(Process):
                 delta_molecules[nucleotides[base]] -= count
                 # ATP hydrolysis cost is 1 per nucleotide degraded
                 delta_molecules['ATP'] -= count
+                delta_molecules['ADP'] += count
 
         return {
             'transcripts': transcript_counts,

--- a/vivarium/processes/metabolism.py
+++ b/vivarium/processes/metabolism.py
@@ -209,7 +209,8 @@ class Metabolism(Process):
         # internal
         for state in list(self.objective_composition.keys()):
             schema['internal'][state] = {
-                '_default': self.initial_state['internal'].get(state, 0),
+                '_value': self.initial_state['internal'].get(state, 0),
+                '_default': 0.0,
                 '_emit': True,
                 '_properties': {
                     'mw': self.fba.molecular_weights[state] * units.g / units.mol},

--- a/vivarium/processes/transcription.py
+++ b/vivarium/processes/transcription.py
@@ -124,7 +124,7 @@ class Transcription(Process):
                   >>> from vivarium.data.nucleotides import nucleotides
                   >>> monomer_ids = nucleotides.values()
                   >>> print(list(monomer_ids))
-                  ['rATP', 'rGTP', 'rUTP', 'rCTP']
+                  ['ATP', 'GTP', 'UTP', 'CTP']
 
                   Note that we only included the ``list()``
                   transformation to make the output prettier. The

--- a/vivarium/processes/transcription.py
+++ b/vivarium/processes/transcription.py
@@ -218,7 +218,7 @@ class Transcription(Process):
 
         self.transcription_factors = self.parameters['transcription_factors']
         self.molecule_ids = self.parameters['molecule_ids']
-        self.molecule_ids.append('ATP')
+        self.molecule_ids.extend(['ATP', 'ADP'])
         self.monomer_ids = self.parameters['monomer_ids']
         self.transcript_ids = self.parameters['transcript_ids']
         self.elongation = 0
@@ -510,8 +510,10 @@ class Transcription(Process):
 
         # 1 ATP hydrolysis cost per nucleotide elongation
         molecules['ATP'] = 0
+        molecules['ADP'] = 0
         for count in elongation.monomers.values():
             molecules['ATP'] -= count
+            molecules['ADP'] += count
 
         chromosome_dict = chromosome.to_dict()
         rnaps = chromosome_dict['rnaps']

--- a/vivarium/processes/translation.py
+++ b/vivarium/processes/translation.py
@@ -312,7 +312,7 @@ class Translation(Process):
 
         self.monomer_ids = self.parameters['monomer_ids']
         self.molecule_ids = self.parameters['molecule_ids']
-        self.molecule_ids.append('ATP')
+        self.molecule_ids.extend(['ATP', 'ADP'])
 
         self.protein_ids = self.parameters['protein_ids']
         self.symbol_to_monomer = self.parameters['symbol_to_monomer']
@@ -551,8 +551,10 @@ class Translation(Process):
 
         # ATP hydrolysis cost is 2 per amino acid elongation
         molecules['ATP'] = 0
+        molecules['ADP'] = 0
         for count in elongation.monomers.values():
             molecules['ATP'] -= 2 * count
+            molecules['ADP'] += 2 * count
 
         ribosome_updates = {
             id: ribosomes[id]


### PR DESCRIPTION
We were previous using ATP, but not producing ADP in the expression processes' ATP hydrolysis reactions.  This is corrected.  Also, the ```Flagella_expression_metabolism``` compartment, which was previously using ```gene_expression``` compartment and doing an awkward merge with ```metabolism``` and ```convenience_kinetics``` for transport, is now just declaring the full compartment without using ``` gene_expression```.

```Flagella_expression_metabolism``` compartment has some poor behavior upon division that I still need to work out before this merges.