### PR TITLE
Set Pint Application Registry

### DIFF
--- a/vivarium/library/units.py
+++ b/vivarium/library/units.py
@@ -29,6 +29,10 @@ from pint.quantity import _Quantity as Quantity
 #: Units registry that stores the units used throughout Vivarium
 units = pint.UnitRegistry()
 
+# We need to set this registry as the default application-wide so our
+# registry will be used when unpickling
+pint.set_application_registry(units)
+
 
 def remove_units(collection):
     '''Strip the units from a collection or scalar


### PR DESCRIPTION
When Pint deserializes unit or quantity objects, it uses the application
registry. Here we set our units registry to be the application registry
so that deserialized units are compatible with other units.

This change is required for parallel processing to work.