### PR TITLE
Deprecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Vivarium
 
+**WARNING: This project is deprecated and no longer maintained.** Please
+use
+[`vivarium-core`](https://github.com/vivarium-collective/vivarium-core)
+and
+[`vivarium-cell`](https://github.com/vivarium-collective/vivarium-cell)
+instead.
+
 Vivarium is a multiscale platform for simulating cells in dynamic
 environments, within which they can grow, divide, and thrive.
 
@@ -10,13 +17,13 @@ Visit [Vivarium documentation](https://wc-vivarium.readthedocs.io/)
 
 ## Concept
 
-A Vivarium is a "place of life" -- an enclosure for raising organisms in controlled environments for observation or 
-research. Typical vivaria include aquariums or terrariums.  The vivarium provided in this repository is a computational 
-vivarium for developing colonies of whole-cell model agents in dynamic environments. Its framework is a synthesis of 
+A Vivarium is a "place of life" -- an enclosure for raising organisms in controlled environments for observation or
+research. Typical vivaria include aquariums or terrariums.  The vivarium provided in this repository is a computational
+vivarium for developing colonies of whole-cell model agents in dynamic environments. Its framework is a synthesis of
 whole-cell modeling, agent-based modeling, multi-scale modeling, and modular programming.
 
-Vivarium is a framework for composing hybrid models of different cellular processes into agents, and placing many agents 
-into a shared spatial environment to observe their interactions. Vivarium is distributed in that these agents can run in 
-different threads or on different computers, and upon cell division new threads are allocated. The agents communicate 
-through message passing and are coordinated by the environmental simulation which receives all of the messages, 
-integrates them, and responds to each agent with their new updated local environments. 
+Vivarium is a framework for composing hybrid models of different cellular processes into agents, and placing many agents
+into a shared spatial environment to observe their interactions. Vivarium is distributed in that these agents can run in
+different threads or on different computers, and upon cell division new threads are allocated. The agents communicate
+through message passing and are coordinated by the environmental simulation which receives all of the messages,
+integrates them, and responds to each agent with their new updated local environments.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt", 'r') as requirements:
 
 setup(
     name='wholecell-vivarium',
-    version='0.0.53',
+    version='0.0.54',
     packages=[
         'vivarium',
         'vivarium.analysis',

--- a/vivarium/__init__.py
+++ b/vivarium/__init__.py
@@ -1,0 +1,6 @@
+import warnings
+
+warnings.warn(
+    'Vivarium is deprecated. '
+    'Please use vivarium-core and vivarium-cell instead',
+)


### PR DESCRIPTION
Deprecates Vivarium in favor of vivarium-core and vivarium-cell by:

* Adding deprecation notice to README
* Adding deprecation warning to `__init__.py` so that anyone using Vivarium gets a warning
* Bumping the version number so we can do a new release to PyPI with these changes

Once we merge this PR and release the updated version to PyPI, we can archive this repository