### PR TITLE
Fix Death Process

### DIFF
--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -14,10 +14,7 @@ from vivarium.core.emitter import (
     path_timeseries_from_embedded_timeseries,
     path_timeseries_from_data,
 )
-from vivarium.core.experiment import (
-    Experiment,
-    update_in,
-)
+from vivarium.core.experiment import Experiment
 from vivarium.core.process import Process, Deriver, Generator, generate_derivers
 from vivarium.core import emitter as emit
 from vivarium.library.dict_utils import (

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -82,12 +82,11 @@ def assoc_path(d, path, value):
 def update_in(d, path, f):
     if path:
         head = path[0]
-        if len(path) == 1:
-            d[head] = f(d.get(head, None))
-        else:
-            if not head in d:
-                d[head] = {}
-            update_in(d[head], path[1:], f)
+        d.setdefault(head, {})
+        updated = copy.deepcopy(d)
+        updated[head] = update_in(d[head], path[1:], f)
+        return updated
+    return f(d)
 
 
 def dissoc(d, removing):
@@ -1065,7 +1064,12 @@ def inverse_topology(outer, update, topology):
                 for child, child_update in update.items():
                     inner = normalize_path(outer + path + (child,))
                     if isinstance(child_update, dict):
-                        update_in(inverse, inner, lambda current: deep_merge(current, child_update))
+                        inverse = update_in(
+                            inverse,
+                            inner,
+                            lambda current: deep_merge(
+                                current, child_update),
+                        )
                     else:
                         assoc_path(inverse, inner, child_update)
 
@@ -1089,7 +1093,11 @@ def inverse_topology(outer, update, topology):
             else:
                 inner = normalize_path(outer + path)
                 if isinstance(value, dict):
-                    update_in(inverse, inner, lambda current: deep_merge(current, value))
+                    inverse = update_in(
+                        inverse,
+                        inner,
+                        lambda current: deep_merge(current, value)
+                    )
                 else:
                     assoc_path(inverse, inner, value)
 
@@ -1531,7 +1539,7 @@ def test_in():
     assoc_path(blank, path, 5)
     print(blank)
     print(get_in(blank, path))
-    update_in(blank, path, lambda x: x + 6)
+    blank = update_in(blank, path, lambda x: x + 6)
     print(blank)
 
 
@@ -1830,6 +1838,124 @@ def test_parallel():
     log.debug(pf(experiment.state.divide_value()))
 
     experiment.end()
+
+
+class TestUpdateIn:
+    d = {
+        'foo': {
+            1: {
+                'a': 'b',
+            },
+        },
+        'bar': {
+            'c': 'd',
+        },
+    }
+
+    def test_simple(self):
+        updated = copy.deepcopy(self.d)
+        updated = update_in(
+            updated, ('foo', 1, 'a'), lambda current: 'updated')
+        expected = {
+            'foo': {
+                1: {
+                    'a': 'updated',
+                },
+            },
+            'bar': {
+                'c': 'd',
+            },
+        }
+        assert updated == expected
+
+    def test_add_leaf(self):
+        updated = copy.deepcopy(self.d)
+        updated = update_in(
+            updated, ('foo', 1, 'new'), lambda current: 'updated')
+        expected = {
+            'foo': {
+                1: {
+                    'a': 'b',
+                    'new': 'updated',
+                },
+            },
+            'bar': {
+                'c': 'd',
+            },
+        }
+        assert updated == expected
+
+    def test_add_dict(self):
+        updated = copy.deepcopy(self.d)
+        updated = update_in(
+            updated, ('foo', 2), lambda current: {'a': 'updated'})
+        expected = {
+            'foo': {
+                1: {
+                    'a': 'b',
+                },
+                2: {
+                    'a': 'updated',
+                },
+            },
+            'bar': {
+                'c': 'd',
+            },
+        }
+        assert updated == expected
+
+    def test_complex_merge(self):
+        updated = copy.deepcopy(self.d)
+        updated = update_in(
+            updated, ('foo',),
+            lambda current: deep_merge(
+                current,
+                {'foo': {'a': 'updated'}, 'b': 2}),
+            )
+        expected = {
+            'foo': {
+                'foo': {
+                    'a': 'updated',
+                },
+                'b': 2,
+                1: {
+                    'a': 'b',
+                },
+            },
+            'bar': {
+                'c': 'd',
+            },
+        }
+        assert updated == expected
+
+    def test_add_to_root(self):
+        updated = copy.deepcopy(self.d)
+        updated = update_in(
+            updated,
+            tuple(),
+            lambda current: deep_merge(current, ({'a': 'updated'})),
+        )
+        expected = {
+            'foo': {
+                1: {
+                    'a': 'b',
+                },
+            },
+            'bar': {
+                'c': 'd',
+            },
+            'a': 'updated'
+        }
+        assert updated == expected
+
+    def test_set_root(self):
+        updated = copy.deepcopy(self.d)
+        updated = update_in(
+            updated, tuple(), lambda current: {'a': 'updated'})
+        expected = {
+            'a': 'updated',
+        }
+        assert updated == expected
 
 
 if __name__ == '__main__':

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -24,6 +24,8 @@ def serialize_value(value):
         return serialize_dictionary(value)
     elif isinstance(value, list):
         return serialize_list(value)
+    elif isinstance(value, tuple):
+        return serialize_list(list(value))
     elif isinstance(value, np.ndarray):
         return serializer_registry.access('numpy').serialize(value)
     elif isinstance(value, Quantity):

--- a/vivarium/processes/death.py
+++ b/vivarium/processes/death.py
@@ -204,23 +204,24 @@ class DeathFreezeState(Process):
         for detector in self.detectors:
             if not detector.check_can_survive(states):
                 # kill the cell
-                return {
+                update = {
                     'global': {
                         'dead': 1,
                     },
                     'processes': {
                         '_delete': [
-                            ('..', target,)
+                            (target,)
                             for target in self.targets
                         ],
                     },
                 }
+                return update
         return {}
 
 
 class ToyAntibioticInjector(Process):
     name = 'toy_antibiotic_injector'
-    
+
     def __init__(self, initial_parameters=None):
         if initial_parameters is None:
             initial_parameters = {}
@@ -275,7 +276,7 @@ class ToyDeath(Generator):
             'death': {
                 'internal': ('cell',),
                 'global': ('global',),
-                'processes': ('global',),
+                'processes': tuple(),
             },
             'injector': {
                 'internal': ('cell',),


### PR DESCRIPTION
Fixing the death process to correctly target processes to remove also required changing `update_in` to support empty paths, which should be interpreted as referring to the root of the dictionary.