### PR TITLE
Fix Cell-Environment Diffusion to Use Timestep

### DIFF
--- a/vivarium/processes/diffusion_cell_environment.py
+++ b/vivarium/processes/diffusion_cell_environment.py
@@ -103,7 +103,7 @@ class CellEnvironmentDiffusion(Process):
             molecule: (
                 states['internal'][molecule]
                 - states['external'][molecule]
-            ) * rate * units.mmol
+            ) * rate * timestep * units.mmol
             for molecule, rate in rates.items()
         }
         flux_counts = {


### PR DESCRIPTION
The CellEnvironmentDiffusion process used to implicitly assume a
timestep of 1 second by not using the timestep parameter. Here we fix
that by multiplying the rates by the timestep.